### PR TITLE
Constrain the width of p-multiselect panels in filters

### DIFF
--- a/web-ui/src/app/search/search-filter.component.scss
+++ b/web-ui/src/app/search/search-filter.component.scss
@@ -1,0 +1,5 @@
+@import '../../_utilities';
+
+::ng-deep .ui-multiselect-panel {
+    max-width: 300px;
+}


### PR DESCRIPTION
@BeritJanssen I have no time to set up a local index for the Dutch Newspapers corpus, but I have constrained the width of the p-multiselect panel in a search filter in the hope that it will solve #214. Could you check whether this solution works? Thanks in advance.