### PR TITLE
Feature/zero result feedback

### DIFF
--- a/web-ui/src/app/search/search-filter.component.html
+++ b/web-ui/src/app/search/search-filter.component.html
@@ -3,14 +3,14 @@
         <p-checkbox [(ngModel)]="data" binary="true" (onChange)="update()"></p-checkbox>
         {{data | json | titlecase }}
     </div>
-    <div class="mc" *ngIf="filter.name == 'MultipleChoiceFilter'">
+    <div class="mc" *ngIf="filter.name == 'MultipleChoiceFilter'" iaBalloon="This filter is preventing your query from returning any results. Please choose at least one option." [iaBalloonVisible]="warnBottleneck && isBottleneck" iaBalloonPosition="right">
         <p-multiSelect [options]="data.options" [(ngModel)]="data.selected" (onChange)="update()" ></p-multiSelect>
     </div>
-    <div class="range" *ngIf="filter.name == 'RangeFilter'">
+    <div class="range" *ngIf="filter.name == 'RangeFilter'" iaBalloon="This filter is preventing your query from returning any results. Please ensure that the minimum is not larger than the maximum." [iaBalloonVisible]="warnBottleneck && isBottleneck" iaBalloonPosition="right">
         <span>{{data[0]}} - {{data[1]}}</span>
         <p-slider [animate]="true" [(ngModel)]="data" [range]="true" [min]="filter.lower" [max]="filter.upper" (onChange)="update()"></p-slider>
     </div>
-    <div class="daterange" *ngIf="filter.name == 'DateFilter'">
+    <div class="daterange" *ngIf="filter.name == 'DateFilter'" iaBalloon="This filter is preventing your query from returning any results. Please ensure that the first date in the range is not after the last date." [iaBalloonVisible]="warnBottleneck && isBottleneck" iaBalloonPosition="right">
         <p-calendar [(ngModel)]="data.min" [minDate]="filter.lower" [maxDate]="data.max" [yearNavigator]="true" yearRange="{{data.minYear}}:{{data.maxYear}}" (onSelect)="update()"
             (onInput)="update()" dateFormat="yy-mm-dd"></p-calendar>
         <p-calendar [(ngModel)]="data.max" [maxDate]="filter.upper" [minDate]="data.min" [yearNavigator]="true" yearRange="{{data.minYear}}:{{data.maxYear}}" (onSelect)="update()"

--- a/web-ui/src/app/search/search-filter.component.ts
+++ b/web-ui/src/app/search/search-filter.component.ts
@@ -16,8 +16,13 @@ export class SearchFilterComponent implements OnChanges, OnInit {
     @Input()
     public filterData: SearchFilterData;
 
+    @Input()
+    public warnBottleneck: boolean;
+
     @Output('update')
     public updateEmitter = new EventEmitter<SearchFilterData>();
+
+    public isBottleneck: boolean = false;
 
     public get filter() {
         return this.field.searchFilter;
@@ -120,6 +125,7 @@ export class SearchFilterComponent implements OnChanges, OnInit {
      * Create a new version of the filter data from the user input.
      */
     getFilterData() {
+        this.isBottleneck = false;
         switch (this.filter.name) {
             case 'BooleanFilter':
                 return {
@@ -128,12 +134,14 @@ export class SearchFilterComponent implements OnChanges, OnInit {
                     data: this.data
                 };
             case 'RangeFilter':
+                if (this.data[0] > this.data[1]) this.isBottleneck = true;
                 return {
                     fieldName: this.field.name,
                     filterName: this.filter.name,
                     data: { gte: this.data[0], lte: this.data[1] }
                 };
             case 'MultipleChoiceFilter':
+                if (this.data.selected.length === 0) this.isBottleneck = true;
                 return {
                     fieldName: this.field.name,
                     filterName: this.filter.name,
@@ -141,6 +149,13 @@ export class SearchFilterComponent implements OnChanges, OnInit {
                 };
             case 'DateFilter':
                 let formatData = (date: Date) => `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+                let lower = this.filter.lower.valueOf(),
+                    upper = this.filter.upper.valueOf(),
+                    min = this.data.min && this.data.min.valueOf() || lower,
+                    max = this.data.max && this.data.max.valueOf() || upper;
+                let localMin = Math.max(min, lower);
+                let localMax = Math.min(max, upper);
+                if (localMin > localMax) this.isBottleneck = true;
                 return {
                     fieldName: this.field.name,
                     filterName: this.filter.name,

--- a/web-ui/src/app/search/search.component.html
+++ b/web-ui/src/app/search/search.component.html
@@ -98,7 +98,7 @@
                                  </span>
                              </p>
                         </div>
-                        <search-filter [field]="field" [enabled]="queryField[field.name].useAsFilter" [filterData]="queryField[field.name].data" (click)="enableFilter(field.name);" (update)="updateFilterData(field.name, $event)"></search-filter>             
+                        <search-filter [field]="field" [enabled]="queryField[field.name].useAsFilter" [filterData]="queryField[field.name].data" [warnBottleneck]="hasSearched && !isSearching && queryField[field.name].useAsFilter && results && results.total == 0" (click)="enableFilter(field.name);" (update)="updateFilterData(field.name, $event)"></search-filter>
                     </div>
                 </ng-container>
             </div>


### PR DESCRIPTION
When a search is performed and zero results are returned, the user is notified if any of the filters is logically preventing any record from matching. For example, if a multiple choice filter is enabled but has zero options checked, then there logically cannot be any results. The feedback looks like this:

![schermafbeelding 2018-08-07 om 15 40 09](https://user-images.githubusercontent.com/1540185/43779254-3616000e-9a58-11e8-8275-1be83f6ab320.png)

In practice, I expect this to only happen with multiple choice filters, because the other filters have practical constraints that prevent this situation. Just in case somebody finds a way around these constraints, though, I implemented this feedback for the range and date range types of filters as well.

Closes #172. Makes #123 slightly worse.