### PR TITLE
add document context to more corpora

### DIFF
--- a/backend/corpora/dutchannualreports/dutchannualreports.py
+++ b/backend/corpora/dutchannualreports/dutchannualreports.py
@@ -212,6 +212,13 @@ class DutchAnnualReports(XMLCorpus):
         )
     ]
 
+    document_context = {
+        'context_fields': ['company', 'year'],
+        'sort_field': 'page',
+        'sort_direction': 'asc',
+        'context_display_name': 'report'
+    }
+
     def request_media(self, document):
         image_path = document['fieldValues']['image_path']
         pdf_info = get_pdf_info(op.join(self.data_directory, image_path))

--- a/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
+++ b/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
@@ -110,6 +110,14 @@ class DutchNewspapersPublic(XMLCorpus):
         'onbekend': 'unknown',
     }
 
+    document_context = {
+        'context_fields': ['newspaper_title', 'issue_number'],
+        'sort_field': None,
+        'sort_direction': None,
+        'context_display_name': 'issue'
+    }
+
+
     @property
     def fields(self):
         return [Field(

--- a/backend/corpora/ecco/ecco.py
+++ b/backend/corpora/ecco/ecco.py
@@ -238,6 +238,13 @@ class Ecco(XMLCorpus):
             )
         ]
 
+    document_context = {
+        'context_fields': ['title', 'volume',],
+        'sort_field': 'page',
+        'sort_direction': 'asc',
+        'context_display_name': 'volume'
+    }
+
 
     def request_media(self, document):
         image_path = document['fieldValues']['image_path']

--- a/backend/corpora/guardianobserver/guardianobserver.py
+++ b/backend/corpora/guardianobserver/guardianobserver.py
@@ -1,5 +1,5 @@
 '''
-Collect information from the Guardian-Observer corpus: the articles are contained in 
+Collect information from the Guardian-Observer corpus: the articles are contained in
 separate xml-files, zipped.
 '''
 
@@ -77,7 +77,7 @@ class GuardianObserver(XMLCorpus):
                 )
             ),
             extractor=extract.XML(
-                tag='NumericPubDate', toplevel=True, 
+                tag='NumericPubDate', toplevel=True,
                 transform=lambda x: '{y}-{m}-{d}'.format(y=x[:4],m=x[4:6],d=x[6:])
                 )
         ),
@@ -165,12 +165,19 @@ class GuardianObserver(XMLCorpus):
         )
     ]
 
+    document_context = {
+        'context_fields': ['pub_id'],
+        'sort_field': 'page',
+        'sort_direction': 'asc',
+        'context_display_name': 'publication'
+    }
+
     def request_media(self, document):
         field_vals = document['fieldValues']
         target_filename = "{}_{}_{}.pdf".format(
             field_vals['pub_id'],
             re.sub('-', '', field_vals['date']),
-            field_vals['id']             
+            field_vals['id']
         )
         image_path = None
         if 'image_path' in field_vals.keys():
@@ -210,7 +217,7 @@ class GuardianObserver(XMLCorpus):
         if not image_path:
             return []
         image_urls = [url_for(
-            'api.api_get_media', 
+            'api.api_get_media',
             corpus=self.es_index,
             image_path=image_path,
             filename=filename,
@@ -223,7 +230,7 @@ class GuardianObserver(XMLCorpus):
             "fileSize": sizeof_fmt(getsize(join(self.data_directory, image_path)))
         }
         return {'media': image_urls, 'info': pdf_info}
-    
+
 
     def get_media(self, request_args):
         '''
@@ -233,9 +240,9 @@ class GuardianObserver(XMLCorpus):
         '''
         image_path = request_args['image_path']
         filename = request_args['filename']
-        
+
         pdf_data = None
-        with ZipFile(join(self.data_directory, image_path), mode='r') as zipped: 
+        with ZipFile(join(self.data_directory, image_path), mode='r') as zipped:
             zip_info = zipped.getinfo(filename)
             pdf_data = zipped.read(zip_info)
         if pdf_data:

--- a/backend/corpora/periodicals/periodicals.py
+++ b/backend/corpora/periodicals/periodicals.py
@@ -278,6 +278,13 @@ class Periodicals(XMLCorpus):
         ),
     ]
 
+    document_context = {
+        'context_fields': ['issue'],
+        'sort_field': 'page_no',
+        'sort_direction': 'asc',
+        'context_display_name': 'issue'
+    }
+
     def request_media(self, document):
         field_vals = document['fieldValues']
         image_directory = field_vals['image_path']
@@ -289,7 +296,7 @@ class Periodicals(XMLCorpus):
             page_no = str(start_index + page).zfill(4)
             image_name = '{}-{}.JPG'.format(starting_page[:-5], page_no)
             if isfile(join(self.data_directory, image_directory, image_name)):
-                image_list.append(url_for('api.api_get_media', 
+                image_list.append(url_for('api.api_get_media',
                     corpus=self.es_index,
                     image_path=join(image_directory, image_name),
                     _external=True

--- a/backend/corpora/spectactors/spectators.py
+++ b/backend/corpora/spectactors/spectators.py
@@ -137,3 +137,10 @@ class Spectators(XMLCorpus):
             search_field_core=True
         ),
     ]
+
+    document_context = {
+        'context_fields': ['issue'],
+        'sort_field': None,
+        'sort_direction':  None,
+        'context_display_name': 'issue'
+    }

--- a/backend/corpora/times/times.py
+++ b/backend/corpora/times/times.py
@@ -466,11 +466,18 @@ class Times(XMLCorpus):
         ),
     ]
 
+    document_context = {
+        'context_fields': ['issue'],
+        'sort_field': 'page',
+        'sort_direction': 'asc',
+        'context_display_name': 'issue'
+    }
+
     def request_media(self, document):
         field_values = document['fieldValues']
         if 'image_path' in field_values:
             image_urls = [url_for(
-                'api.api_get_media', 
+                'api.api_get_media',
                 corpus=self.es_index,
                 image_path=field_values['image_path'],
                 _external=True


### PR DESCRIPTION
Update #759 adds the option to add a link to the "context" of a document, if that makes sense in the corpus.

This update would add that functionality to several of the non-parliament corpora, which requires adding the specification in the corpus definitions.

Since are deploying our current development on the people and parliament server but not regular i-analyzer, this update will have no effect in the near future. It just made sense to write this now because I just worked on the feature, but it does not need to be merged any time soon.

I should note that I don't have these corpora locally, so I did not test if everything actually works. I'm also not very familiar with the corpora so I'm not sure if my specifications are always appropriate. I'm mostly making the PR so that when we do bring vanilla i-analyzer up to date with develop, we'll remember that this update exists.