### PR TITLE
Highlight Overhaul

### DIFF
--- a/backend/addcorpus/es_mappings.py
+++ b/backend/addcorpus/es_mappings.py
@@ -1,4 +1,4 @@
-def main_content_mapping(token_counts = True, stopword_analysis = False, stemming_analysis = False):
+def main_content_mapping(token_counts = True, stopword_analysis = False, stemming_analysis = False, term_vector_toplevel=False):
     '''
     Mapping for the main content field. Options:
 
@@ -8,9 +8,13 @@ def main_content_mapping(token_counts = True, stopword_analysis = False, stemmin
     '''
 
     mapping = {
-        'type': 'text',
-        'term_vector': 'with_positions_offsets' # include char positions on _source for highlighting too
+        'type': 'text'
     }
+
+    if term_vector_toplevel:
+        mapping.update({
+        'term_vector': 'with_positions_offsets' # include char positions on _source for highlighting too
+    })
 
     if any([token_counts, stopword_analysis, stemming_analysis]):
         multifields = {}

--- a/backend/addcorpus/es_mappings.py
+++ b/backend/addcorpus/es_mappings.py
@@ -31,6 +31,7 @@ def main_content_mapping(token_counts = True, stopword_analysis = False, stemmin
                 "term_vector": "with_positions_offsets",
             }
         mapping['fields'] = multifields
+        mapping['term_vector'] = "with_positions_offsets"  # include char positions on _source for highlighting too
 
     return mapping
 

--- a/backend/addcorpus/es_mappings.py
+++ b/backend/addcorpus/es_mappings.py
@@ -8,7 +8,8 @@ def main_content_mapping(token_counts = True, stopword_analysis = False, stemmin
     '''
 
     mapping = {
-        'type': 'text'
+        'type': 'text',
+        'term_vector': 'with_positions_offsets' # include char positions on _source for highlighting too
     }
 
     if any([token_counts, stopword_analysis, stemming_analysis]):
@@ -31,7 +32,6 @@ def main_content_mapping(token_counts = True, stopword_analysis = False, stemmin
                 "term_vector": "with_positions_offsets",
             }
         mapping['fields'] = multifields
-        mapping['term_vector'] = "with_positions_offsets"  # include char positions on _source for highlighting too
 
     return mapping
 

--- a/backend/corpora/parliament/utils/field_defaults.py
+++ b/backend/corpora/parliament/utils/field_defaults.py
@@ -293,7 +293,7 @@ def speech():
         display_name='Speech',
         description='The transcribed speech',
         # each index has its own definition of the 'clean' and 'stemmed' analyzer, based on language
-        es_mapping = main_content_mapping(token_counts=True, stopword_analysis=True, stemming_analysis=True),
+        es_mapping = main_content_mapping(token_counts=True, stopword_analysis=True, stemming_analysis=True, term_vector_toplevel=True),
         results_overview=True,
         search_field_core=True,
         display_type='text_content',

--- a/frontend/src/app/document-view/document-view.component.html
+++ b/frontend/src/app/document-view/document-view.component.html
@@ -12,7 +12,8 @@
                     <ng-container *ngFor="let field of propertyFields">
                         <tr *ngIf="document.fieldValues[field.name]">
                             <th>{{field.displayName}}</th>
-                            <td *ngIf="!isUrlField(field)" data-test-field-value [innerHtml]="document.fieldValues[field.name] | highlight:query"></td>
+                            <td *ngIf="!isUrlField(field) && selectedFieldsContain(field)" data-test-field-value [innerHtml]="document.fieldValues[field.name] | highlight:queryModel.queryText"></td>
+                            <td *ngIf="!isUrlField(field) && !selectedFieldsContain(field)" data-test-field-value [innerHtml]="document.fieldValues[field.name]"></td>
                             <td *ngIf="isUrlField(field)">
                                 <a href={{document.fieldValues[field.name]}} target="_blank">{{document.fieldValues[field.name]}}</a>
                             </td>
@@ -41,7 +42,8 @@
             </div>
             <div *ngIf="tabIndex==0">
                 <ng-container *ngFor="let field of contentFields">
-                    <div class="content" *ngIf="document.fieldValues[field.name]" [innerHtml]="document.fieldValues[field.name] | highlight:query"></div>
+                    <div class="content" *ngIf="document.fieldValues[field.name] && selectedFieldsContain(field)" [innerHtml]="document.fieldValues[field.name] | highlight:queryModel.queryText"></div>
+                    <div class="content" *ngIf="document.fieldValues[field.name] && !selectedFieldsContain(field)" [innerHtml]="document.fieldValues[field.name]"></div>
                 </ng-container>
             </div>
             <div *ngIf="tabIndex==1">

--- a/frontend/src/app/document-view/document-view.component.html
+++ b/frontend/src/app/document-view/document-view.component.html
@@ -12,8 +12,7 @@
                     <ng-container *ngFor="let field of propertyFields">
                         <tr *ngIf="document.fieldValues[field.name]">
                             <th>{{field.displayName}}</th>
-                            <td *ngIf="!isUrlField(field) && selectedFieldsContain(field)" data-test-field-value [innerHtml]="document.fieldValues[field.name] | highlight:queryModel.queryText"></td>
-                            <td *ngIf="!isUrlField(field) && !selectedFieldsContain(field)" data-test-field-value [innerHtml]="document.fieldValues[field.name]"></td>
+                            <td *ngIf="!isUrlField(field)" data-test-field-value [innerHtml]="highlightedInnerHtml(field)"></td>
                             <td *ngIf="isUrlField(field)">
                                 <a href={{document.fieldValues[field.name]}} target="_blank">{{document.fieldValues[field.name]}}</a>
                             </td>
@@ -41,11 +40,6 @@
                 </ul>
             </div>
             <div *ngIf="tabIndex==0">
-                <ng-container *ngFor="let field of contentFields">
-                    <div class="content" *ngIf="document.fieldValues[field.name] && selectedFieldsContain(field)" [innerHtml]="document.fieldValues[field.name] | highlight:queryModel.queryText"></div>
-                    <div class="content" *ngIf="document.fieldValues[field.name] && !selectedFieldsContain(field)" [innerHtml]="document.fieldValues[field.name]"></div>
-                </ng-container>
-                <h3>BREAK</h3>
                 <ng-container *ngFor="let field of contentFields">
                     <div class="content" *ngIf="document.fieldValues[field.name]" [innerHtml]="highlightedInnerHtml(field)"></div>
                 </ng-container>

--- a/frontend/src/app/document-view/document-view.component.html
+++ b/frontend/src/app/document-view/document-view.component.html
@@ -45,6 +45,10 @@
                     <div class="content" *ngIf="document.fieldValues[field.name] && selectedFieldsContain(field)" [innerHtml]="document.fieldValues[field.name] | highlight:queryModel.queryText"></div>
                     <div class="content" *ngIf="document.fieldValues[field.name] && !selectedFieldsContain(field)" [innerHtml]="document.fieldValues[field.name]"></div>
                 </ng-container>
+                <h3>BREAK</h3>
+                <ng-container *ngFor="let field of contentFields">
+                    <div class="content" *ngIf="document.fieldValues[field.name]" [innerHtml]="highlightedInnerHtml(field)"></div>
+                </ng-container>
             </div>
             <div *ngIf="tabIndex==1">
                 <ia-image-view [corpus]="corpus" [document]="document"></ia-image-view>

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -77,7 +77,8 @@ export class DocumentViewComponent implements OnChanges {
 
     highlightedInnerHtml(field: CorpusField) {
         let highlighted = this.document.fieldValues[field.name];
-        if (this.document.highlight && field.name in this.document.highlight) {
+        if (this.document.highlight && field.name in this.document.highlight &&
+            this.selectedFieldsContain(field)) {
             for (let highlight of this.document.highlight[field.name]) {
                 const stripped_highlight = this.stripTags(highlight);
                 highlighted = highlighted.replace(stripped_highlight, highlight);

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnChanges } from '@angular/core';
 
-import { CorpusField, FoundDocument, Corpus } from '../models/index';
+import { CorpusField, FoundDocument, Corpus, QueryModel } from '../models/index';
 
 
 @Component({
@@ -25,7 +25,7 @@ export class DocumentViewComponent implements OnChanges {
     public document: FoundDocument;
 
     @Input()
-    public query: string;
+    public queryModel: QueryModel;
 
     @Input()
     public corpus: Corpus;
@@ -44,6 +44,7 @@ export class DocumentViewComponent implements OnChanges {
     constructor() { }
 
     ngOnChanges() {
+        console.log(this.queryModel)
         this.tabIndex = this.documentTabIndex;
     }
 
@@ -53,5 +54,19 @@ export class DocumentViewComponent implements OnChanges {
 
     isUrlField(field: CorpusField) {
         return field.name === 'url' || field.name.startsWith('url_');
+    }
+
+    /**
+     * Checks if user has selected fields in the queryModel and whether current field is among them
+     * Used to check which fields need to be highlighted
+     */
+    selectedFieldsContain(field: CorpusField) {
+        if (this.queryModel && this.queryModel.fields && this.queryModel.fields.includes(field.name)) {
+            return true;
+        } else if (this.queryModel && !this.queryModel.fields) {
+            return true;  // if there are no selected fields, return true for all fields
+        } else {
+            return false;
+        }
     }
 }

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -45,6 +45,7 @@ export class DocumentViewComponent implements OnChanges {
 
     ngOnChanges() {
         this.tabIndex = this.documentTabIndex;
+        console.log(this.document.highlight);
     }
 
     changeTabIndex(index: number) {
@@ -66,6 +67,24 @@ export class DocumentViewComponent implements OnChanges {
             return true;  // if there are no selected fields, return true for all fields
         } else {
             return false;
+        }
+    }
+
+    stripTags(htmlString: string){
+        const parseHTML= new DOMParser().parseFromString(htmlString, 'text/html');
+        return parseHTML.body.textContent || '';
+      }
+
+    highlightedInnerHtml(field: CorpusField) {
+        let highlighted = this.document.fieldValues[field.name];
+        if (this.document.highlight && field.name in this.document.highlight) {
+            for (let highlight of this.document.highlight[field.name]) {
+                const stripped_highlight = this.stripTags(highlight);
+                highlighted = highlighted.replace(stripped_highlight, highlight);
+            }
+            return highlighted;
+        } else {
+            console.log(field.name);
         }
     }
 }

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -84,7 +84,7 @@ export class DocumentViewComponent implements OnChanges {
             }
             return highlighted;
         } else {
-            console.log(field.name);
+            return this.document.fieldValues[field.name];
         }
     }
 }

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -45,7 +45,6 @@ export class DocumentViewComponent implements OnChanges {
 
     ngOnChanges() {
         this.tabIndex = this.documentTabIndex;
-        console.log(this.document.highlight);
     }
 
     changeTabIndex(index: number) {

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -44,8 +44,6 @@ export class DocumentViewComponent implements OnChanges {
     constructor() { }
 
     ngOnChanges() {
-        console.log(this.queryModel)
-        console.log(this.queryModel)
         this.tabIndex = this.documentTabIndex;
     }
 

--- a/frontend/src/app/models/corpus.ts
+++ b/frontend/src/app/models/corpus.ts
@@ -60,6 +60,7 @@ export interface CorpusField {
     visualizations?: string[];
     visualizationSort?: string;
     multiFields?: string[];
+    positionsOffsets?: boolean;
     hidden: boolean;
     sortable: boolean;
     primarySort: boolean;

--- a/frontend/src/app/search/highlight-selector.component.html
+++ b/frontend/src/app/search/highlight-selector.component.html
@@ -1,6 +1,31 @@
 <div class="contextbox">
-    <h2 class="subtitle">Context (no. of characters):</h2>
-    <p class="control" iaBalloon="Leave blank or set to 0 to turn off highlighting" iaBalloonLength="medium" iaBalloonPosition="right">
-        <input class="input" type="number" (change)="updateHighlightSize($event)">
-    </p>
+    <div>
+        <h2 class="subtitle highlights-subtitle">Highlights:</h2>
+    </div>
+    <div class="column is-narrow">
+        <div class="field has-addons">
+            <div class="extended-selector">
+                <div *ngIf="highlight!=0"  class="field has-addons">
+                    <div class="control" iaBalloon="Increase/decrease preview size" iaBalloonLength="medium" iaBalloonPosition="right">
+                        <button class="button is-light" (click)="updateHighlightSize($event, 'more')">
+                            <i class="fa fa-plus" aria-hidden="true"></i>
+                        </button>
+                        <button class="button is-light" (click)="updateHighlightSize($event, 'less')">
+                            <i class="fa fa-minus" aria-hidden="true"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <!-- Buttons for switching between table and graphical representation -->
+            <div class="control" iaBalloon="Toggle preview and highlights" iaBalloonLength="medium" iaBalloonPosition="right">
+                <button class="button" [class.is-primary]="highlight!=0" [disabled]="queryText==null||queryText==''" (click)="updateHighlightSize($event, 'on')">
+                    ON
+                </button>
+                <button class="button" [class.is-primary]="highlight==0" (click)="updateHighlightSize($event, 'off')">
+                    OFF
+                </button>
+            </div>
+        </div>
+
+    </div>
 </div>

--- a/frontend/src/app/search/highlight-selector.component.scss
+++ b/frontend/src/app/search/highlight-selector.component.scss
@@ -8,10 +8,6 @@
     margin-top: -.5rem;
 }
 
-.extended-selector {
-    margin-left: 1rem;
-}
-
 .highlights-subtitle {
     text-align: right;
 }

--- a/frontend/src/app/search/highlight-selector.component.scss
+++ b/frontend/src/app/search/highlight-selector.component.scss
@@ -7,3 +7,11 @@
 .contextbox {
     margin-top: -.5rem;
 }
+
+.extended-selector {
+    margin-left: 1rem;
+}
+
+.highlights-subtitle {
+    text-align: right;
+}

--- a/frontend/src/app/search/highlight-selector.component.ts
+++ b/frontend/src/app/search/highlight-selector.component.ts
@@ -27,6 +27,8 @@ export class HighlightSelectorComponent extends ParamDirective {
     ngOnChanges() {
         if (this.queryText == '' || this.queryText == null) {
             this.setParams({ highlight: null });
+        } else {
+            this.setParams({ highlight: 100 });
         }
     }
 

--- a/frontend/src/app/search/highlight-selector.component.ts
+++ b/frontend/src/app/search/highlight-selector.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 
 import { ParamDirective } from '../param/param-directive';
@@ -18,8 +18,16 @@ export class HighlightSelectorComponent extends ParamDirective {
       super(route, router);
     }
 
+    @Input() queryText;
+
     initialize() {
 
+    }
+
+    ngOnChanges() {
+        if (this.queryText == '' || this.queryText == null) {
+            this.setParams({ highlight: null });
+        }
     }
 
     teardown() {
@@ -31,9 +39,20 @@ export class HighlightSelectorComponent extends ParamDirective {
     }
 
 
-    updateHighlightSize(event) {
-        const highlightSize = event.target.value;
-        this.setParams({ highlight: highlightSize !== "0" ? highlightSize : null });
+    updateHighlightSize(event, instruction?: string) {
+        let highlightSize = this.highlight;
+        if (instruction == 'on' && highlightSize == 0) {
+            highlightSize = 100;
+        } else if (instruction == 'more' && highlightSize < 800) {
+            highlightSize += 100;
+        } else if (instruction == 'less' && highlightSize > 120) {
+            highlightSize -= 100;
+        } else if (instruction == 'off') {
+            highlightSize = 0;
+        } else if (instruction == 'custom') {
+            highlightSize = event.target.value;
+        }
+        this.setParams({ highlight: highlightSize !== 0 ? highlightSize : null });
     }
 
 }

--- a/frontend/src/app/search/highlight-selector.component.ts
+++ b/frontend/src/app/search/highlight-selector.component.ts
@@ -51,8 +51,6 @@ export class HighlightSelectorComponent extends ParamDirective {
             highlightSize -= 100;
         } else if (instruction == 'off') {
             highlightSize = 0;
-        } else if (instruction == 'custom') {
-            highlightSize = event.target.value;
         }
         this.setParams({ highlight: highlightSize !== 0 ? highlightSize : null });
     }

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -13,7 +13,7 @@
             {{results.total.value}} results.
             Showing results {{fromIndex+1}} - {{fromIndex+resultsPerPage > totalResults? totalResults : fromIndex+resultsPerPage}}:
         </h2>
-        <ng-content *ngIf="!(queryText===null || queryText==='')" select="ia-highlight-selector"></ng-content>
+        <ia-highlight-selector [queryText]="queryText"></ia-highlight-selector>
     </div>
 
     <section class="section results-navigation" #resultsNavigation [ngClass]="{'is-scrolled-down': isScrolledDown}">

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -48,7 +48,11 @@
                                 <ng-container *ngIf="document.highlight && document.highlight[field.name]; else unhighlightedRow">
                                     <td>
                                         <ng-container *ngFor="let highlight of document.highlight[field.name]">
-                                            <tr><div ngPreserveWhitespaces style="word-break:break-word" [innerHtml]="highlight"></div></tr>
+                                            <tr>
+                                                <div ngPreserveWhitespaces style="word-break:break-word" [innerHtml]="highlight"></div>
+                                                <!-- insert ellipsis [...] in between snippets or at the end of a single snippet -->
+                                                <p *ngIf="highlight != document.highlight[field.name][document.highlight[field.name].length-1]">[...]</p>
+                                            </tr>
                                         </ng-container>
                                     </td>
                                 </ng-container>

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -81,7 +81,7 @@
 <p-dialog [(visible)]="showDocument" width="100%"
     [modal]="true" [responsive]="true" [maximizable]="true" [dismissableMask]="true" [draggable]="true" [resizable]="false" [blockScroll]="true"
     *ngIf="viewDocument" header="Document {{viewDocument.position}} of {{totalResults}}">
-    <ia-document-view [document]="viewDocument" [fields]="corpus.fields" [query]="queryText" [corpus]="corpus" [documentTabIndex]="documentTabIndex"></ia-document-view>
+    <ia-document-view [document]="viewDocument" [fields]="corpus.fields" [queryModel]="queryModel" [corpus]="corpus" [documentTabIndex]="documentTabIndex"></ia-document-view>
     <ng-template pTemplate="footer">
         <div class="columns" style="text-align:left">
             <div class="column">

--- a/frontend/src/app/services/corpus.service.spec.ts
+++ b/frontend/src/app/services/corpus.service.spec.ts
@@ -195,6 +195,7 @@ describe('CorpusService', () => {
                 visualizations: ['resultscount', 'termfrequency'],
                 visualizationSort: 'key',
                 multiFields: undefined,
+                positionsOffsets: undefined,
                 hidden: true,
                 sortable: false,
                 primarySort: false,
@@ -225,6 +226,7 @@ describe('CorpusService', () => {
                 visualizations: ['resultscount', 'termfrequency'],
                 visualizationSort: 'key',
                 multiFields: undefined,
+                positionsOffsets: undefined,
                 searchFilter: {
                     description: 'Restrict the years from which search results will be returned.',
                     fieldName: 'year',
@@ -248,6 +250,7 @@ describe('CorpusService', () => {
                 visualizations: ['wordcloud', 'ngram'],
                 visualizationSort: null,
                 multiFields: ['clean', 'stemmed', 'length'],
+                positionsOffsets: true,
                 searchFilter: null,
                 searchFieldCore: true,
                 mappingType: 'text',

--- a/frontend/src/app/services/corpus.service.ts
+++ b/frontend/src/app/services/corpus.service.ts
@@ -93,7 +93,7 @@ export class CorpusService {
             visualizations: data.visualizations,
             visualizationSort: data.visualization_sort,
             multiFields: data['es_mapping']?.fields ? Object.keys(data['es_mapping'].fields) : undefined,
-            positionsOffsets: data['es_mapping']?.term_vector == 'with_positions_offsets',
+            positionsOffsets: data['es_mapping']?.term_vector ? data['es_mapping']?.term_vector == 'with_positions_offsets': undefined,
             hidden: data.hidden,
             sortable: data.sortable,
             primarySort: data.primary_sort,

--- a/frontend/src/app/services/corpus.service.ts
+++ b/frontend/src/app/services/corpus.service.ts
@@ -93,6 +93,7 @@ export class CorpusService {
             visualizations: data.visualizations,
             visualizationSort: data.visualization_sort,
             multiFields: data['es_mapping']?.fields ? Object.keys(data['es_mapping'].fields) : undefined,
+            positionsOffsets: data.term_vector == 'with_positions_offsets',
             hidden: data.hidden,
             sortable: data.sortable,
             primarySort: data.primary_sort,

--- a/frontend/src/app/services/corpus.service.ts
+++ b/frontend/src/app/services/corpus.service.ts
@@ -93,7 +93,7 @@ export class CorpusService {
             visualizations: data.visualizations,
             visualizationSort: data.visualization_sort,
             multiFields: data['es_mapping']?.fields ? Object.keys(data['es_mapping'].fields) : undefined,
-            positionsOffsets: data.term_vector == 'with_positions_offsets',
+            positionsOffsets: data['es_mapping']?.term_vector == 'with_positions_offsets',
             hidden: data.hidden,
             sortable: data.sortable,
             primarySort: data.primary_sort,

--- a/frontend/src/app/services/elastic-search.service.ts
+++ b/frontend/src/app/services/elastic-search.service.ts
@@ -70,14 +70,8 @@ export class ElasticSearchService {
                     ({ [field.name]: {"type": "fvh",
                     "matched_fields": ["speech", "speech.stemmed"] }}): ({ [field.name]: { }
                 })})
+
             }
-        if (query.highlight['fields'].indexOf({'speech': {}}) != -1) {
-            console.log('hurray!')
-        }
-        for (let item of query.highlight['fields']) {
-            if (JSON.stringify(item) == JSON.stringify({"speech": {}}))
-                console.log(`hello: ${JSON.stringify(item)}`);
-        }
         }
 
         return query;

--- a/frontend/src/app/services/elastic-search.service.ts
+++ b/frontend/src/app/services/elastic-search.service.ts
@@ -65,9 +65,19 @@ export class ElasticSearchService {
                 pre_tags: ['<span class="highlight">'],
                 post_tags: ['</span>'],
                 order: 'score',
-                fields: highlightFields.map( field => ({ [field.name]: { }
-                }))
-            };
+                fields: highlightFields.map( function(field) {
+                    return field.name == "speech" ?
+                    ({ [field.name]: {"type": "fvh",
+                    "matched_fields": ["speech", "speech.stemmed"] }}): ({ [field.name]: { }
+                })})
+            }
+        if (query.highlight['fields'].indexOf({'speech': {}}) != -1) {
+            console.log('hurray!')
+        }
+        for (let item of query.highlight['fields']) {
+            if (JSON.stringify(item) == JSON.stringify({"speech": {}}))
+                console.log(`hello: ${JSON.stringify(item)}`);
+        }
         }
 
         return query;

--- a/frontend/src/app/services/elastic-search.service.ts
+++ b/frontend/src/app/services/elastic-search.service.ts
@@ -66,9 +66,9 @@ export class ElasticSearchService {
                 post_tags: ['</span>'],
                 order: 'score',
                 fields: highlightFields.map( function(field) {
-                    return field.name == "speech" ?
-                    ({ [field.name]: {"type": "fvh",
-                    "matched_fields": ["speech", "speech.stemmed"] }}): ({ [field.name]: { }
+                    return field.displayType == "text_content" ? // add matched_fields for stemmed highlighting
+                    ({ [field.name]: {"type": "fvh", "matched_fields": ["speech", "speech.stemmed"] }}):
+                    ({ [field.name]: { }
                 })})
 
             }

--- a/frontend/src/app/services/elastic-search.service.ts
+++ b/frontend/src/app/services/elastic-search.service.ts
@@ -66,7 +66,7 @@ export class ElasticSearchService {
                 post_tags: ['</span>'],
                 order: 'score',
                 fields: highlightFields.map( function(field) {
-                    return field.displayType == "text_content" ? // add matched_fields for stemmed highlighting
+                    return field.displayType == "text_content" && field.positionsOffsets ? // add matched_fields for stemmed highlighting
                     ({ [field.name]: {"type": "fvh", "matched_fields": ["speech", "speech.stemmed"] }}):
                     ({ [field.name]: { }
                 })})

--- a/frontend/src/app/services/elastic-search.service.ts
+++ b/frontend/src/app/services/elastic-search.service.ts
@@ -66,9 +66,9 @@ export class ElasticSearchService {
                 post_tags: ['</span>'],
                 order: 'score',
                 fields: highlightFields.map( function(field) {
-                    return field.displayType == "text_content" ? // add matched_fields for stemmed highlighting
-                    ({ [field.name]: {"type": "fvh", "matched_fields": ["speech", "speech.stemmed"] }}):
-                    ({ [field.name]: { }
+                    return field.name == "speech" ?
+                    ({ [field.name]: {"type": "fvh",
+                    "matched_fields": ["speech", "speech.stemmed"] }}): ({ [field.name]: { }
                 })})
 
             }


### PR DESCRIPTION
This branch addresses issues #679 #807 and #819, as well as introducing a few other features regarding highlights and snippets.

Broadly speaking, this branch switches over most of the highlighting from the Regex approach, described in `highlight.service.ts` and `highlight.pipe.ts` to the built-in Elastic Search approach, now mostly described in `elastic-search.service.ts`. The benefits of the built-in approach are:
 - stemmed highlights are available through the `"matched_fields"` functionality in ES highlighting for all stemmed fields
 - word boundaries are no longer used to cut highlights up, instead whole phrases are highlighted.
 - it's slightly faster (not really noticeable but maybe on larger datasets it will be)

The matched_fields functionality relies on the 'Lucene Fast Vector Highlight' (fvh), which requires the snippet length to be at least 18 characters, I could not retrieve the reason for this, just that it is a rule. However, that is nicely addressed by the next feature in this branch: a new highlight-selector controller.

The new controller is not just pretty, it also functions to initialize, update, and reset the highlight parameter based on the query as well as the user inputs on the controller. Currently, the options are on/off and more/less.

Controller without query:
<img width="1269" alt="Screenshot 2023-03-02 at 19 29 22" src="https://user-images.githubusercontent.com/31687030/222608660-53817fe5-299e-4418-84c8-9bfeaf45490e.png">

Controller with query:
<img width="1219" alt="Screenshot 2023-03-02 at 19 30 18" src="https://user-images.githubusercontent.com/31687030/222608745-ea1efc31-2c54-4bdd-b966-f9549e5fa675.png">

One thing I would love some input on is whether you have to re-index the corpora to make this branch work. I had to, but I was working with very old indices I discovered. I have added a line where the content fields are indexed using the 'with_positions_offsets' term vector, but I discovered through some experimentation that maybe actually the corpora were already indexed in this way and I did not need to specify it there... So I do not know whether I had to re-index because my indices were old or because the content field needed to also be re-indexed *throws hands up in confusion* I would love your input on this.

The Regex approach to highlighting is still used in the manual and in the search-results where no highlight field is given by ES, but I think we could potentially phase it out? Might be more hassle than it's worth, but it might also cut down on the amount of code which we could argue is a goal in and of itself.

p.s. I have tried and tried rebasing this branch but it keeps giving me trouble and it's 19:00 so it's still un-rebased.