### PR TITLE
update german corpora

### DIFF
--- a/backend/corpora/parliament/germany-new.py
+++ b/backend/corpora/parliament/germany-new.py
@@ -8,7 +8,7 @@ from corpora.parliament.parliament import Parliament
 from addcorpus.extract import Constant, Combined, CSV
 from addcorpus.corpus import CSVCorpus
 from addcorpus.filters import DateFilter, MultipleChoiceFilter
-import corpora.parliament.utils.field_defaults_old as field_defaults
+import corpora.parliament.utils.field_defaults as field_defaults
 
 
 def date_to_year(date):
@@ -52,22 +52,24 @@ class ParliamentGermanyNew(Parliament, CSVCorpus):
     )
     date.search_filter.lower = min_date
 
-    house = field_defaults.house()
-    house.extractor = Constant(
+    chamber = field_defaults.chamber()
+    chamber.extractor = Constant(
         value='Bundestag'
     )
+    chamber.search_filter = None
+    chamber.visualizations = []
 
     debate_id = field_defaults.debate_id()
     debate_id.extractor = CSV(
         field='session'
     )
-    
+
     # in Germany, abbreviations are the most common way to refer to parties
     party = field_defaults.party()
     party.extractor = CSV(
-        field='party_abbreviation'  
+        field='party_abbreviation'
     )
-    
+
     party_full = field_defaults.party_full()
     party_full.extractor = CSV(
         field='party_full_name'
@@ -130,7 +132,7 @@ class ParliamentGermanyNew(Parliament, CSVCorpus):
         field='speaker_death_date',
         transform=date_to_year
     )
-    
+
     speaker_gender = field_defaults.speaker_gender()
     speaker_gender.extractor = CSV(
         field='speaker_gender'
@@ -147,49 +149,39 @@ class ParliamentGermanyNew(Parliament, CSVCorpus):
         multiple=True,
         transform=lambda x : ' '.join(x)
     )
-    speech.es_mapping = {
-        "type" : "text",
-        "analyzer": "standard",
-        "term_vector": "with_positions_offsets", 
-        "fields": {
-        "stemmed": {
-            "type": "text",
-            "analyzer": "german"
-            },
-        "clean": {
-            "type": 'text',
-            "analyzer": "clean"
-            },
-        "length": {
-            "type": "token_count",
-            "analyzer": "standard",
-            }
-        }
-    }
 
     speech_id = field_defaults.speech_id()
     speech_id.extractor = CSV(
         field='id'
     )
 
-    url = field_defaults.source_url()
+    url = field_defaults.url()
     url.extractor = CSV(
         field='document_url'
     )
-    
+
+    # order of speeches: value is identical to speech_id
+    # but saved as integer for sorting
+    sequence = field_defaults.sequence()
+    sequence.extractor = CSV(
+        field = 'id'
+    )
+
     def __init__(self):
         self.fields = [
             self.country, self.date,
+            self.chamber,
             self.debate_id,
             self.speaker, self.speaker_id,
             self.speaker_aristocracy, self.speaker_academic_title,
             self.speaker_birth_country, self.speaker_birthplace,
-            self.speaker_birth_year, self.speaker_death_year, 
+            self.speaker_birth_year, self.speaker_death_year,
             self.speaker_gender, self.speaker_profession,
             self.role, self.role_long,
             self.party, self.party_full, self.party_id,
             self.speech, self.speech_id,
             self.url,
+            self.sequence,
         ]
 
 

--- a/backend/corpora/parliament/germany-old.py
+++ b/backend/corpora/parliament/germany-old.py
@@ -8,8 +8,7 @@ from flask import current_app
 from corpora.parliament.parliament import Parliament
 from addcorpus.extract import Constant, Combined, CSV
 from addcorpus.corpus import CSVCorpus
-from addcorpus.filters import MultipleChoiceFilter
-import corpora.parliament.utils.field_defaults_old as field_defaults
+import corpora.parliament.utils.field_defaults as field_defaults
 
 
 def standardize_bool(date_is_estimate):
@@ -53,8 +52,8 @@ class ParliamentGermanyOld(Parliament, CSVCorpus):
         field='book_label'
     )
 
-    parliament = field_defaults.parliament()
-    parliament.extractor = CSV(
+    era = field_defaults.era()
+    era.extractor = CSV(
         field='parliament'
     )
 
@@ -82,8 +81,8 @@ class ParliamentGermanyOld(Parliament, CSVCorpus):
         multiple=True,
         transform=lambda x : ' '.join(x)
     )
-    
-    url = field_defaults.source_url()
+
+    url = field_defaults.url()
     url.extractor = CSV(
         field='img_url'
     )
@@ -97,8 +96,9 @@ class ParliamentGermanyOld(Parliament, CSVCorpus):
         self.fields = [
             self.country,
             self.book_id, self.book_label,
-            self.parliament, 
+            self.era,
             self.date, self.date_is_estimate,
             self.page, self.url,
             self.speech, self.speech_id,
+            self.url,
         ]

--- a/backend/corpora/parliament/tests/test_import.py
+++ b/backend/corpora/parliament/tests/test_import.py
@@ -139,6 +139,7 @@ M. Georges Perin. Messieurs, je viens, au nom d'un certain nombre de mes amis et
         'docs': [
         {
             'country': 'Germany',
+            'chamber': 'Bundestag',
             'date': '1949-09-22',
             'debate_id': '7',
             'speaker': 'Gebhard Seelos',
@@ -158,6 +159,8 @@ M. Georges Perin. Messieurs, je viens, au nom d'un certain nombre de mes amis et
             'party_id': '2',
             'speech': 'Baracken sind etwas Vorübergehendes; sie halten aber immer länger, als eigentlich geplant.',
             'id': '94',
+            'url': 'https://dip21.bundestag.de/dip21/btp/01/01007.pdf',
+            'sequence': '94'
         }],
         'n_documents': 2
     },
@@ -168,11 +171,11 @@ M. Georges Perin. Messieurs, je viens, au nom d'un certain nombre de mes amis et
             'country': 'Germany',
             'book_id': 'bsb00000436',
             'book_label': '1867/70,1 ( Protokolle mit Sach- und Sprechregister )',
-            'parliament': 'Reichstag (Norddeutscher Bund/Zollparlamente) 1867 - 1895 Norddeutscher Bund',
+            'era': 'Reichstag (Norddeutscher Bund/Zollparlamente) 1867 - 1895 Norddeutscher Bund',
             'date': '1867-02-25',
             'date_is_estimate': 'true',
             'page': '27',
-            'source_url': 'https://api.digitale-sammlungen.de/iiif/image/v2/bsb00000436_00027/full/full/0/default.jpg',
+            'url': 'https://api.digitale-sammlungen.de/iiif/image/v2/bsb00000436_00027/full/full/0/default.jpg',
             'speech': "Nach vorangegangenem Gottesdienste in der Königlichen Schloßcapelle und der St. Hedwigskirche versammelten sich Heute- Nachmittags 11 Uhr die durch Allerhöchstes Patent vom 13. d. M. einberufenen Mitglieder des Reichstages des Norddeutschen Bundes im Weißen Saale des Königlichen Schlosses. Bald daraus traten die Reichstags-Commifsarien ein. Nachdem dieselben links vom Throne sich ausgestellt und die Versammlung sich -geordnet hatte, machte der Vorsitzende der Reichstags-Commissarien, Gras von Bismarck, Seiner Majestät dem Könige davon Meldung. Allerhöchst dieselben begaben Sich daraus in Begleitung Ihrer Königlichen Hoheiten des Kronprinzen und der Prinzen des Königlichen Hauses in dem nach dem Programm geordneten Zuge, unter 'Vortragung der Reichs-Insignien, nach dem Weißen Saale und nahmen, mit einem lebhaften dreimaligen Hoch, welches der Wirkliche Geheime Rath von Frankenberg ausbrachte, von der Versammlung empfangen, auf dem Throne Platz, während Seine Königliche Hoheit der Kronprinz guf der mittleren Stufe desselben, Ihre Königlichen Hoheiten die Prinzen des Königlichen Hauses zur Rechten des Thrones sich aufstellten. Seine Majestät der König verlasen hierauf, das Haupt mit dem Helme bedeckt, die nachfolgende Rede:",
             'id': '0',
         }],


### PR DESCRIPTION
Close #659 

Updates the german parliament corpora to the new definitions.

Note: [field_defaults_old.py](https://github.com/UUDigitalHumanitieslab/I-analyzer/blob/develop/backend/corpora/parliament/utils/field_defaults_old.py) can be deleted when this PR and #660  are both merged.