### PR TITLE
Fix the form submission logic (to some extent)

### DIFF
--- a/ianalyzer/static/search.js
+++ b/ianalyzer/static/search.js
@@ -138,8 +138,6 @@ $(function(){
         
     });
 
-    $("input#download_fallback").hide();
-
     $(".top_buttons #admin").button({
         icon: "ui-icon-person",
         iconPosition: "end"
@@ -158,14 +156,19 @@ $(function(){
     });
 
     /* Search dialog */
-    var $search_dialog = $("#search_dialog");
+    var $search_dialog = $("#search_dialog"),
+        $form = $('form');
     $("#search").button({
         icon: "ui-icon-search"
     }).css({
         width: '100%',
         marginTop: '5px'
-    }).click(function(){        
-        $search_dialog.dialog("open");
+    });
+    $form.submit(function(event){        
+        if (!$search_dialog.dialog("isOpen")) {
+            event.preventDefault();
+            $search_dialog.dialog("open");
+        }
     });
     $search_dialog.dialog({
         autoOpen: false,
@@ -178,7 +181,7 @@ $(function(){
             $search_dialog.dialog("option", { buttons: [] });
             $search_dialog.text("Searching...");
             
-            var post = {}, $form = $('form'), formdata = $form.serializeArray();
+            var post = {}, formdata = $form.serializeArray();
             for(var i = 0; i < formdata.length; i++)
                 post[formdata[i].name] = formdata[i].value;
             

--- a/ianalyzer/templates/app.html
+++ b/ianalyzer/templates/app.html
@@ -88,10 +88,9 @@ var AUTOCOMPLETE = {{ autocomplete|tojson }},
     </div>
 </div>
 
-<input type="submit" value="Download" id="download_fallback">
+<button type="submit" id="search">Search</button>
 </form>
 
-<button id="search">Search</button>
 <div id="search_dialog" title="Search">
 </div>
 </body>


### PR DESCRIPTION
There used to be two submission buttons: an invisible one inside the
form and a visible one outside. The latter was not attached to the
form in any way, but had an event handler attached. This explains why
pressing the return key while the query field was active never did
what you expected. This has now been solved by unifying these buttons
and by attaching the event handler to the form submission rather than
to the button click.

Needless to say, the entire thing could use some cleaning-up.

Fixes #15.