### PR TITLE
Automatically verify superuser email adress

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -46,10 +46,6 @@ def admin_user(django_user_model, admin_credentials):
         username=admin_credentials['username'],
         password=admin_credentials['password'],
         email=admin_credentials['email'])
-    EmailAddress.objects.create(user=user,
-                                email=user.email,
-                                verified=True,
-                                primary=True)
     return user
 
 

--- a/backend/users/signals.py
+++ b/backend/users/signals.py
@@ -1,6 +1,8 @@
+from allauth.account.models import EmailAddress
 from django.contrib.auth.models import Group
 from django.db.models.signals import post_save
 from django.dispatch import receiver
+
 from .models import CustomUser
 
 
@@ -10,3 +12,19 @@ def assign_basic_group(sender, instance, created, **kwargs):
     if created:
         basic_group, _ = Group.objects.get_or_create(name='basic')
         instance.groups.add(basic_group)
+
+
+@receiver(post_save, sender=CustomUser)
+def ensure_admin_email(sender, instance, created, **kwargs):
+    ''' Ensure emailaddress is automatically verified for superuser accounts'''
+    if created and instance.is_superuser:
+        try:
+            EmailAddress.objects.get_or_create(
+                user=instance,
+                email=instance.email,
+                verified=True,
+                primary=True
+            )
+            print(f'Automatically verified email {instance.email} for {instance}')
+        except Exception as e:
+            print('Failed to automatically verify admin email', e, sep='\n')


### PR DESCRIPTION
Resolves the super-minor inconvenience of having to manually create an `allauth.account.models.EmailAddress` after `django createsuperuser`.