### PR TITLE
Feature/about page update

### DIFF
--- a/frontend/src/app/about/about.component.html
+++ b/frontend/src/app/about/about.component.html
@@ -1,10 +1,6 @@
 <section class="section">
     <div class="container is-readable">
-        <div class="columns">
-            <div class="column is-9">
-                <h1 class="title">About {{appName}}</h1>
-                <div class="content" [ngClass]="{'is-loading':isLoading}" [innerHTML]="aboutHtml"></div>
-            </div>
-        </div>
+        <h1 class="title">About {{appName}}</h1>
+        <div class="content" [ngClass]="{'is-loading':isLoading}" [innerHTML]="aboutHtml"></div>
     </div>
 </section>

--- a/frontend/src/app/footer/footer.component.html
+++ b/frontend/src/app/footer/footer.component.html
@@ -22,5 +22,8 @@
             </div>
         </div>
         </div>
+        <div class="block">
+            <a href="https://github.com/UUDigitalHumanitieslab/I-analyzer">Source code</a> (MIT license)
+        </div>
     </div>
 </footer>

--- a/frontend/src/assets/about/en-GB/ianalyzer.md
+++ b/frontend/src/assets/about/en-GB/ianalyzer.md
@@ -12,7 +12,7 @@ In its source code, I-analyzer separates the interface from the data structure o
 
 This way, whenever researchers have data that they want to add, we don't need to describe what it means to filter or how the visualisations should work; we just need to define what the data looks like.
 
-As I-analyzer is designed to be flexible, we have worked with different research projects over time to add corpora and develop the application. You can find more information about some of these projects in our [portfolio](https://cdh.uu.nl/portfolio/?_theme=i-analyzer).
+As I-analyzer is designed to be flexible, we have worked with different research projects over time to add corpora and develop the application. You can find more information about some of these projects in our [portfolio](https://cdh.uu.nl/portfolio/).
 
 The source code of I-analyzer is not publicly available at the moment, but we intend to make the application open-source in 2023.
 

--- a/frontend/src/assets/about/en-GB/ianalyzer.md
+++ b/frontend/src/assets/about/en-GB/ianalyzer.md
@@ -14,7 +14,7 @@ This way, whenever researchers have data that they want to add, we don't need to
 
 As I-analyzer is designed to be flexible, we have worked with different research projects over time to add corpora and develop the application. You can find more information about some of these projects in our [portfolio](https://cdh.uu.nl/portfolio/).
 
-The source code of I-analyzer is not publicly available at the moment, but we intend to make the application open-source in 2023.
+The [source code of I-analyzer](https://github.com/UUDigitalHumanitieslab/I-analyzer) is shared under an MIT license.
 
 ## Research using I-analyzer
 
@@ -43,4 +43,6 @@ Do you think that some of these may apply to you? We are still interested in hea
 
 ## Contact
 
-For questions, suggestions, or adding new data: contact us via [cdh@uu.nl](mailto:cdh@uu.nl)
+For questions, suggestions, or adding new data: contact us via [cdh@uu.nl](mailto:cdh@uu.nl).
+
+For small suggestions, feedback, or bug reports, you can also make an issue on the [I-analyzer github repository](https://github.com/UUDigitalHumanitieslab/I-analyzer/issues).

--- a/frontend/src/assets/manual/en-GB/citation.md
+++ b/frontend/src/assets/manual/en-GB/citation.md
@@ -8,17 +8,19 @@ If you downloaded a document in I-analyzer, or read it online in the I-analyzer 
 
 For example, a citation might look something like the following:
 
-> Doe, J. (1900, Jan 1). A very interesting article. *The Times.* http://ianalyzer.hum.uu.nl/document/fascinating-corpus/12345678
+> Doe, J. (1900). A very interesting article. *Fascinating Periodical*, *10*(2), 10-13. http://ianalyzer.hum.uu.nl/document/fascinating-corpus/12345678
 
 The specifics will depend on the citation style you are using and the type of data in the corpus.
 
 Documents in I-analyzer have a unique link, which looks like the one in the example above. This is the most appropriate way to reference a specific document.
 
+Note that not all data on I-analyzer is public. For instance, some corpora are only available with an institutional login. This means that your readers may not be able to follow the link to I-analyzer.
+
 ### Citing collection of documents
 
 For distant reading research, you may want to cite a large collection of documents, rather than a few specific ones. In this case, it is usually most appropriate to cite the corpus as a whole. This may look something like the following:
 
-> Research Software Lab, Centre for Digital Humanities, Utrecht University (2023). *The Times* [data set]. http://ianalyzer.hum.uu.nl/search/times
+> Research Software Lab, Centre for Digital Humanities, Utrecht University (2023). *Troonredes* [data set]. http://ianalyzer.hum.uu.nl/search/troonredes
 
 Be aware that some corpora may have other contributors. We are working on providing more specific guidelines per corpus. Feel free to contact us if you want to make sure you are referencing a corpus correctly.
 

--- a/frontend/src/assets/manual/en-GB/citation.md
+++ b/frontend/src/assets/manual/en-GB/citation.md
@@ -1,0 +1,36 @@
+## Citing documents from I-analyzer
+
+If you want to cite a document that you accessed through I-analyzer, be sure to read the documentation of the corpus. This may include more specific information about the data and how to cite it. This page gives some general advice on citing documents from I-analyzer in your research.
+
+### Citing a document from the I-analyzer interface
+
+If you downloaded a document in I-analyzer, or read it online in the I-analyzer interface, your citation should make it clear that you retrieved it through here. This provides accountability: loading corpora into I-analyzer is a process that may introduce mistakes, so you should always cite the resource that you actually referenced.
+
+For example, a citation might look something like the following:
+
+> Doe, J. (1900, Jan 1). A very interesting article. *The Times.* http://ianalyzer.hum.uu.nl/document/fascinating-corpus/12345678
+
+The specifics will depend on the citation style you are using and the type of data in the corpus.
+
+Documents in I-analyzer have a unique link, which looks like the one in the example above. This is the most appropriate way to reference a specific document.
+
+### Citing collection of documents
+
+For distant reading research, you may want to cite a large collection of documents, rather than a few specific ones. In this case, it is usually most appropriate to cite the corpus as a whole. This may look something like the following:
+
+> Research Software Lab, Centre for Digital Humanities, Utrecht University (2023). *The Times* [data set]. http://ianalyzer.hum.uu.nl/search/times
+
+Be aware that some corpora may have other contributors. We are working on providing more specific guidelines per corpus. Feel free to contact us if you want to make sure you are referencing a corpus correctly.
+
+### Citing a document available elsewhere
+
+In some cases, you may have used I-analyzer to find relevant documents, and then accessed them through an external interface or archive. If so, it may be appropriate to cite that source as your reference. If you are unsure, you may consider:
+
+- Which resource did you use as your source of truth?
+- Does your citation allow readers to reference your sources? (Is is public? Will it still be available in the future?)
+
+However, even if you cite an external source, a proper account of your research methodology should include how you selected your source material. See below how you can cite I-analyzer as a part of your methodology.
+
+## Citing I-analyzer itself
+
+To cite I-analyzer as a piece of software, consult our [zenodo page](https://zenodo.org/record/8091461). This page details how you can cite I-analyzer; it includes templates for various citation styles, and the option to export a template as a bibtex file, among others.

--- a/frontend/src/assets/manual/en-GB/manifest.json
+++ b/frontend/src/assets/manual/en-GB/manifest.json
@@ -33,5 +33,9 @@
     {
         "id": "download",
         "title": "Downloading data"
+    },
+    {
+        "id": "citation",
+        "title": "Citing I-analyzer"
     }
 ]


### PR DESCRIPTION
Some updates to reflect I-analyzer being public.

- Added a link to the source code in the footer
- Added some references to our github in the about page
- Added a page in the manual about citation that links to our zenodo page. Because I figured most users would be more interested in citing documents than citing I-analyzer itself, this also adds some very basic advice for citing content.
- The text of the about page now has the same size margin on either side.