### PR TITLE
fix range filter crashing page

### DIFF
--- a/frontend/src/app/filter/range-filter.component.html
+++ b/frontend/src/app/filter/range-filter.component.html
@@ -1,5 +1,5 @@
-<div class="range">
-    <span>{{data.min}} - {{data.max}}</span>
-    <p-slider [animate]="true" [ngModel]="getDisplayData(data)"
-        [range]="true" [min]="min" [max]="max" (onSlideEnd)="update(getFilterData($event))"></p-slider>
+<div class="range" *ngIf="data$ | async as data">
+    <span>{{data[0]}} - {{data[1]}}</span>
+    <p-slider [animate]="true" [ngModel]="data"
+        [range]="true" [min]="min" [max]="max" (onSlideEnd)="update(getFilterData($event.values))"></p-slider>
 </div>

--- a/frontend/src/app/filter/range-filter.component.html
+++ b/frontend/src/app/filter/range-filter.component.html
@@ -1,5 +1,5 @@
-<div class="range" *ngIf="data$ | async as data">
-    <span>{{data[0]}} - {{data[1]}}</span>
-    <p-slider [animate]="true" [ngModel]="data"
+<div class="range" *ngIf="filter?.data | async as data">
+    <span>{{data.min}} - {{data.max}}</span>
+    <p-slider [animate]="true" [ngModel]="[data.min, data.max]"
         [range]="true" [min]="min" [max]="max" (onSlideEnd)="update(getFilterData($event.values))"></p-slider>
 </div>

--- a/frontend/src/app/filter/range-filter.component.ts
+++ b/frontend/src/app/filter/range-filter.component.ts
@@ -2,6 +2,8 @@ import { Component } from '@angular/core';
 
 import { RangeFilterData, RangeFilter } from '../models';
 import { BaseFilterComponent } from './base-filter.component';
+import { map, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'ia-range-filter',
@@ -12,9 +14,16 @@ export class RangeFilterComponent extends BaseFilterComponent<RangeFilterData> {
     min: number;
     max: number;
 
+    data$: Observable<[number, number]>;
+
     onFilterSet(filter: RangeFilter): void {
         this.min = filter.defaultData.min;
         this.max = filter.defaultData.max;
+
+        this.data$ = this.filter?.data.asObservable().pipe(
+            tap(data => console.log(data)),
+            map(this.getDisplayData)
+        );
     }
 
     getDisplayData(filterData: RangeFilterData): [number, number] {

--- a/frontend/src/app/filter/range-filter.component.ts
+++ b/frontend/src/app/filter/range-filter.component.ts
@@ -2,8 +2,6 @@ import { Component } from '@angular/core';
 
 import { RangeFilterData, RangeFilter } from '../models';
 import { BaseFilterComponent } from './base-filter.component';
-import { map, tap } from 'rxjs/operators';
-import { Observable } from 'rxjs';
 
 @Component({
   selector: 'ia-range-filter',
@@ -14,20 +12,9 @@ export class RangeFilterComponent extends BaseFilterComponent<RangeFilterData> {
     min: number;
     max: number;
 
-    data$: Observable<[number, number]>;
-
     onFilterSet(filter: RangeFilter): void {
         this.min = filter.defaultData.min;
         this.max = filter.defaultData.max;
-
-        this.data$ = this.filter?.data.asObservable().pipe(
-            tap(data => console.log(data)),
-            map(this.getDisplayData)
-        );
-    }
-
-    getDisplayData(filterData: RangeFilterData): [number, number] {
-        return [filterData.min, filterData.max];
     }
 
     getFilterData(value: [number, number]): RangeFilterData {


### PR DESCRIPTION
Fixes an issue where loading a corpus with a range filter would completely freeze the page.