### PR TITLE
Avoid errors in related words

### DIFF
--- a/backend/wordmodels/views.py
+++ b/backend/wordmodels/views.py
@@ -43,10 +43,6 @@ def get_related_words_time_interval():
         request.json['time']
     )
     if isinstance(results, str):
-        # the method returned an error string
-        # response = jsonify({
-        #     'success': False,
-        #     'message': results})
         response = jsonify({
             'success': True,
             'data': []


### PR DESCRIPTION
Prevents the related words graph from throwing an error if the query term is included for some time intervals but not all.

The 'zoomed in' view for the graph now just returns an empty list of neighbours for that interval instead of an error.

Close #848 