### PR TITLE
fix: #869 - current visualisation not showing in dropdown

### DIFF
--- a/frontend/src/app/dropdown/dropdown.component.html
+++ b/frontend/src/app/dropdown/dropdown.component.html
@@ -17,7 +17,7 @@
             <a class="dropdown-item" [ngClass]="{'is-active': value === undefined}" (click)="select(undefined)" *ngIf="canDeselect">
                 {{placeholder}}
             </a>
-            <a class="dropdown-item" *ngFor="let option of options" [ngClass]="{'is-active': value !== undefined && option['label'] == value['label']}"
+            <a class="dropdown-item" *ngFor="let option of options" [ngClass]="{'is-active': value !== undefined && lodash.isEqual(option, value)}"
                 (click)="select(option)">
                 <ng-container *ngIf="optionLabel === undefined">{{option}}</ng-container>
                 <ng-container *ngIf="optionLabel !== undefined">{{option[optionLabel]}}</ng-container>

--- a/frontend/src/app/dropdown/dropdown.component.ts
+++ b/frontend/src/app/dropdown/dropdown.component.ts
@@ -1,6 +1,8 @@
 import { Component, ElementRef, EventEmitter, HostListener, Input, Output, OnDestroy } from '@angular/core';
 import { Subject, Subscription } from 'rxjs';
 import {debounceTime} from 'rxjs/operators';
+import * as _ from 'lodash';
+
 
 @Component({
     selector: 'ia-dropdown',
@@ -33,6 +35,8 @@ export class DropdownComponent<T> implements OnDestroy {
 
     private changeSubject = new Subject<T | undefined>();
     private changeSubscription: Subscription;
+
+    private lodash = _;
 
     constructor(private elementRef: ElementRef) {
         // don't trigger a lot of events when a user is quickly looping through the options


### PR DESCRIPTION
Alright, this spectacular bugfix is maybe a tiny little bit unsatisfying, but I truly don't know what else could be causing this issue and this does fix it. 

My process was the following: the issue happens in the dropdown.component.html, specifically where it compares the value (an Object with the current visualisation type) to each possible visualisation option (also Objects), and assigns a class to the match. 

The bug only happens right after a new query: it doesn't occur at the initial state of the corpus, where the user can only select Number of Results and Most Frequent Words, and the class change works after the user selects any visualisation type in the dropdown (including if the user selects the current visualisation). 

I used the following console logs to see what was happening:
<img width="1078" alt="Screenshot 2022-11-11 at 15 01 54" src="https://user-images.githubusercontent.com/31687030/201431465-d66782b9-8272-4f1a-b45b-9e599120e9db.png">

Which resulted in the following:
<img width="449" alt="Screenshot 2022-11-11 at 15 00 50" src="https://user-images.githubusercontent.com/31687030/201431518-266f1741-38f1-4f0e-8084-a11aa4089619.png">

Very frustrating: I have no idea why it is not recognizing it as an identical Object, but I fixed it by just comparing the labels. If you have any idea why this is happening, I'd be excited to learn. I checked if there was maybe something in the search component, since the bug only occurs right after a new query, but I could not really find anything that would cause it. Maybe my JS/TS skills are just not developed enough :p


