### PR TITLE
use is_staff for frontend serialisation

### DIFF
--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -5,7 +5,7 @@ from django.db import transaction
 
 
 class CustomUserDetailsSerializer(UserDetailsSerializer):
-    is_admin = serializers.BooleanField(source='is_superuser')
+    is_admin = serializers.BooleanField(source='is_staff')
 
     class Meta(UserDetailsSerializer.Meta):
         fields = ('id', 'username', 'email', 'saml',


### PR DESCRIPTION
Changes the property used for `is_admin` in the user seraliser from `is_superuser` to `is_staff`

The function of `is_admin` in the user serializer determines whether the user sees a link to the admin menu in the frontend. Access to the admin menu is determined by staff status rather than superuser status, so this prevents an issue where a non-superuser staff member would not see the link to the admin menu.