### PR TITLE
unlimited comparison terms in similarity graph

### DIFF
--- a/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
+++ b/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
@@ -8,6 +8,7 @@ import { faCheck } from '@fortawesome/free-solid-svg-icons';
 })
 export class TermComparisonEditorComponent implements OnChanges {
     @Input() initialValue = []; // starting value
+    @Input() termLimit = 10;
 
     queries: string[] = [];
 
@@ -34,6 +35,6 @@ export class TermComparisonEditorComponent implements OnChanges {
 
     get disableConfirm(): boolean {
         if (!this.queries || !this.queries.length) { return false; }
-        return this.queries.length >= 10;
+        return this.queries.length >= this.termLimit;
     }
 }

--- a/frontend/src/app/word-models/word-similarity/word-similarity.component.html
+++ b/frontend/src/app/word-models/word-similarity/word-similarity.component.html
@@ -2,6 +2,7 @@
     <div class="control">
         <label class="label">Enter one or more terms to compare to "{{queryText}}":</label>
         <ia-term-comparison-editor
+            [termLimit]="comparisonTermLimit"
             (queriesChanged)="updateComparisonTerms($event)" (clearQueries)="updateComparisonTerms()">
         </ia-term-comparison-editor>
     </div>

--- a/frontend/src/app/word-models/word-similarity/word-similarity.component.ts
+++ b/frontend/src/app/word-models/word-similarity/word-similarity.component.ts
@@ -15,6 +15,7 @@ export class WordSimilarityComponent implements OnChanges {
     @Input() asTable: boolean;
     @Input() palette: string[];
 
+    comparisonTermLimit = Infinity;
     comparisonTerms: string[] = [];
 
     @Output() error = new EventEmitter();


### PR DESCRIPTION
close #916 

Removes any limit to the number of comparison terms that can be entered in the "compare similarity" graph. Note that this does not include any visual update to accommodate more than 10 terms, which would be tackled in #915 .

![image](https://user-images.githubusercontent.com/43678097/201912250-adebed70-04ba-4800-a650-d9bd94d5ea5b.png)

However, the number of terms is no issue for the table view.