### PR TITLE
hide word_model_path from API

### DIFF
--- a/backend/addcorpus/corpus.py
+++ b/backend/addcorpus/corpus.py
@@ -238,7 +238,7 @@ class Corpus(object):
         # - hidden attributes
         # - attributes listed in `exclude`
         # - bound methods
-        exclude = ['data_directory', 'es_settings']
+        exclude = ['data_directory', 'es_settings', 'word_model_path']
         corpus_attribute_names = [
             a for a in dir(self)
             if a in dir(Corpus) and not a.startswith('_') and a not in exclude and not inspect.ismethod(self.__getattribute__(a))

--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -33,3 +33,7 @@ def test_corpus_serialization(admin_client, mock_corpus):
     assert corpus['languages'] == ['English']
     assert corpus['category'] == 'Books'
     assert len(corpus['fields']) == 2
+
+    secrets = ['data_directory', 'word_model_path', 'es_settings']
+    for property in secrets:
+        assert property not in corpus


### PR DESCRIPTION
Fixes an issue that appeared after #1212, namely that the word model path of corpora was exposed in the API.