### PR TITLE
fix issue #873, bugfix for multiple queries

### DIFF
--- a/frontend/src/app/visualization/barchart/barchart.component.ts
+++ b/frontend/src/app/visualization/barchart/barchart.component.ts
@@ -197,8 +197,7 @@ export class BarChartComponent<Result extends BarchartResult> implements OnChang
     /** add a new series (i.e. a new query) to the graph. */
     updateQueries(queries: string[]) {
         this.rawData = queries.map(queryText => {
-            const existingSeries = this.rawData.find(series => series.queryText === queryText);
-            return existingSeries || this.newSeries(queryText);
+            return this.newSeries(queryText);
         });
         this.prepareChart();
     }


### PR DESCRIPTION
See also issue #873. This fixes that by removing the existingSeries logic and just generating an all-new array of series for visualisations every time. This is fine I think, because the series are only small objects that are easily generated.