### PR TITLE
remove clutter from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,7 @@ The text mining tool that obviates all others.
 
 I-analyzer is a web application that allows users to search through large text corpora, requiring no experience in text mining or technical know-how.
 
-## Directory structure
-
-The I-analyzer backend (`/backend`) is a python/Django app that provides the following functionality:
-
-- A 'users' module that defines user accounts.
-
-- A 'corpora' module containing corpus definitions and metadata of the currently implemented corpora. For each corpus added in I-analyzer, this module defines how to extract document contents from its source files and sets parameters for displaying the corpus in the interface, such as sorting options.
-
-- An 'addcorpus' module which manages the functionality to extract data from corpus source files (given the definition) and save this in an elasticsearch index. Source files can be XML or HTML format (which are parsed with `beautifulsoup4` + `lxml`) or CSV. This module also provides the basic data structure for corpora.
-
-- An 'es' module which handles the communication with elasticsearch. The data is passed through to the index using the `elasticsearch` package for Python (note that `elasticsearch-dsl` is not used, since its [documentation](https://elasticsearch-dsl.readthedocs.io/en/latest) at the time seemed less immediately accessible than the [low-level](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html) version).
-
-- An 'api' module that that enables users to search through an ElasticSearch index of a text corpus and stream search results into a CSV file. The module also performs more complex analysis of search results for visualisations.
-
-- A 'visualizations' module that does the analysis for several types of text-based visualisations.
-
-- A 'downloads' module that collects results into csv files.
-
-- A 'wordmodels' module that handles functionality related to word embeddings.
-
-`ianalyzer/frontend` is an [Angular 13](https://angular.io/) web interface.
-
-See the documentation for [a more extensive overview](./documentation/Overview.md)
+See the documentation for [an overview of the repository](./documentation/Overview.md)
 
 ## Prerequisites
 
@@ -37,8 +15,6 @@ See the documentation for [a more extensive overview](./documentation/Overview.m
 * [ElasticSearch](https://www.elastic.co/) 8. To avoid a lot of errors, choose the option: install elasticsearch with .zip or .tar.gz. ES wil install everything in one folder, and not all over your machine, which happens with other options.
 * [Redis](https://www.redis.io/) (used by [Celery](http://www.celeryproject.org/)). Recommended installation is [installing from source](https://redis.io/docs/getting-started/installation/install-redis-from-source/)
 * Yarn
-
-If you wish to have email functionality, also make sure you have an email server set up, such as [maildev](https://maildev.github.io/maildev/).
 
 The documentation includes a [recipe for installing the prerequisites on Debian 10](./documentation/Local-Debian-I-Analyzer-setup.md)
 
@@ -77,40 +53,16 @@ yarn postinstall
 The backend readme provides more details on these steps.
 8. Set up the database and migrations by running `yarn django migrate`.
 9. Make a superuser account with `yarn django createsuperuser`
-10. In `frontend/src/environments`, create a file `environment.private.ts` with the following settings:
-```
-privateEnvironment = {
-    appName: I-Analyzer,
-    aboutPage: ianalyzer
-}
-```
 
 ## Adding corpora
 
 To include corpora on your environment, you need to index them from their source files. The source files are not included in this directory; ask another developer about their availability. If you have (a sample of) the source files for a corpus, you can add it your our environment as follows:
 
-_Note:_ these instructions are for adding a corpus that already has a corpus definition. For adding new corpus definitions, see [How to add a new corpus to I-analyzer](./documentation/How-to-add-a-new-corpus-to-Ianalyzer.md).
+_Note:_ these instructions are for indexing a corpus that already has a corpus definition. For adding new corpus definitions, see [How to add a new corpus to I-analyzer](./documentation/How-to-add-a-new-corpus-to-Ianalyzer.md).
 
 1. Add the corpus to the `CORPORA` dictionary in your local settings file. The key should match the class name of the corpus definition. This match is not case-sensitive, and your key may include extra non-alphabetic characters (they will be ignored when matching). The value should be the absolute path the corpus definition file (e.g. `.../backend/corpora/times/times.py`).
-2. Set configurations for your corpus. Check the definition file to see which variables it expects to find in the configuration. Some of these may already be set in settings.py, but you will at least need to define the name of the elasticsearch index and the (absolute) path to your source files.
-3. Activate your python virtual environment. Create an ElasticSearch index from the source files by running, e.g., `yarn django index dutchannualreports -s 1785-01-01 -e 2010-12-31`, for indexing the Dutch Annual Reports corpus starting in 1785 and ending in 2010. The dates are optional, and default to specified minimum and maximum dates of the corpus. (Note that new indices are created with `number_of_replicas` set to 0 (this is to make index creation easier/lighter). In production, you can automatically update this setting after index creation by adding the `--prod` flag (e.g. `yarn django index goodreads --prod`). Note though, that the
-`--prod` flag creates a _versioned_ index name, which needs an alias to actually work as `name_of_index_without_version` (see below for more details).
-
-#### Flags of indexing script
-- --prod / -p Whether or not to create a versioned index name
-- --mappings_only / -m Whether to only create an index with mappings and settings, without adding data to it (useful before reindexing from another index or another server)
-- --add / -a Add documents to an existing index (skip index creation)
-- --update / -u Add or change fields in the documents. This requires an `update_body` or `update_script` to be set in the corpus definition, see [example for update_body in dutchnewspapers](backend/corpora/dutchnewspapers/dutchnewspapers_all.py) and [example for update_script in goodreads](backend/corpora/goodreads/goodreads.py).
-- --delete / -d Delete an existing index with the `corpus.es_index` name. Note that in production, `corpus.es_index` will usually be an *alias*, and you would use the `yarn django es alias -c corpus-name --clean` to achieve the same thing.
-- --rollover / -r Only applies in production: rollover a versioned index to the newest version. This *will not* delete the old index (so you have a chance to check the new index and roll back, if necessary)
-
-#### Production
-
-On the servers, we work with aliases. Indices created with the `--prod` flag will have a version number (e.g. `indexname-1`), and as such will not be recognized by the corpus definition (which is looking for `indexname`). Create an alias for that using the `alias` command: `yarn django alias -c corpusname`. That script ensures that an alias is present for the index with the highest version numbers, and not for all others (i.e. older versions). The advantage of this approach is that an old version of the index can be kept in place as long as is needed, for example while a new version of the index is created. Note that removing an alias does not remove the index itself.
-
-Once you have an alias in place, you might want to remove any old versions of the index. The `alias` command can be used for this. If you call `yarn django alias -c corpusname --clean` any versions of the index that are not the newest version will be removed. Note that removing an index also removes any existing aliases for it. You might want to perform this as a separate operation (i.e. after completing step 14) so that the old index stays in place for a bit while you check that all is fine.
-
-See the documentation for more information about [indexing on the server](./documentation/Indexing-on-server.md).
+2. Set configurations for your corpus. Check the definition file to see which variables it expects to find in the configuration. Some of these may already be set in settings.py, but you will at least need to define the (absolute) path to your source files.
+3. Activate your python virtual environment. Create an ElasticSearch index from the source files by running, e.g., `yarn django index dutchannualreports`, for indexing the Dutch Annual Reports corpus in a development environment. See [Indexing](documentation/Indexing-corpora.md) for more information.
 
 ## Running a dev environment
 
@@ -118,8 +70,7 @@ See the documentation for more information about [indexing on the server](./docu
 2. Activate your python environment. Start the backend server with `yarn start-back`. This creates an instance of the Django server at `127.0.0.1:8000`.
 3. (optional) If you want to use celery, start your local redis server by running `redis-server` in a separate terminal.
 4. (optional) If you want to use celery, activate your python environment. Run `yarn celery worker`. Celery is used for long downloads and the word cloud and ngrams visualisations.
-5. (optional) If you want to use email functionality, start your local email server.
-6. Start the frontend by running `yarn start-front`.
+5. Start the frontend by running `yarn start-front`.
 
 ## Notes for development
 

--- a/documentation/Email.md
+++ b/documentation/Email.md
@@ -1,0 +1,13 @@
+## Email
+
+The backend sends emails about account administration (veryfing emails, resetting passwords), and downloads.
+
+By default, the backend will use the django console backend for emails, so any outgoing mail will be displayed on your console.
+
+If you want to use a server like [maildev](https://maildev.github.io/maildev/), you can configure a different email backend in your local settings, for example:
+
+```python
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = '0.0.0.0'
+EMAIL_PORT = '1025'
+```

--- a/documentation/Indexing-corpora.md
+++ b/documentation/Indexing-corpora.md
@@ -1,0 +1,37 @@
+# Indexing corpora
+
+Indexing is the step to load corpus data into elasticsearch, which makes the data available through the I-analyzer interface.
+
+You can start indexing once you have
+- A python source file for the corpus
+- A directory with source data
+- Added the necessary properties to django settings
+
+The basic indexing command is:
+
+```bash
+yarn django index my-corpus
+```
+
+Use `yarn django index --help` to see all possible flags. Some useful options are highlighted below.
+
+## Development
+
+For development environments, we usually maintain a single index per corpus, rather than creating versioned indices. New indices are also created with `number_of_replicas` set to 0 (this is to make index creation easier/lighter).
+
+Some options that may be useful for development:
+
+### Delete index before starting
+
+`--delete` / `-d` deletes an existing index of this name, if there is one. Without this flag, you will add your data to the existing index.
+
+### Date selection
+
+`--start` / `-s` and `--end` / `-e` respectively give a start and end date to select source files. Note that this only works if the `sources` function in your corpus definition makes use of these options; not all corpora have this defined. (It is not always possible to infer exact dates from source file metadata.)
+
+The filtering of source files may not be exact (e.g. only take the year into account). These flags do *not* filter documents based on their contents.
+
+
+## Production
+
+See [Indexing on server](documentation/Indexing-on-server.md) for more information about production-specific settings.

--- a/documentation/Indexing-on-server.md
+++ b/documentation/Indexing-on-server.md
@@ -1,5 +1,8 @@
 # Indexing corpora on the server
 
+For production environments, we use *versioned* index names (e.g. `times-1`, `times-2`), and use an alias (e.g. `times`) to point to the correct version. The advantage of this approach is that an old version of the index can be kept in place as long as is needed, for example while a new version of the index is created.
+
+
 ## Moving data to server
 On the server, move data to a location in the `/its` share.
 
@@ -14,13 +17,19 @@ Start a screen with a descriptive name (e.g., `screen -S index-superb-corpus`). 
 Call the flask command for indexing, e.g., `yarn django index superb-corpus -p`. The production flag indicates that we have a *versioned* index after this: `superb-corpus-1`. You can also choose to add the `--rollover` (`-r`) flag: this is equivalent with automaticaly calling `yarn django alias` after `yarn django index`. As it's advisable to double-check a new index before setting / rolling over the alias, this flag should be used with caution.
 
 ## Additional indexing flags
+
 It is also possible to only add settings and mappings by providing the `--mappings-only` or `-m` flag. This is useful, for instance, before a `REINDEX` via Kibana from one Elasticsearch cluster to another (which is often faster than reindexing from source).
+
+`--update` / `-u` can be used to run an update script for the corpus. This requires an `update_body` or `update_script` to be set in the corpus definition, see [example for update_body in dutchnewspapers](backend/corpora/dutchnewspapers/dutchnewspapers_all.py) and [example for update_script in goodreads](backend/corpora/goodreads/goodreads.py).
+
 
 ## Alias
 Either:
 - create an alias `superb-corpus` on Kibana manually:
 `PUT suberb-corpus-1/_alias/superb-corpus`. After this, the corpus will be reachable under the alias.
 - or: run `yarn django alias superb-corpus-name`. This will set an alias with the name defined by `es_alias` or (fallback) `es_index`. If you additionally provide the `--clean` flag, this will also remove the index with the lower version number. Naturally, this should only be used if the new index version has the expected number of documents, fields, etc., and the old index version is fully dispensable.
+
+Note that removing an alias does not remove the index itself, but removing an index also removes any existing aliases for it.
 
 ## Indexing from multiple corpus definitions
 If you have separate datasets for different parts of a corpus, you may combine them by setting the `ES_INDEX` variable in the corpus definitions to the same `overarching-corpus` index name.

--- a/documentation/Overview.md
+++ b/documentation/Overview.md
@@ -2,6 +2,28 @@
 
 The application consists of a backend, implemented in [Django](https://www.djangoproject.com/) and a frontend implemented in [Angular](https://angular.io/).
 
+## Directory structure
+
+The I-analyzer backend (`/backend`) is a python/Django app that provides the following functionality:
+
+- A 'users' module that defines user accounts.
+
+- A 'corpora' module containing corpus definitions and metadata of the currently implemented corpora. For each corpus added in I-analyzer, this module defines how to extract document contents from its source files and sets parameters for displaying the corpus in the interface, such as sorting options.
+
+- An 'addcorpus' module which manages the functionality to extract data from corpus source files (given the definition) and save this in an elasticsearch index. Source files can be XML or HTML format (which are parsed with `beautifulsoup4` + `lxml`) or CSV. This module also provides the basic data structure for corpora.
+
+- An 'es' module which handles the communication with elasticsearch. The data is passed through to the index using the `elasticsearch` package for Python (note that `elasticsearch-dsl` is not used, since its [documentation](https://elasticsearch-dsl.readthedocs.io/en/latest) at the time seemed less immediately accessible than the [low-level](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html) version).
+
+- An 'api' module that that enables users to search through an ElasticSearch index of a text corpus and stream search results into a CSV file. The module also performs more complex analysis of search results for visualisations.
+
+- A 'visualizations' module that does the analysis for several types of text-based visualisations.
+
+- A 'downloads' module that collects results into csv files.
+
+- A 'wordmodels' module that handles functionality related to word embeddings.
+
+`ianalyzer/frontend` is an [Angular 13](https://angular.io/) web interface.
+
 # Backend
 
 The backend has three responsibilities:


### PR DESCRIPTION
Moves a lot of text from the README to documentation files, in particular:

- The description of indexing flags
- The description of index management in production
- The overview of backend modules

The description of the email server incorrectly suggested that this was mandatory, so that has been changed. I added a new file in the documentation that explains how to work with an smtp email backend.