### PR TITLE
Feature/peace portal adjustments

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,7 +1,7 @@
 <ia-notifications></ia-notifications>
-<ia-menu></ia-menu>
+<ia-menu *ngIf="!iframe"></ia-menu>
 <main>
     <router-outlet></router-outlet>
     <ia-dialog></ia-dialog>
 </main>
-<ia-footer></ia-footer>
+<ia-footer *ngIf="!iframe"></ia-footer>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,14 +1,19 @@
 import { Component } from '@angular/core';
 import { AuthService } from './services/auth.service';
 
+import { environment } from '../environments/environment';
+
 @Component({
     selector: 'app-root',
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.scss'],
 })
 export class AppComponent {
+    public iframe: boolean
+
     constructor(private authService: AuthService) {
         this.authService.setInitialAuth();
+        this.iframe = environment.runInIFrame;
     }
 }
 

--- a/frontend/src/app/search/search-results.component.ts
+++ b/frontend/src/app/search/search-results.component.ts
@@ -16,12 +16,12 @@ const MAXIMUM_DISPLAYED = 10000;
     styleUrls: ['./search-results.component.scss']
 })
 export class SearchResultsComponent implements OnChanges {
-    /**
-     * The search queryModel to use
-     */
     @ViewChild('resultsNavigation', {static: true})
     public resultsNavigation: ElementRef;
 
+    /**
+     * The search queryModel to use
+     */
     @Input()
     public queryModel: QueryModel;
 

--- a/frontend/src/app/search/search.component.ts
+++ b/frontend/src/app/search/search.component.ts
@@ -1,12 +1,12 @@
 import { Subscription } from 'rxjs';
+import * as _ from 'lodash';
 import { Component, ElementRef, ViewChild, HostListener } from '@angular/core';
 import { ActivatedRoute, Router, ParamMap } from '@angular/router';
 
-import { Corpus, CorpusField, ResultOverview, QueryModel, User } from '../models/index';
+import { Corpus, CorpusField, QueryModel, ResultOverview, User } from '../models/index';
 import { CorpusService, DialogService, } from '../services/index';
 import { ParamDirective } from '../param/param-directive';
 import { AuthService } from '../services/auth.service';
-import * as _ from 'lodash';
 import { paramsHaveChanged } from '../utils/params';
 
 @Component({
@@ -21,6 +21,12 @@ export class SearchComponent extends ParamDirective {
     public isScrolledDown: boolean;
 
     public corpus: Corpus;
+
+    /**
+     * This is a constant used to ensure that, when we are displayed in an iframe,
+     * the filters are displayed even if there are no results.
+     */
+    private minIframeHeight = 1300;
 
     /**
      * The filters have been modified.
@@ -65,6 +71,11 @@ export class SearchComponent extends ParamDirective {
             .filter((corpus) => !!corpus).subscribe((corpus) => {
             this.setCorpus(corpus);
         });
+
+        if (window.parent) {
+            // iframe support
+            window.parent.postMessage(["setHeight", this.minIframeHeight], "*");
+        }
     }
 
     teardown() {
@@ -86,6 +97,7 @@ export class SearchComponent extends ParamDirective {
         this.isScrolledDown =
             this.searchSection.nativeElement.getBoundingClientRect().y === 0;
     }
+
 
     /**
      * Event triggered from search-results.component

--- a/frontend/src/environments/environment.git.ts
+++ b/frontend/src/environments/environment.git.ts
@@ -6,5 +6,6 @@ export const environment = {
     adminUrl: '/admin',
     samlLogoutUrl: '/users/saml2/logout/',
     logos: [],
-    showSolis: true
+    showSolis: true,
+    runInIFrame: false
 };

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -12,5 +12,6 @@ export const environment = {
     samlLogoutUrl: '/users/saml2/logout/',
     logos: [
     ],
-    showSolis: true
+    showSolis: true,
+    runInIFrame: false
 };


### PR DESCRIPTION
This branch *should* add iframe support needed for PeacePortal (tbc):
- it leaves out the header and footer
- it posts a `setHeight` message to the parent (in the case of Peace Portal, this is handled by JavaScript on the embedding WordPress site) to assure that the iframe has a (hard-coded) height

In [Peace Portal's search-results-component](https://github.com/UUDigitalHumanitieslab/peace-portal/blob/peaceportal/release/2.5.0/frontend/src/app/search/search-results.component.ts), there is also a `resultsRendered` Output that (according to comments) has been added for iframe support, but as I could find no other component listening to these events, I assume this is an approach that has been abandoned in favour of the `setHeight` message to the parent