### PR TITLE
Show a hint about timeline zooming once per session

### DIFF
--- a/web-ui/src/app/visualization/timeline.component.html
+++ b/web-ui/src/app/visualization/timeline.component.html
@@ -1,0 +1,3 @@
+<p class=notification *ngIf=showHint>
+    <b>Drag to zoom, click to unzoom</b>
+</p>

--- a/web-ui/src/app/visualization/timeline.component.scss
+++ b/web-ui/src/app/visualization/timeline.component.scss
@@ -3,3 +3,13 @@
 .d3-chart .bar {
 	fill: $primary;
 }
+
+ia-timeline {
+    z-index: 1;
+    position: absolute;
+}
+
+.notification {
+    @include unselectable;
+    opacity: 0.75;
+}

--- a/web-ui/src/app/visualization/visualization.component.scss
+++ b/web-ui/src/app/visualization/visualization.component.scss
@@ -1,13 +1,16 @@
-.d3-chart {		  
-	width: 90%;		  
-	height: 400px;	
+.d3-chart {
+    width: 90%;
+    height: 400px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
-.d3-chart .axis path,		
-.d3-chart .axis line {		  
-	stroke: #999;		
+.d3-chart .axis path,
+.d3-chart .axis line {
+    stroke: #999;
 }
 
-.d3-chart .axis text {		  
-	fill: #999;		
+.d3-chart .axis text {
+    fill: #999;
 }


### PR DESCRIPTION
The first time in a session (i.e., after opening I-analyzer in a new tab) when displaying a timeline visualization, a hint is shown on how one can zoom in and out. This hint is slightly transparent and is placed right on top of the timeline. It looks like this:

![schermafbeelding 2018-08-28 om 17 49 08](https://user-images.githubusercontent.com/1540185/44735264-38fe6500-aaec-11e8-948e-fef4be256dbf.png)

This hint is hidden one second after the user starts moving the mouse, but no sooner than 1.5 seconds after the visualization appears. It then remains hidden until the next session.

Closes #176.

One implementation peculiarity: due to the fact that the SVG element containing the visualization is a child of the `#chart` in the `ia-visualization` and a *sibling* of the `ia-timeline` (see the visualization component template and the passing of `chartElement`), I had to center the latter on top of the former. This will probably have unwanted side effects if we later to give `ia-barchart` or some future new type of chart additional content that should appear above, instead of on top of the graph. The only way to prevent this would be to give each visualization type its own private SVG element, which I believe would be neater anyway.