### PR TITLE
rename Corpus -> CorpusDefinition

### DIFF
--- a/backend/addcorpus/corpus.py
+++ b/backend/addcorpus/corpus.py
@@ -18,7 +18,7 @@ logger = logging.getLogger('indexing')
 from addcorpus.constants import CATEGORIES
 
 
-class Corpus(object):
+class CorpusDefinition(object):
     '''
     Subclasses of this class define corpora and their documents by specifying:
 
@@ -241,7 +241,7 @@ class Corpus(object):
         exclude = ['data_directory', 'es_settings', 'word_model_path']
         corpus_attribute_names = [
             a for a in dir(self)
-            if a in dir(Corpus) and not a.startswith('_') and a not in exclude and not inspect.ismethod(self.__getattribute__(a))
+            if a in dir(CorpusDefinition) and not a.startswith('_') and a not in exclude and not inspect.ismethod(self.__getattribute__(a))
         ]
 
         # collect values
@@ -325,7 +325,7 @@ class Corpus(object):
                 raise RuntimeError(
                     "Specified extractor method cannot be used with this type of data")
 
-class XMLCorpus(Corpus):
+class XMLCorpusDefinition(CorpusDefinition):
     '''
     An XMLCorpus is any corpus that extracts its data from XML sources.
     '''
@@ -557,7 +557,7 @@ class XMLCorpus(Corpus):
         return out_dict
 
 
-class HTMLCorpus(XMLCorpus):
+class HTMLCorpusDefinition(XMLCorpusDefinition):
     '''
     An HTMLCorpus is any corpus that extracts its data from HTML sources.
     '''
@@ -613,7 +613,7 @@ class HTMLCorpus(XMLCorpus):
             }
 
 
-class CSVCorpus(Corpus):
+class CSVCorpusDefinition(CorpusDefinition):
     '''
     An CSVCorpus is any corpus that extracts its data from CSV sources.
     '''

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -1,14 +1,14 @@
 from rest_framework import serializers
 from django.conf import settings
 from typing import Tuple
-from addcorpus.corpus import Corpus
+from addcorpus.corpus import CorpusDefinition
 from addcorpus.models import MAX_LENGTH_NAME, MAX_LENGTH_DESCRIPTION
 
 class CorpusSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=MAX_LENGTH_NAME)
     description = serializers.CharField(max_length=MAX_LENGTH_DESCRIPTION)
 
-    def to_representation(self, instance: Tuple[str, Corpus]):
+    def to_representation(self, instance: Tuple[str, CorpusDefinition]):
         name, definition = instance
         return {
             'name': name,

--- a/backend/addcorpus/tests/mock_csv_corpus.py
+++ b/backend/addcorpus/tests/mock_csv_corpus.py
@@ -1,11 +1,11 @@
-from addcorpus.corpus import CSVCorpus, Field
+from addcorpus.corpus import CSVCorpusDefinition, Field
 from addcorpus.extract import CSV
 import os
 import datetime
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-class MockCSVCorpus(CSVCorpus):
+class MockCSVCorpus(CSVCorpusDefinition):
     """Example CSV corpus class for testing"""
 
     title = "Example"

--- a/backend/addcorpus/tests/test_word_models_present.py
+++ b/backend/addcorpus/tests/test_word_models_present.py
@@ -1,11 +1,11 @@
 import datetime
 import os
 
-from addcorpus.corpus import Corpus
+from addcorpus.corpus import CorpusDefinition
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-class ExampleCorpus(Corpus):
+class ExampleCorpus(CorpusDefinition):
     """Example corpus class for testing"""
 
     title = "Example"

--- a/backend/corpora/dbnl/dbnl.py
+++ b/backend/corpora/dbnl/dbnl.py
@@ -4,14 +4,14 @@ import re
 from tqdm import tqdm
 
 from django.conf import settings
-from addcorpus.corpus import XMLCorpus, Field
+from addcorpus.corpus import XMLCorpusDefinition, Field
 from addcorpus.extract import Metadata, XML, Pass, Order, Backup, Combined
 import corpora.dbnl.utils as utils
 from addcorpus.es_mappings import *
 from addcorpus.filters import RangeFilter, MultipleChoiceFilter, BooleanFilter
 from corpora.dbnl.dbnl_metadata import DBNLMetadata
 
-class DBNL(XMLCorpus):
+class DBNL(XMLCorpusDefinition):
     title = 'DBNL'
     description = 'Digital Library for Dutch Literature'
     data_directory = settings.DBNL_DATA

--- a/backend/corpora/dbnl/dbnl_metadata.py
+++ b/backend/corpora/dbnl/dbnl_metadata.py
@@ -1,10 +1,10 @@
 import os
 from django.conf import settings
-from addcorpus.corpus import CSVCorpus, Field
+from addcorpus.corpus import CSVCorpusDefinition, Field
 from addcorpus.extract import CSV, Combined, Pass
 import corpora.dbnl.utils as utils
 
-class DBNLMetadata(CSVCorpus):
+class DBNLMetadata(CSVCorpusDefinition):
     '''Helper corpus for extracting the DBNL metadata.
 
     Used by the DBNL corpus for CSV extraction utilities -

--- a/backend/corpora/dutchannualreports/dutchannualreports.py
+++ b/backend/corpora/dutchannualreports/dutchannualreports.py
@@ -9,7 +9,7 @@ from django.conf import settings
 
 from addcorpus.extract import XML, Metadata, Combined
 from addcorpus.filters import MultipleChoiceFilter, RangeFilter
-from addcorpus.corpus import XMLCorpus, Field
+from addcorpus.corpus import XMLCorpusDefinition, Field
 from media.image_processing import get_pdf_info, retrieve_pdf, pdf_pages, build_partial_pdf
 from addcorpus.load_corpus import corpus_dir
 
@@ -17,7 +17,7 @@ from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 
 from media.media_url import media_url
 
-class DutchAnnualReports(XMLCorpus):
+class DutchAnnualReports(XMLCorpusDefinition):
     """ Alto XML corpus of Dutch annual reports. """
 
     # Data overrides from .common.Corpus (fields at bottom of class)

--- a/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
+++ b/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
@@ -10,7 +10,7 @@ import os
 
 from django.conf import settings
 
-from addcorpus.corpus import XMLCorpus, Field, consolidate_start_end_years
+from addcorpus.corpus import XMLCorpusDefinition, Field, consolidate_start_end_years
 from addcorpus import filters
 from addcorpus.extract import Metadata, XML
 from addcorpus.load_corpus import corpus_dir
@@ -20,7 +20,7 @@ from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 from addcorpus.es_settings import es_settings
 
 
-class DutchNewspapersPublic(XMLCorpus):
+class DutchNewspapersPublic(XMLCorpusDefinition):
     '''
     The public portion of KB newspapers
 

--- a/backend/corpora/ecco/ecco.py
+++ b/backend/corpora/ecco/ecco.py
@@ -13,7 +13,7 @@ from django.conf import settings
 
 from addcorpus.extract import Combined, Metadata, XML
 from addcorpus import filters
-from addcorpus.corpus import XMLCorpus, Field
+from addcorpus.corpus import XMLCorpusDefinition, Field
 from addcorpus.es_settings import es_settings
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 from corpora.utils.constants import document_context
@@ -23,7 +23,7 @@ from media.media_url import media_url
 # Source files ################################################################
 
 
-class Ecco(XMLCorpus):
+class Ecco(XMLCorpusDefinition):
     title = "Eighteenth Century Collections Online"
     description = "Digital collection of books published in Great Britain during the 18th century."
     min_date = datetime(year=1700, month=1, day=1)

--- a/backend/corpora/goodreads/goodreads.py
+++ b/backend/corpora/goodreads/goodreads.py
@@ -10,14 +10,14 @@ import openpyxl
 
 from addcorpus.extract import CSV, Metadata
 from addcorpus.filters import MultipleChoiceFilter, RangeFilter
-from addcorpus.corpus import CSVCorpus, Field
+from addcorpus.corpus import CSVCorpusDefinition, Field
 
 from addcorpus.es_mappings import main_content_mapping
 from addcorpus.es_settings import es_settings
 
 logger = logging.getLogger('indexing')
 
-class GoodReads(CSVCorpus):
+class GoodReads(CSVCorpusDefinition):
     """ Home-scraped CSV corpus of GoodReads reviews. """
 
     # Data overrides from .common.Corpus (fields at bottom of class)

--- a/backend/corpora/guardianobserver/guardianobserver.py
+++ b/backend/corpora/guardianobserver/guardianobserver.py
@@ -19,7 +19,7 @@ from django.conf import settings
 from es.es_update import update_document
 from addcorpus import extract
 from addcorpus import filters
-from addcorpus.corpus import XMLCorpus, Field, until, after, string_contains, consolidate_start_end_years
+from addcorpus.corpus import XMLCorpusDefinition, Field, until, after, string_contains, consolidate_start_end_years
 from media.image_processing import sizeof_fmt
 from media.media_url import media_url
 
@@ -31,7 +31,7 @@ PROCESSED = "corpora/guardianobserver/processed.txt"
 # Source files ################################################################
 
 
-class GuardianObserver(XMLCorpus):
+class GuardianObserver(XMLCorpusDefinition):
     title = "Guardian-Observer"
     description = "Newspaper archive, 1791-2003"
     min_date = datetime(year=1791, month=1, day=1)

--- a/backend/corpora/jewishinscriptions/jewishinscriptions.py
+++ b/backend/corpora/jewishinscriptions/jewishinscriptions.py
@@ -8,11 +8,11 @@ from django.conf import settings
 
 from addcorpus.extract import XML, Metadata, Combined
 from addcorpus.filters import MultipleChoiceFilter, RangeFilter #SliderRangeFilter, BoxRangeFilter
-from addcorpus.corpus import XMLCorpus, Field
+from addcorpus.corpus import XMLCorpusDefinition, Field
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 
 
-class JewishInscriptions(XMLCorpus):
+class JewishInscriptions(XMLCorpusDefinition):
     """ Alto XML corpus of Jewish funerary inscriptions. """
 
     # Data overrides from .common.Corpus (fields at bottom of class)

--- a/backend/corpora/parliament/canada.py
+++ b/backend/corpora/parliament/canada.py
@@ -8,11 +8,11 @@ from django.conf import settings
 from corpora.parliament.parliament import Parliament
 from corpora.utils.constants import document_context
 from addcorpus.extract import Constant,CSV
-from addcorpus.corpus import CSVCorpus
+from addcorpus.corpus import CSVCorpusDefinition
 import corpora.parliament.utils.field_defaults as field_defaults
 from corpora.parliament.uk import format_house
 
-class ParliamentCanada(Parliament, CSVCorpus):
+class ParliamentCanada(Parliament, CSVCorpusDefinition):
     title = 'People & Parliament (Canada)'
     description = "Speeches from House of Commons"
     min_date = datetime(year=1901, month=1, day=1)

--- a/backend/corpora/parliament/denmark-new.py
+++ b/backend/corpora/parliament/denmark-new.py
@@ -6,7 +6,7 @@ import re
 
 from corpora.parliament.parliament import Parliament
 from addcorpus.extract import Constant, CSV, Metadata, Combined
-from addcorpus.corpus import CSVCorpus
+from addcorpus.corpus import CSVCorpusDefinition
 import corpora.parliament.utils.field_defaults as field_defaults
 import corpora.utils.formatting as formatting
 import corpora.utils.constants as constants
@@ -32,7 +32,7 @@ def get_timestamp_from_id(id):
     return match.group(1) if match else None
 
 
-class ParliamentDenmarkNew(Parliament, CSVCorpus):
+class ParliamentDenmarkNew(Parliament, CSVCorpusDefinition):
     title = 'People & Parliament (Denmark, 2009-2017)'
     description = "Speeches from the Folketing"
     min_date = datetime(year=2009, month=1, day=1)

--- a/backend/corpora/parliament/denmark.py
+++ b/backend/corpora/parliament/denmark.py
@@ -5,7 +5,7 @@ from django.conf import settings
 
 from corpora.parliament.parliament import Parliament
 from addcorpus.extract import Constant, CSV
-from addcorpus.corpus import CSVCorpus
+from addcorpus.corpus import CSVCorpusDefinition
 import corpora.parliament.utils.field_defaults as field_defaults
 import corpora.utils.formatting as formatting
 
@@ -31,7 +31,7 @@ def format_chamber(chamber):
 
     return chambers.get(chamber, chamber)
 
-class ParliamentDenmark(Parliament, CSVCorpus):
+class ParliamentDenmark(Parliament, CSVCorpusDefinition):
     title = 'People & Parliament (Denmark, 1848-2008)'
     description = "Speeches from the Folketing and Landsting"
     min_date = datetime(year=1848, month=1, day=1)

--- a/backend/corpora/parliament/finland.py
+++ b/backend/corpora/parliament/finland.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from glob import glob
 
-from addcorpus.corpus import XMLCorpus
+from addcorpus.corpus import XMLCorpusDefinition
 from addcorpus.extract import XML, Combined, Constant, Metadata
 from corpora.parliament.parliament import Parliament
 import corpora.utils.formatting as formatting
@@ -38,7 +38,7 @@ def find_date(speech_node):
     return debate_node.teiHeader.find('date')
 
 
-class ParliamentFinland(Parliament, XMLCorpus):
+class ParliamentFinland(Parliament, XMLCorpusDefinition):
     title = 'People and Parliament (Finland)'
     description = 'Speeches from the eduskunta'
     min_date = datetime(year=1907, month=1, day=1)

--- a/backend/corpora/parliament/france.py
+++ b/backend/corpora/parliament/france.py
@@ -6,12 +6,12 @@ from django.conf import settings
 
 from corpora.parliament.parliament import Parliament
 from addcorpus.extract import Constant, Combined, CSV
-from addcorpus.corpus import CSVCorpus
+from addcorpus.corpus import CSVCorpusDefinition
 import corpora.parliament.utils.field_defaults as field_defaults
 from corpora.utils.formatting import underscore_to_space
 from corpora.utils.constants import document_context
 
-class ParliamentFrance(Parliament, CSVCorpus):
+class ParliamentFrance(Parliament, CSVCorpusDefinition):
     title = "People & Parliament (France 1881-2022)"
     description = "Speeches from the 3rd, 4th and 5th republic of France"
     min_date = datetime(year=1881, month=1, day=1)

--- a/backend/corpora/parliament/germany-new.py
+++ b/backend/corpora/parliament/germany-new.py
@@ -6,12 +6,12 @@ from django.conf import settings
 
 from corpora.parliament.parliament import Parliament
 from addcorpus.extract import Constant, Combined, CSV
-from addcorpus.corpus import CSVCorpus
+from addcorpus.corpus import CSVCorpusDefinition
 import corpora.utils.formatting as formatting
 import corpora.parliament.utils.field_defaults as field_defaults
 
 
-class ParliamentGermanyNew(Parliament, CSVCorpus):
+class ParliamentGermanyNew(Parliament, CSVCorpusDefinition):
     title = 'People & Parliament (Germany 1949-2021)'
     description = "Speeches from the Bundestag"
     min_date = datetime(year=1949, month=1, day=1)

--- a/backend/corpora/parliament/germany-old.py
+++ b/backend/corpora/parliament/germany-old.py
@@ -5,14 +5,14 @@ from django.conf import settings
 
 from corpora.parliament.parliament import Parliament
 from addcorpus.extract import Constant, CSV
-from addcorpus.corpus import CSVCorpus
+from addcorpus.corpus import CSVCorpusDefinition
 import corpora.parliament.utils.field_defaults as field_defaults
 
 
 def standardize_bool(date_is_estimate):
     return date_is_estimate.lower()
 
-class ParliamentGermanyOld(Parliament, CSVCorpus):
+class ParliamentGermanyOld(Parliament, CSVCorpusDefinition):
     title = 'People & Parliament (Germany Reichstag - 1867-1942)'
     description = "Speeches from the Reichstag"
     min_date = datetime(year=1867, month=1, day=1)

--- a/backend/corpora/parliament/ireland.py
+++ b/backend/corpora/parliament/ireland.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 import json
 import csv
 
-from addcorpus.corpus import Corpus, CSVCorpus, XMLCorpus
+from addcorpus.corpus import CorpusDefinition, CSVCorpusDefinition, XMLCorpusDefinition
 from addcorpus.extract import Constant, CSV, XML, Metadata, Combined, Backup
 from corpora.parliament.parliament import Parliament
 import corpora.parliament.utils.field_defaults as field_defaults
@@ -65,7 +65,7 @@ def find_ministerial_role(data):
     if len(positions):
         return ', '.join(position['role'] for position in positions)
 
-class ParliamentIrelandOld(CSVCorpus):
+class ParliamentIrelandOld(CSVCorpusDefinition):
     '''
     Class for extracting 1919-2013 Irish debates.
 
@@ -308,7 +308,7 @@ def role_extractor(role_type):
     )
 
 
-class ParliamentIrelandNew(XMLCorpus):
+class ParliamentIrelandNew(XMLCorpusDefinition):
     '''
     Class for extracting 2014-2020 Irish debates.
 
@@ -436,7 +436,7 @@ class ParliamentIrelandNew(XMLCorpus):
     ]
 
 
-class ParliamentIreland(Parliament, Corpus):
+class ParliamentIreland(Parliament, CorpusDefinition):
     '''
     Class for 1919-2020 Irish debates.
     '''

--- a/backend/corpora/parliament/netherlands.py
+++ b/backend/corpora/parliament/netherlands.py
@@ -6,7 +6,7 @@ from os.path import join
 from django.conf import settings
 
 import bs4
-from addcorpus.corpus import XMLCorpus
+from addcorpus.corpus import XMLCorpusDefinition
 from addcorpus.extract import XML, Constant, Combined, Choice
 from corpora.parliament.utils.parlamint import extract_all_party_data, extract_people_data, extract_role_data, party_attribute_extractor, person_attribute_extractor
 from corpora.utils.formatting import format_page_numbers
@@ -116,7 +116,7 @@ def get_sequence_recent(id):
         return int(match.group(1))
 
 
-class ParliamentNetherlands(Parliament, XMLCorpus):
+class ParliamentNetherlands(Parliament, XMLCorpusDefinition):
     '''
     Class for indexing Dutch parliamentary data
     '''

--- a/backend/corpora/parliament/norway-new.py
+++ b/backend/corpora/parliament/norway-new.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from django.conf import settings
 
 from addcorpus.extract import Combined, Constant, CSV
-from addcorpus.corpus import CSVCorpus
+from addcorpus.corpus import CSVCorpusDefinition
 from corpora.parliament.parliament import Parliament
 import corpora.parliament.utils.field_defaults as field_defaults
 import corpora.utils.formatting as formatting
@@ -41,7 +41,7 @@ def format_language(language):
 
 EMPTY_VALUES = ['', 'NA']
 
-class ParliamentNorwayNew(Parliament, CSVCorpus):
+class ParliamentNorwayNew(Parliament, CSVCorpusDefinition):
     '''
     Class for indexing Norwegian parliamentary data
     '''

--- a/backend/corpora/parliament/norway.py
+++ b/backend/corpora/parliament/norway.py
@@ -5,7 +5,7 @@ from django.conf import settings
 import os
 
 from addcorpus.extract import Combined, Constant, CSV
-from addcorpus.corpus import CSVCorpus
+from addcorpus.corpus import CSVCorpusDefinition
 from corpora.utils.constants import document_context
 from corpora.parliament.parliament import Parliament
 import corpora.parliament.utils.field_defaults as field_defaults
@@ -15,7 +15,7 @@ def remove_file_extension(filename):
     name, ext = os.path.splitext(filename)
     return name
 
-class ParliamentNorway(Parliament, CSVCorpus):
+class ParliamentNorway(Parliament, CSVCorpusDefinition):
     '''
     Class for indexing Norwegian parliamentary data
     '''

--- a/backend/corpora/parliament/parliament.py
+++ b/backend/corpora/parliament/parliament.py
@@ -4,13 +4,13 @@ import os.path as op
 
 from django.conf import settings
 
-from addcorpus.corpus import Corpus
+from addcorpus.corpus import CorpusDefinition
 from addcorpus.filters import MultipleChoiceFilter
 import corpora.parliament.utils.field_defaults as field_defaults
 from corpora.parliament.utils.constants import MIN_DATE, MAX_DATE
 from addcorpus.es_settings import es_settings
 
-class Parliament(Corpus):
+class Parliament(CorpusDefinition):
     '''
     Base class for speeches in the People & Parliament project.
 

--- a/backend/corpora/parliament/sweden-old.py
+++ b/backend/corpora/parliament/sweden-old.py
@@ -1,7 +1,7 @@
 from glob import glob
 from datetime import datetime
 
-from addcorpus.corpus import CSVCorpus
+from addcorpus.corpus import CSVCorpusDefinition
 from addcorpus.extract import CSV, Constant
 from corpora.parliament.parliament import Parliament
 import corpora.parliament.utils.field_defaults as field_defaults
@@ -30,7 +30,7 @@ def format_chamber(chamber):
 
     return chambers.get(chamber, chamber)
 
-class ParliamentSwedenOld(Parliament, CSVCorpus):
+class ParliamentSwedenOld(Parliament, CSVCorpusDefinition):
     title = 'People and Parliament (Sweden 1809-1919)'
     description = 'Speeches from the Riksdag'
     min_date = datetime(year=1809, month=1, day=1)

--- a/backend/corpora/parliament/sweden.py
+++ b/backend/corpora/parliament/sweden.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from glob import glob
 
-from addcorpus.corpus import CSVCorpus
+from addcorpus.corpus import CSVCorpusDefinition
 from addcorpus.extract import CSV, Constant
 from corpora.parliament.parliament import Parliament
 import corpora.utils.formatting as formatting
@@ -40,7 +40,7 @@ def format_chamber(chamber):
 
     return chamber
 
-class ParliamentSweden(Parliament, CSVCorpus):
+class ParliamentSweden(Parliament, CSVCorpusDefinition):
     title = 'People and Parliament (Sweden 1920-2022)'
     description = 'Speeches from the Riksdag'
     min_date = datetime(year=1920, month=1, day=1)

--- a/backend/corpora/parliament/uk.py
+++ b/backend/corpora/parliament/uk.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from django.conf import settings
 
 from addcorpus.extract import Constant, CSV
-from addcorpus.corpus import CSVCorpus
+from addcorpus.corpus import CSVCorpusDefinition
 from corpora.parliament.parliament import Parliament
 import corpora.parliament.utils.field_defaults as field_defaults
 from corpora.utils.constants import document_context
@@ -31,7 +31,7 @@ def format_speaker(speaker):
 
         return speaker.title()
 
-class ParliamentUK(Parliament, CSVCorpus):
+class ParliamentUK(Parliament, CSVCorpusDefinition):
     title = 'People & Parliament (UK)'
     description = "Speeches from the House of Lords and House of Commons"
     data_directory = settings.PP_UK_DATA

--- a/backend/corpora/periodicals/periodicals.py
+++ b/backend/corpora/periodicals/periodicals.py
@@ -14,7 +14,7 @@ from django.conf import settings
 
 from addcorpus import extract
 from addcorpus import filters
-from addcorpus.corpus import XMLCorpus, Field
+from addcorpus.corpus import XMLCorpusDefinition, Field
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 from addcorpus.es_settings import es_settings
 
@@ -23,7 +23,7 @@ from media.media_url import media_url
 # Source files ################################################################
 
 
-class Periodicals(XMLCorpus):
+class Periodicals(XMLCorpusDefinition):
     title = "Periodicals"
     description = "A collection of 19th century periodicals"
     min_date = datetime(1800,1,1)

--- a/backend/corpora/rechtspraak/rechtspraak.py
+++ b/backend/corpora/rechtspraak/rechtspraak.py
@@ -9,7 +9,7 @@ from zipfile import ZipFile, BadZipFile
 from django.conf import settings
 
 from addcorpus import extract, filters
-from addcorpus.corpus import Field, XMLCorpus
+from addcorpus.corpus import Field, XMLCorpusDefinition
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 from addcorpus.es_settings import es_settings
 
@@ -30,7 +30,7 @@ def rdf_description_extractor(tag, section='xml', **kwargs):
     )
 
 
-class Rechtspraak(XMLCorpus):
+class Rechtspraak(XMLCorpusDefinition):
     title = "Judicial system Netherlands"
     description = "Open data of (anonymised) court rulings of the Dutch judicial system"
     min_date = datetime(year=1900, month=1, day=1)

--- a/backend/corpora/spectactors/spectators.py
+++ b/backend/corpora/spectactors/spectators.py
@@ -14,7 +14,7 @@ from django.conf import settings
 
 from addcorpus import extract
 from addcorpus import filters
-from addcorpus.corpus import XMLCorpus, Field
+from addcorpus.corpus import XMLCorpusDefinition, Field
 
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 from addcorpus.es_settings import es_settings
@@ -23,7 +23,7 @@ from addcorpus.es_settings import es_settings
 # Source files ################################################################
 
 
-class Spectators(XMLCorpus):
+class Spectators(XMLCorpusDefinition):
     title = "Spectators"
     description = "A collection of Spectator newspapers"
     min_date = datetime()

--- a/backend/corpora/times/times.py
+++ b/backend/corpora/times/times.py
@@ -16,7 +16,7 @@ from django.conf import settings
 
 from addcorpus import extract
 from addcorpus import filters
-from addcorpus.corpus import XMLCorpus, Field, until, after, string_contains, consolidate_start_end_years
+from addcorpus.corpus import XMLCorpusDefinition, Field, until, after, string_contains, consolidate_start_end_years
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 from addcorpus.es_settings import es_settings
 from media.media_url import media_url
@@ -24,7 +24,7 @@ from media.media_url import media_url
 # Source files ################################################################
 
 
-class Times(XMLCorpus):
+class Times(XMLCorpusDefinition):
     title = "Times"
     description = "Newspaper archive, 1785-2010"
     min_date = datetime(year=1785, month=1, day=1)

--- a/backend/corpora/tml/tml.py
+++ b/backend/corpora/tml/tml.py
@@ -14,14 +14,14 @@ from django.conf import settings
 
 from addcorpus import extract
 from addcorpus import filters
-from addcorpus.corpus import HTMLCorpus, XMLCorpus, Field, until, after, string_contains
+from addcorpus.corpus import HTMLCorpusDefinition, XMLCorpusDefinition, Field, until, after, string_contains
 
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 
 # Source files ################################################################
 
 
-class Tml(HTMLCorpus):
+class Tml(HTMLCorpusDefinition):
     title = "Thesaurus Musicarum Latinarum"
     description = "A collection of Medieval writings about music"
     min_date = datetime(year=300, month=1, day=1)

--- a/backend/corpora/troonredes/troonredes.py
+++ b/backend/corpora/troonredes/troonredes.py
@@ -16,7 +16,7 @@ from django.conf import settings
 
 from addcorpus import extract
 from addcorpus import filters
-from addcorpus.corpus import XMLCorpus, Field, until, after, string_contains
+from addcorpus.corpus import XMLCorpusDefinition, Field, until, after, string_contains
 from addcorpus.load_corpus import corpus_dir
 
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
@@ -29,7 +29,7 @@ MONARCHS = ['Willem I', 'Willem II', 'Willem III', 'Emma',
 SPEECH_TYPES = ['openingsrede', 'troonrede', 'inhuldigingsrede']
 
 
-class Troonredes(XMLCorpus):
+class Troonredes(XMLCorpusDefinition):
     title = "Troonredes"
     description = "Speeches by Dutch monarchs"
     min_date = datetime(year=1814, month=1, day=1)

--- a/backend/download/tests/mock_corpora/multilingual_mock_corpus.py
+++ b/backend/download/tests/mock_corpora/multilingual_mock_corpus.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from addcorpus.corpus import Field, CSVCorpus
+from addcorpus.corpus import Field, CSVCorpusDefinition
 from addcorpus.extract import CSV
 import os
 
@@ -7,7 +7,7 @@ import os
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-class MultilingualMockCorpus(CSVCorpus):
+class MultilingualMockCorpus(CSVCorpusDefinition):
     title = 'Multilingual Mock Corpus'
     description = 'A mixed-language corpus. Especially useful for testing character encoding'
     visualize = []

--- a/backend/tag/tests/tag_mock_corpus.py
+++ b/backend/tag/tests/tag_mock_corpus.py
@@ -1,14 +1,14 @@
 import os
 import datetime
 
-from addcorpus.corpus import CSVCorpus, Field
+from addcorpus.corpus import CSVCorpusDefinition, Field
 from addcorpus.extract import CSV
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 
 here = os.path.abspath(os.path.dirname(__file__))
 
 
-class TaggingMockCorpus(CSVCorpus):
+class TaggingMockCorpus(CSVCorpusDefinition):
     title = 'Tagging Mock Corpus'
     description = 'Mock corpus for tagging'
     es_index = 'tagging-mock-corpus'

--- a/backend/visualization/tests/mock_corpora/large_mock_corpus.py
+++ b/backend/visualization/tests/mock_corpora/large_mock_corpus.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from addcorpus.corpus import Corpus, Field
+from addcorpus.corpus import CorpusDefinition, Field
 import random
 
 TOTAL_DOCUMENTS = 11000
@@ -20,7 +20,7 @@ def generate_text():
     random.shuffle(tokens)
     return ' '.join(tokens)
 
-class LargeMockCorpus(Corpus):
+class LargeMockCorpus(CorpusDefinition):
     '''
     For testing the download limit: a mock corpus that contains over
     10.000 documents.

--- a/backend/visualization/tests/mock_corpora/small_mock_corpus.py
+++ b/backend/visualization/tests/mock_corpora/small_mock_corpus.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from addcorpus.corpus import Field, CSVCorpus
+from addcorpus.corpus import Field, CSVCorpusDefinition
 from addcorpus.extract import CSV
 import os
 
@@ -7,7 +7,7 @@ import os
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-class SmallMockCorpus(CSVCorpus):
+class SmallMockCorpus(CSVCorpusDefinition):
     title = 'Mock Corpus'
     description = 'Corpus for testing'
     visualize = []

--- a/backend/wordmodels/tests/mock-corpus/mock_corpus.py
+++ b/backend/wordmodels/tests/mock-corpus/mock_corpus.py
@@ -1,11 +1,11 @@
 import datetime
-from addcorpus.corpus import Corpus, Field
+from addcorpus.corpus import CorpusDefinition, Field
 
 from os.path import abspath, dirname, join
 
 here = abspath(dirname(__file__))
 
-class WordmodelsMockCorpus(Corpus):
+class WordmodelsMockCorpus(CorpusDefinition):
     title = "Mock corpus with word models represented as Keyed Vectors"
     description = "Mock corpus for testing word models, saved as gensim Keyed Vectors"
     es_index = 'nothing'


### PR DESCRIPTION
Renames the `Corpus` class used for definitions to `CorpusDefinition` - which distinguishes it from the `Corpus` model class. As trivial as it sounds. Close #1112