### PR TITLE
Fixed id bug, id is now taken from results one level higher

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -65,7 +65,13 @@ def create_filename(route):
 def create_csv(results, fields, filename):
     entries = []
     for result in results:
-        entry = {field: result['_source'][field] for field in fields}
+        entry={}
+        for field in fields:
+            if field in result['_source']:
+                entry.update( {field:result['_source'][field]} )
+                #the id field lives one level higher and is named '_id' by elastic search
+            if field=="id" and "_id" in result: 
+                entry.update( {field: result['_id']} )
         entries.append(entry)
     csv.register_dialect('myDialect', delimiter=',', quotechar='"',
                          quoting=csv.QUOTE_NONNUMERIC, skipinitialspace=True)                  


### PR DESCRIPTION
This branch was forked from develop. Id field is now taken from the results dict where it lives one level higher als '_id'.