### PR TITLE
Separate page for corpus that is part of PEACE 

### DIFF
--- a/backend/corpora/peaceportal/fiji_separate.py
+++ b/backend/corpora/peaceportal/fiji_separate.py
@@ -3,8 +3,7 @@ from corpora.peaceportal.peaceportal import PeacePortal
 
 class FIJISEPARATE(PeacePortal):
 
-    es_index = current_app.config['PEACEPORTAL_FIJI_ES_INDEX']
-    es_alias = current_app.config['FIJI_ALIAS']
+    es_index = current_app.config['FIJI_ALIAS']
 
     # all fields listed here will be ignored if they are
     # in the PeacePortal base class definition. Ideal for excluding


### PR DESCRIPTION
This is an example of the use case described in https://github.com/UUDigitalHumanitieslab/peace-portal/issues/29, i.e. displaying one of the indices of the PEACE Portal in a separate iframe. 

I did this by adding a (tiny!!) corpus definition that inherits from the peaceportal base class. Like this, it has two main features:
- we can specify `es_index`, which will have to be an alias (e.g. 'fiji`) pointing to the existing index. Note that the alias has to be created manually, the `flask alias` command does not support it.
- We can exclude some fields that are irrelevant, for example `source_database` (which will have only one value), and fields that we now are empty for the corpus ('region' is an example from FIJI, although it should be filled after https://github.com/UUDigitalHumanitieslab/peace-portal/issues/16).

After the corpus has been added to `config.py` (just adding `'fiji_separate': '/path/to/wherever/it/is/fiji_separate.py'` to `CORPORA` is enough), you can add the corpus to the `peaceportal` user, and it will be available to open at 'http://wherever.it.is/search/fiji' (where 'fiji' is the same as `es_index` in the corpus definition).

@BeritJanssen : if the question comes up again, feel free to test with and merge this branch (after making whatever changes you deem necessary of course)