### PR TITLE
Feature/dialogue buttons

### DIFF
--- a/frontend/src/app/dialog/dialog.component.html
+++ b/frontend/src/app/dialog/dialog.component.html
@@ -1,8 +1,8 @@
 <p-dialog [(visible)]="showDialog" *ngIf="showDialog" positionTop="50" width="800">
   <p-header>{{title}}</p-header>
-  <div class="content" [ngClass]="{'is-loading':isLoading}" [innerHTML]="innerHtml"></div>  
+  <div class="content" [ngClass]="{'is-loading':isLoading}" [innerHTML]="innerHtml"></div>
   <p-footer *ngIf="!isLoading && footerButtonLabel">
-      <a class="button" (click)="navigate()">
+      <a [routerLink]="footerRouterLink" autofocus tabindex="0">
           <span class="icon">
               <i class="fa fa-book"></i>
           </span>

--- a/frontend/src/app/dialog/dialog.component.ts
+++ b/frontend/src/app/dialog/dialog.component.ts
@@ -57,8 +57,4 @@ export class DialogComponent implements OnDestroy, OnInit {
     ngOnDestroy(): void {
         this.dialogEventSubscription.unsubscribe();
     }
-
-    navigate(): void {
-        this.router.navigate(this.footerRouterLink);
-    }
 }

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -86,13 +86,15 @@
             <div class="column">
                 <a *ngIf="viewDocument && viewDocument.position > 1"
                     iaBalloon="view previous document" iaBalloonPosition="right"
-                    (click)="prevDocument(viewDocument)" >
+                    (click)="prevDocument(viewDocument)" (keydown.enter)="prevDocument(viewDocument)"
+                    role="button" tabindex="0">
                     <span class="icon"><fa-icon [icon]="faArrowLeft">previous</fa-icon></span>
                 </a>
             </div>
             <div class="column" style="text-align:center">
                 <a [routerLink]="['/document', corpus.name, viewDocument.id]"
-                    iaBalloon="view this document on its own page">
+                    iaBalloon="view this document on its own page" autofocus
+                    tabindex="0">
                     <span class="icon">
                         <fa-icon [icon]="linkIcon"></fa-icon>
                     </span>
@@ -100,7 +102,8 @@
                 </a>
                 &nbsp;
                 <a *ngIf="hasContext(viewDocument)" [routerLink]="['/search', corpus.name]" [queryParams]="contextParams(viewDocument)"
-                iaBalloon="view all documents from this {{contextDisplayName}}">
+                    iaBalloon="view all documents from this {{contextDisplayName}}"
+                    tabindex="0">
                     <span class="icon">
                         <fa-icon [icon]="contextIcon"></fa-icon>
                     </span>
@@ -110,7 +113,8 @@
             <div class="column" style="text-align:right">
                 <a *ngIf="viewDocument && viewDocument.position < totalResults"
                     iaBalloon="view next document" iaBalloonPosition="left"
-                    (click)="nextDocument(viewDocument)">
+                    (click)="nextDocument(viewDocument)" (keydown.enter)="nextDocument(viewDocument)"
+                    role="button" tabindex="0">
                     <span class="icon"><fa-icon [icon]="faArrowRight">next</fa-icon></span>
                 </a>
             </div>


### PR DESCRIPTION
Accesssibility improvements for dialogue windows.

- Fixes an issue where links/buttons in the footer could not be accessed by keyboard (see #794)
- Anchor elements that link to the manual now work with an href attribute rather than a javascript callback, so users can see where the button is taking them.
- The link to the manual is now styled like a link instead of a button.