### PR TITLE
skip es client tests from fixture if needed

### DIFF
--- a/backend/api/conftest.py
+++ b/backend/api/conftest.py
@@ -59,26 +59,23 @@ def test_es_client(test_app):
     try:
         # initiate an elasticsearch client
         # sniff_on_start to check whether we can connect to the ES server
-        # allows skipping tests that require ES server if none is running
+        # skip tests that require ES server if none is running
         client = elasticsearch('mock-corpus', UnittestConfig, sniff_on_start=True)
     except:
-        client = None
+        pytest.skip('Cannot connect to elasticsearch server')
 
-    if client:
-        # add data from mock corpus
-        corpus = load_corpus('mock-corpus')
-        index.create(client, corpus, False, True, False)
-        index.populate(client, 'mock-corpus', corpus)
+    # add data from mock corpus
+    corpus = load_corpus('mock-corpus')
+    index.create(client, corpus, False, True, False)
+    index.populate(client, 'mock-corpus', corpus)
 
-        # ES is "near real time", so give it a second before we start searching the index
-        sleep(2)
+    # ES is "near real time", so give it a second before we start searching the index
+    sleep(2)
 
-        yield client
+    yield client
 
-        # delete index when done
-        client.indices.delete(index = 'mock-corpus')
-    else:
-        yield None
+    # delete index when done
+    client.indices.delete(index = 'mock-corpus')
 
 
 @pytest.fixture

--- a/backend/api/tests/test_ngrams.py
+++ b/backend/api/tests/test_ngrams.py
@@ -93,9 +93,6 @@ def test_top_10_ngrams():
         assert dataset_relative['data'] == relative_frequencies[word]
 
 def test_absolute_bigrams(test_app, test_es_client, basic_query):
-    if not test_es_client:
-        pytest.skip('No elastic search client')
-
     # search for a word that occurs a few times
     query = basic_query
     query['query']['bool']['must']['simple_query_string']['query'] = 'to'

--- a/backend/api/tests/test_query.py
+++ b/backend/api/tests/test_query.py
@@ -41,9 +41,6 @@ def test_search(test_app, test_es_client, basic_query):
     """
     Test some search requests based on queries manipulated in the query module
     """
-    if not test_es_client:
-        pytest.skip('No elastic search client')
-
     query_no_text = query.remove_query(basic_query)
     result = search(
         corpus = 'mock-corpus',

--- a/backend/api/tests/test_term_frequency.py
+++ b/backend/api/tests/test_term_frequency.py
@@ -36,8 +36,6 @@ def test_extract_data_for_term_frequency(test_app):
 
 def test_match_count(test_app, test_es_client):
     """Test counting matches of the search term"""
-    if not test_es_client:
-        pytest.skip('No elastic search client')
 
     frequencies = [
         ('Alice', 2), # 1 in alice in wonderland title, 1 in its content
@@ -55,8 +53,6 @@ def test_match_count(test_app, test_es_client):
 
 def test_total_docs_and_tokens(test_app, test_es_client):
     """Test total document counter"""
-    if not test_es_client:
-        pytest.skip('No elastic search client')
 
     query = make_query()
     highlight_specs, aggregators = analyze.extract_data_for_term_frequency('mock-corpus', ['content'])
@@ -65,8 +61,6 @@ def test_total_docs_and_tokens(test_app, test_es_client):
     assert token_count == TOTAL_WORDS_IN_MOCK_CORPUS
 
 def test_term_frequency(test_app, test_es_client):
-    if not test_es_client:
-        pytest.skip('No elastic search client')
 
     ## search in all fields
     query = make_query(query_text='Alice')
@@ -85,8 +79,6 @@ def test_term_frequency(test_app, test_es_client):
     assert token_count == TOTAL_WORDS_IN_MOCK_CORPUS
 
 def test_histogram_term_frequency(test_app, test_es_client):
-    if not test_es_client:
-        pytest.skip('No elastic search client')
 
     cases = [
         {
@@ -116,8 +108,6 @@ def test_histogram_term_frequency(test_app, test_es_client):
         }
 
 def test_timeline_term_frequency(test_app, test_es_client):
-    if not test_es_client:
-        pytest.skip('No elastic search client')
 
     cases = [
         {

--- a/backend/api/tests/test_views.py
+++ b/backend/api/tests/test_views.py
@@ -38,16 +38,12 @@ def ngram_body(basic_query):
 
 @pytest.mark.usefixtures("client", "times_user", "session")
 def test_ngrams(client, test_app, test_es_client, ngram_body):
-    if not test_es_client:
-        pytest.skip('No elastic search client')
     client.times_login()
     post_response = client.post('/api/ngram_tasks', json=ngram_body)
     assert post_response.status_code == 200
 
 @pytest.mark.usefixtures("client", "times_user", "session")
 def test_aggregate_term_frequency(client, test_app, test_es_client, aggregate_term_frequency_body):
-    if not test_es_client:
-        pytest.skip('No elastic search client')
     client.times_login()
     post_response = client.post('/api/aggregate_term_frequency', json=aggregate_term_frequency_body)
     assert post_response.status_code == 200
@@ -57,8 +53,6 @@ def test_aggregate_term_frequency(client, test_app, test_es_client, aggregate_te
 
 @pytest.mark.usefixtures("client", "times_user", "session")
 def test_date_term_frequency(client, test_app, test_es_client, date_term_frequency_body):
-    if not test_es_client:
-        pytest.skip('No elastic search client')
     client.times_login()
     post_response = client.post('/api/date_term_frequency', json=date_term_frequency_body)
     assert post_response.status_code == 200


### PR DESCRIPTION
now we no longer need to include `if not test_es_client: pytest.skip()` for every test that uses the elasticsearch client.