### PR TITLE
feature/limit-wordcloud

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -45,7 +45,7 @@ def download_csv(self, request_json, email, instance_path, download_size):
 
 @celery_app.task()
 def get_wordcloud_data(request_json):
-    list_of_texts = download.scroll(request_json['corpus'], request_json['es_query'])
+    list_of_texts = download.scroll(request_json['corpus'], request_json['es_query'], current_app.config['WORDCLOUD_LIMIT'])
     return list_of_texts
 
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -389,6 +389,8 @@ def api_wordcloud():
     ''' get the results for a small batch of results right away '''
     if not request.json:
         abort(400)
+    if request.json['size']>1000:
+        abort(400)
     else:
         list_of_texts = download.normal_search(request.json['corpus'], request.json['es_query'], request.json['size'])
         word_counts = tasks.make_wordcloud_data.delay(list_of_texts, request.json)

--- a/backend/ianalyzer/default_config.py
+++ b/backend/ianalyzer/default_config.py
@@ -121,3 +121,5 @@ MAIL_CSV_SUBJECT_LINE = 'I-Analyzer download'
 # Word model information for related words visualization
 WM_COMPLETE_FN = "complete.pkl"
 WM_BINNED_FN = "binned.pkl"
+
+WORDCLOUD_LIMIT = 100000;

--- a/frontend/src/app/visualization/visualization.component.html
+++ b/frontend/src/app/visualization/visualization.component.html
@@ -28,7 +28,7 @@
     		</ia-term-frequency>
     		<ia-timeline *ngSwitchCase=" 'timeline' " [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
     		[asPercent]="asPercentage"></ia-timeline>
-            <ia-wordcloud *ngSwitchCase=" 'wordcloud' " [searchData]="aggResults" [disableLoadMore]="disableWordCloudLoadMore" (loadAll)="loadAllWordcloudData()"></ia-wordcloud>
+            <ia-wordcloud *ngSwitchCase=" 'wordcloud' " [searchData]="aggResults" [disableLoadMore]="disableWordCloudLoadMore" (loadMore)="loadMoreWordcloudData()"></ia-wordcloud>
             <ia-related-words  *ngSwitchCase=" 'relatedwords' " [searchData]="relatedWordsGraph" [queryText]="queryModel.queryText" [corpusName]="corpus.name" (error)="setErrorMessage($event)"></ia-related-words>
         </ng-container>
     </ng-container>

--- a/frontend/src/app/visualization/visualization.component.ts
+++ b/frontend/src/app/visualization/visualization.component.ts
@@ -164,7 +164,7 @@ export class VisualizationComponent implements OnInit, OnChanges {
         }
     }
 
-    loadAllWordcloudData() {
+    loadMoreWordcloudData() {
         let queryModel = this.queryModel;
         if (queryModel) {
             this.searchService.getWordcloudTasks(this.visualizedField.name, queryModel, this.corpus.name).then(result => {

--- a/frontend/src/app/visualization/wordcloud.component.html
+++ b/frontend/src/app/visualization/wordcloud.component.html
@@ -4,6 +4,6 @@
         <i class="fa fa-question-circle"></i>
     </span>
 </a>
-<button class="button" [ngClass]="{'is-loading': isLoading}" [attr.disabled]="disableLoadMore? '' : null" (click)="loadAllData()">
-    <span iaBalloon="Load all results to your search query." iaBalloonLength="medium">Load all results</span>
+<button class="button" [ngClass]="{'is-loading': isLoading}" [attr.disabled]="disableLoadMore? '' : null" (click)="loadMoreData()">
+    <span iaBalloon="Load up to 100,000 results to your search query." iaBalloonLength="medium">Load more results</span>
 </button>

--- a/frontend/src/app/visualization/wordcloud.component.ts
+++ b/frontend/src/app/visualization/wordcloud.component.ts
@@ -18,8 +18,8 @@ export class WordcloudComponent implements OnChanges, OnInit {
     @ViewChild('wordcloud') private chartContainer: ElementRef;
     @Input('searchData') public significantText: AggregateData;
     @Input('disableLoadMore') public disableLoadMore: boolean;
-    @Output('loadAll')
-    public loadAllDataEmitter = new EventEmitter();
+    @Output('loadMore')
+    public loadMoreDataEmitter = new EventEmitter();
 
     private width: number = 600;
     private height: number = 400;
@@ -52,8 +52,8 @@ export class WordcloudComponent implements OnChanges, OnInit {
         this.dialogService.showManualPage('wordcloud');
     }
 
-    loadAllData() {
-        this.loadAllDataEmitter.emit();
+    loadMoreData() {
+        this.loadMoreDataEmitter.emit();
         this.isLoading = true;
     }
 

--- a/frontend/src/assets/manual/en-GB/wordcloud.md
+++ b/frontend/src/assets/manual/en-GB/wordcloud.md
@@ -2,4 +2,4 @@ The word cloud shows term frequencies of the first 1000 search results correspon
 
 From each text field in the current search results, stop words are removed. After this, the frequency of the remaining words in all the text fields is counted. The 50 most frequent words are then ordered on the canvas, where the text size indicates the frequency of the words. The colour and orientation of the word are not meaningful.
 
-By clicking "Load all results", you can get the term frequencies for the full set of search results. This request may take a long time, however (indicated by the spinner on the button). If there are less than 1000 results to your query, this button is greyed out.
+By clicking "Load more results", you can get the term frequencies for up to 100,000 search results. If there are less than 1000 results to your query, this button is greyed out.


### PR DESCRIPTION
Closes issue #414 : prevents request time-outs by enforcing a limit of 100,000 search results.