### PR TITLE
Feature/term frequency fixes

### DIFF
--- a/backend/es/download.py
+++ b/backend/es/download.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from ianalyzer.elasticsearch import elasticsearch
 from es.search import get_index, search, hits, total_hits
 
-def scroll(corpus, query_model, download_size=None):
+def scroll(corpus, query_model, download_size=None, **kwargs):
     index = get_index(corpus)
     client = elasticsearch(index)
     server = settings.CORPUS_SERVER_NAMES.get(corpus, 'default')
@@ -14,11 +14,12 @@ def scroll(corpus, query_model, download_size=None):
     output = []
     search_results = client.search(
         index=index,
-        size = size,
-        scroll = scroll_timeout,
-        timeout = '60s',
+        size=size,
+        scroll=scroll_timeout,
+        timeout='60s',
         track_total_hits=True,
         **query_model,
+        **kwargs
     )
     output.extend(hits(search_results))
     total = total_hits(search_results)

--- a/backend/es/download.py
+++ b/backend/es/download.py
@@ -3,9 +3,10 @@ from django.conf import settings
 from ianalyzer.elasticsearch import elasticsearch
 from es.search import get_index, search, hits, total_hits
 
-def scroll(corpus, query_model, download_size=None, **kwargs):
+def scroll(corpus, query_model, download_size=None, client=None, **kwargs):
     index = get_index(corpus)
-    client = elasticsearch(index)
+    if not client:
+        client = elasticsearch(index)
     server = settings.CORPUS_SERVER_NAMES.get(corpus, 'default')
     scroll_timeout = settings.SERVERS[server]['scroll_timeout']
     scroll_page_size = settings.SERVERS[server]['scroll_page_size']

--- a/backend/visualization/conftest.py
+++ b/backend/visualization/conftest.py
@@ -1,11 +1,73 @@
 import pytest
 import os
+import random
 
 from conftest import index_test_corpus, clear_test_corpus
 from visualization.tests.mock_corpora.small_mock_corpus import SPECS as SMALL_MOCK_CORPUS_SPECS
 from visualization.tests.mock_corpora.large_mock_corpus import SPECS as LARGE_MOCK_CORPUS_SPECS
 
 here = os.path.abspath(os.path.dirname(__file__))
+
+class MockIndex(object):
+    def analyze(self, index, body):
+        return {'tokens': [{'token': 'test'}]}
+
+class MockClient(object):
+    ''' Mock ES Client returning random hits and term vectors '''
+    def __init__(self, num_hits):
+        self.num_hits = num_hits
+        self.indices = MockIndex()
+
+    def search(self, index, size, **kwargs):
+        return {'hits':
+            {'total': {'value': self.num_hits},
+            'hits': [{'_id': hit_id} for hit_id in range(min(size, self.num_hits))]},
+            '_scroll_id': '42'
+        }
+    
+    def clear_scroll(self, scroll_id):
+        return {'status': 'ok'}
+
+    def termvectors(self, index, id, fields):
+        ''' return 10 matches for term `test` '''
+        return {'term_vectors': {field: {
+            "terms": {'test': {
+                    'ttf': random.randrange(1, 20000),
+                    'tokens': [
+                        {
+                        "position": random.randrange(1, 200)
+                        }
+                        for j in range(10)
+                    ]
+                }, 'nottest': {
+                    'ttf': random.randrange(1, 20000),
+                    'tokens': [
+                        {
+                        "position": random.randrange(1, 200)
+                        }
+                        for j in range(5)
+                    ]
+                }
+                }
+            } for field in fields}}
+
+@pytest.fixture()
+def es_client_m_hits():
+    ''' return a client that is expected to give:
+    - 5000 total hits
+    - size hits
+    - size * 10 term matches
+    '''
+    return MockClient(5000)
+
+@pytest.fixture()
+def es_client_k_hits():
+    ''' return a client that is expected give:
+    - 500 total hits
+    - size hits
+    - size * 10 term matches
+    '''
+    return MockClient(500)
 
 @pytest.fixture(scope='session')
 def small_mock_corpus():
@@ -80,3 +142,4 @@ def basic_query():
             }
         }
     }
+

--- a/backend/visualization/term_frequency.py
+++ b/backend/visualization/term_frequency.py
@@ -87,8 +87,8 @@ def get_match_count(es_client, es_query, corpus, size, fieldnames):
     mean_last_matches = sum(matches[-ESTIMATE_WINDOW:]) / ESTIMATE_WINDOW
     # we estimate that skipped contain matches linearly decrease 
     # from average in ESTIMATE_WINDOW to 1
-    estimate_skipped = int((mean_last_matches - 1) * skipped_docs / 2)
-    match_count = n_matches + max(estimate_skipped, skipped_docs)
+    estimate_skipped = int((mean_last_matches - 1) * skipped_docs / 2) + skipped_docs
+    match_count = n_matches + estimate_skipped
     return match_count
 
 def count_matches_in_document(id, index, fieldnames, query_text, es_client):

--- a/backend/visualization/term_frequency.py
+++ b/backend/visualization/term_frequency.py
@@ -67,6 +67,7 @@ def get_match_count(es_client, es_query, corpus, size, fieldnames):
     found_hits, total_results = download.scroll(corpus=corpus,
         query_model=es_query,
         download_size=size,
+        client=es_client,
         source=[]
     )
 

--- a/backend/visualization/term_frequency.py
+++ b/backend/visualization/term_frequency.py
@@ -7,7 +7,7 @@ from visualization import query, termvectors
 from es import download
 
 DEFAULT_SIZE = 100
-ESTIMATE_WINDOW = 50
+ESTIMATE_WINDOW = 5
 
 def parse_datestring(datestring):
     return datetime.strptime(datestring, '%Y-%m-%d')

--- a/backend/visualization/term_frequency.py
+++ b/backend/visualization/term_frequency.py
@@ -6,10 +6,12 @@ from copy import deepcopy
 from visualization import query, termvectors
 from es import download
 
+DEFAULT_SIZE = 100
+
 def parse_datestring(datestring):
     return datetime.strptime(datestring, '%Y-%m-%d')
 
-def get_date_term_frequency(es_query, corpus, field, start_date_str, end_date_str = None, size = 100, include_query_in_result = False):
+def get_date_term_frequency(es_query, corpus, field, start_date_str, end_date_str=None, size=DEFAULT_SIZE, include_query_in_result=False):
 
     start_date = parse_datestring(start_date_str)
     end_date = parse_datestring(end_date_str) if end_date_str else None
@@ -61,9 +63,10 @@ def extract_data_for_term_frequency(corpus, es_query):
     return fieldnames, token_count_aggregators
 
 def get_match_count(es_client, es_query, corpus, size, fieldnames):
-    found_hits, total_results = download.scroll(corpus = corpus,
+    found_hits, total_results = download.scroll(corpus=corpus,
         query_model=es_query,
-        download_size=size
+        download_size=size,
+        source=[]
     )
 
     index = get_index(corpus)
@@ -138,7 +141,7 @@ def get_term_frequency(es_query, corpus, size):
 
     return match_count, total_doc_count, token_count
 
-def get_aggregate_term_frequency(es_query, corpus, field_name, field_value, size = 100, include_query_in_result = False):
+def get_aggregate_term_frequency(es_query, corpus, field_name, field_value, size=DEFAULT_SIZE, include_query_in_result=False):
     # filter for relevant value
     term_filter = query.make_term_filter(field_name, field_value)
     es_query = query.add_filter(es_query, term_filter)

--- a/backend/visualization/term_frequency.py
+++ b/backend/visualization/term_frequency.py
@@ -1,3 +1,5 @@
+import math
+
 from addcorpus.load_corpus import load_corpus
 from datetime import datetime
 from es.search import get_index, total_hits, search
@@ -87,7 +89,7 @@ def get_match_count(es_client, es_query, corpus, size, fieldnames):
     mean_last_matches = sum(matches[-ESTIMATE_WINDOW:]) / ESTIMATE_WINDOW
     # we estimate that skipped contain matches linearly decrease 
     # from average in ESTIMATE_WINDOW to 1
-    estimate_skipped = int((mean_last_matches - 1) * skipped_docs / 2) + skipped_docs
+    estimate_skipped = int(math.ceil(mean_last_matches - 1) * skipped_docs / 2) + skipped_docs
     match_count = n_matches + estimate_skipped
     return match_count
 

--- a/backend/visualization/tests/test_term_frequency.py
+++ b/backend/visualization/tests/test_term_frequency.py
@@ -1,6 +1,4 @@
-from visualization import term_frequency, tasks
-import csv
-
+from visualization import term_frequency
 
 def test_extract_data_for_term_frequency(small_mock_corpus):
     es_query = make_query('test', ['content', 'title'])
@@ -56,10 +54,19 @@ def test_match_count(small_mock_corpus, es_client, index_small_mock_corpus):
         match_count = term_frequency.get_match_count(es_client, query, small_mock_corpus, 100, fieldnames)
         assert match_count == freq
 
+def test_match_count_estimate(es_client_m_hits, es_client_k_hits, small_mock_corpus, basic_query):
+    matches = term_frequency.get_match_count(es_client_m_hits, basic_query, small_mock_corpus, 1000, ['test'])
+    # es_client_m_hits gives 5000 total hits and 10'000 terms for the 1000 document sample
+    # it estimates (10 - 1) * 4000 / 2 = 18000 terms for the uncounted documents
+    assert matches == 28000
+
+def test_match_count_full(es_client_k_hits, small_mock_corpus, basic_query):
+    matches = term_frequency.get_match_count(es_client_k_hits, basic_query, small_mock_corpus, 1000, ['test'])
+    # es_client_k_hits gives 500 total hits and 5000 terms (fully counted)
+    assert matches == 5000
+
 def test_total_docs_and_tokens(es_client, mock_corpus, index_mock_corpus, mock_corpus_specs):
     """Test total document counter"""
-
-
     query = make_query(query_text='*', search_in_fields=['content'])
 
     fieldnames, aggregators = term_frequency.extract_data_for_term_frequency(mock_corpus, query)

--- a/backend/visualization/tests/test_term_frequency.py
+++ b/backend/visualization/tests/test_term_frequency.py
@@ -57,8 +57,8 @@ def test_match_count(small_mock_corpus, es_client, index_small_mock_corpus):
 def test_match_count_estimate(es_client_m_hits, es_client_k_hits, small_mock_corpus, basic_query):
     matches = term_frequency.get_match_count(es_client_m_hits, basic_query, small_mock_corpus, 1000, ['test'])
     # es_client_m_hits gives 5000 total hits and 10'000 terms for the 1000 document sample
-    # it estimates (10 - 1) * 4000 / 2 = 18000 terms for the uncounted documents
-    assert matches == 28000
+    # it estimates (10 - 1) * 4000 / 2 + 4000 = 22000 terms for the uncounted documents
+    assert matches == 32000
 
 def test_match_count_full(es_client_k_hits, small_mock_corpus, basic_query):
     matches = term_frequency.get_match_count(es_client_k_hits, basic_query, small_mock_corpus, 1000, ['test'])

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -73,6 +73,10 @@ services:
       context: ./backend
     environment:
       CELERY_BROKER: $CELERY_BROKER
+      SQL_DATABASE: $SQL_DATABASE
+      SQL_USER: $SQL_USER
+      SQL_PASSWORD: $SQL_PASSWORD
+      SQL_HOST: $SQL_HOST
       ES_HOST: $ES_HOST
     volumes:
       - type: bind
@@ -81,6 +85,7 @@ services:
     command: bash -c "celery -A ianalyzer.celery worker --loglevel=info"
     depends_on:
       - redis
+      - db
 
 
 volumes:

--- a/frontend/src/app/models/visualization.ts
+++ b/frontend/src/app/models/visualization.ts
@@ -43,7 +43,7 @@ export type BarchartResult = DateResult|AggregateResult;
  */
  export interface BarchartSeries<Result> {
     data: Result[];
-    total_doc_count: number; // total documents matching the query across the series
+    averageDocCount: number; // average number of documents matching query across series
     searchRatio: number; // ratio of total_doc_count that can be searched through without exceeding documentLimit
     queryText?: string; // replaces the text in this.queryModel when searching
 }

--- a/frontend/src/app/models/visualization.ts
+++ b/frontend/src/app/models/visualization.ts
@@ -43,7 +43,7 @@ export type BarchartResult = DateResult|AggregateResult;
  */
  export interface BarchartSeries<Result> {
     data: Result[];
-    averageDocCount: number; // average number of documents matching query across series
+    total_doc_count: number; // total documents matching the query across the series
     searchRatio: number; // ratio of total_doc_count that can be searched through without exceeding documentLimit
     queryText?: string; // replaces the text in this.queryModel when searching
 }

--- a/frontend/src/app/visualization/barchart/barchart.directive.ts
+++ b/frontend/src/app/visualization/barchart/barchart.directive.ts
@@ -49,7 +49,7 @@ export abstract class BarchartDirective
 
     chartType: 'bar' | 'line' | 'scatter' = 'bar';
 
-    documentLimit = 100; // maximum number of documents to search through for term frequency
+    documentLimit = 5000; // maximum number of documents to search through for term frequency
     documentLimitExceeded = false; // whether the results include documents than the limit
     totalTokenCountAvailable: boolean; // whether the data includes token count totals
 

--- a/frontend/src/app/visualization/barchart/barchart.directive.ts
+++ b/frontend/src/app/visualization/barchart/barchart.directive.ts
@@ -49,7 +49,7 @@ export abstract class BarchartDirective
 
     chartType: 'bar' | 'line' | 'scatter' = 'bar';
 
-    documentLimit = 5000; // maximum number of documents to search through for term frequency
+    documentLimit = 1000; // maximum number of documents to search through for term frequency
     documentLimitExceeded = false; // whether the results include documents than the limit
     totalTokenCountAvailable: boolean; // whether the data includes token count totals
 
@@ -614,7 +614,7 @@ export abstract class BarchartDirective
      */
     get percentageDocumentsSearched() {
         if (this.rawData) {
-            return _.round(100 *  _.min(this.rawData.map(series => series.searchRatio)));
+            return _.round(100 *  _.min(this.rawData.map(series => series.searchRatio)), 1);
         }
     }
 

--- a/frontend/src/app/visualization/barchart/barchart.directive.ts
+++ b/frontend/src/app/visualization/barchart/barchart.directive.ts
@@ -221,7 +221,7 @@ export abstract class BarchartDirective
         return {
             queryText,
             data: [],
-            averageDocCount: 0,
+            total_doc_count: 0,
             searchRatio: 1.0,
         };
     }
@@ -311,12 +311,12 @@ export abstract class BarchartDirective
     docCountResultIntoSeries(result, series: BarchartSeries<DataPoint>, setSearchRatio = true): BarchartSeries<DataPoint> {
         let data = result.aggregations[this.visualizedField.name]
             .map(this.aggregateResultToDataPoint);
-        const averageDocCount = this.averageDocCount(data);
-        const searchRatio = setSearchRatio ? this.documentLimit / averageDocCount : series.searchRatio;
-        data = this.includeRelativeDocCount(data, averageDocCount);
+        const total_doc_count = this.totalDocCount(data);
+        const searchRatio = setSearchRatio ? this.documentLimit / total_doc_count : series.searchRatio;
+        data = this.includeRelativeDocCount(data, total_doc_count);
         return {
             data,
-            averageDocCount,
+            total_doc_count,
             searchRatio,
             queryText: series.queryText,
         };
@@ -393,11 +393,6 @@ export abstract class BarchartDirective
     /** total document count for a data array */
     totalDocCount(data: AggregateResult[]) {
         return _.sumBy(data, item => item.doc_count);
-    }
-
-    /** total document count for a data array */
-    averageDocCount(data: AggregateResult[]) {
-        return _.meanBy(data, item => item.doc_count);
     }
 
     /**

--- a/frontend/src/app/visualization/barchart/barchart.directive.ts
+++ b/frontend/src/app/visualization/barchart/barchart.directive.ts
@@ -585,7 +585,7 @@ export abstract class BarchartDirective
     /** return a copy of a query model with removed sort parameter (=> relevance sorting) */
     removeSort(query: QueryModel): QueryModel {
         const queryModelCopy = query.clone();
-        queryModelCopy.sort.setSortBy(undefined);
+        queryModelCopy.sort.reset();
         return queryModelCopy;
     }
 

--- a/frontend/src/app/visualization/barchart/barchart.directive.ts
+++ b/frontend/src/app/visualization/barchart/barchart.directive.ts
@@ -221,7 +221,7 @@ export abstract class BarchartDirective
         return {
             queryText,
             data: [],
-            total_doc_count: 0,
+            averageDocCount: 0,
             searchRatio: 1.0,
         };
     }
@@ -311,12 +311,12 @@ export abstract class BarchartDirective
     docCountResultIntoSeries(result, series: BarchartSeries<DataPoint>, setSearchRatio = true): BarchartSeries<DataPoint> {
         let data = result.aggregations[this.visualizedField.name]
             .map(this.aggregateResultToDataPoint);
-        const total_doc_count = this.totalDocCount(data);
-        const searchRatio = setSearchRatio ? this.documentLimit / total_doc_count : series.searchRatio;
-        data = this.includeRelativeDocCount(data, total_doc_count);
+        const averageDocCount = this.averageDocCount(data);
+        const searchRatio = setSearchRatio ? this.documentLimit / averageDocCount : series.searchRatio;
+        data = this.includeRelativeDocCount(data, averageDocCount);
         return {
             data,
-            total_doc_count,
+            averageDocCount,
             searchRatio,
             queryText: series.queryText,
         };
@@ -393,6 +393,11 @@ export abstract class BarchartDirective
     /** total document count for a data array */
     totalDocCount(data: AggregateResult[]) {
         return _.sumBy(data, item => item.doc_count);
+    }
+
+    /** total document count for a data array */
+    averageDocCount(data: AggregateResult[]) {
+        return _.meanBy(data, item => item.doc_count);
     }
 
     /**

--- a/frontend/src/app/visualization/barchart/barchart.directive.ts
+++ b/frontend/src/app/visualization/barchart/barchart.directive.ts
@@ -431,7 +431,7 @@ export abstract class BarchartDirective
 
     /** adapt query model to fit series: use correct search fields and query text */
     queryModelForSeries(series: BarchartSeries<DataPoint>, queryModel: QueryModel) {
-        return this.selectSearchFields(this.setQueryText(queryModel, series.queryText));
+        return this.selectSearchFields(this.removeSort(this.setQueryText(queryModel, series.queryText)));
     }
 
     /** Request doc counts for a series */
@@ -579,6 +579,13 @@ export abstract class BarchartDirective
     setQueryText(query: QueryModel, queryText: string): QueryModel {
         const queryModelCopy = query.clone();
         queryModelCopy.queryText = queryText;
+        return queryModelCopy;
+    }
+
+    /** return a copy of a query model with removed sort parameter (=> relevance sorting) */
+    removeSort(query: QueryModel): QueryModel {
+        const queryModelCopy = query.clone();
+        queryModelCopy.sort.setSortBy(undefined);
         return queryModelCopy;
     }
 

--- a/frontend/src/app/visualization/barchart/barchart.directive.ts
+++ b/frontend/src/app/visualization/barchart/barchart.directive.ts
@@ -13,7 +13,7 @@ import Zoom from 'chartjs-plugin-zoom';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { selectColor } from '../../utils/select-color';
 import { VisualizationService } from '../../services/visualization.service';
-import { findByName, showLoading } from '../../utils/utils';
+import { showLoading } from '../../utils/utils';
 import { takeUntil } from 'rxjs/operators';
 
 const hintSeenSessionStorageKey = 'hasSeenTimelineZoomingHint';
@@ -49,7 +49,7 @@ export abstract class BarchartDirective
 
     chartType: 'bar' | 'line' | 'scatter' = 'bar';
 
-    documentLimit = 5000; // maximum number of documents to search through for term frequency
+    documentLimit = 100; // maximum number of documents to search through for term frequency
     documentLimitExceeded = false; // whether the results include documents than the limit
     totalTokenCountAvailable: boolean; // whether the data includes token count totals
 
@@ -400,7 +400,7 @@ export abstract class BarchartDirective
      * when determining term frequency.
      */
      documentLimitForCategory(cat: DataPoint, series: BarchartSeries<DataPoint>): number {
-        return _.min([10000, _.ceil(cat.doc_count * series.searchRatio)]);
+        return _.min([this.documentLimit, _.ceil(cat.doc_count * series.searchRatio)]);
     }
 
 

--- a/frontend/src/app/visualization/barchart/histogram.component.html
+++ b/frontend/src/app/visualization/barchart/histogram.component.html
@@ -28,8 +28,7 @@
         <div class="block">
             The results for your search include too many documents to count all matches.
             Only a sample of the first {{percentageDocumentsSearched}}% of documents for each bin are analyzed;
-            the rest are assumed to contain linearly decreasing matches between the end of the sample
-            to one match.
+            the match for other documents is extrapolated.
         </div>
 
         <ia-full-data-button (requestFullData)="requestFullData()"></ia-full-data-button>

--- a/frontend/src/app/visualization/barchart/histogram.component.html
+++ b/frontend/src/app/visualization/barchart/histogram.component.html
@@ -27,8 +27,9 @@
     <div class="message-body">
         <div class="block">
             The results for your search include too many documents to count all matches.
-            Only the first {{percentageDocumentsSearched}}% of documents for each bin are analyzed;
-            the rest are assumed to have only one match for your query.
+            Only a sample of the first {{percentageDocumentsSearched}}% of documents for each bin are analyzed;
+            the rest are assumed to contain linearly decreasing matches between the end of the sample
+            to one match.
         </div>
 
         <ia-full-data-button (requestFullData)="requestFullData()"></ia-full-data-button>

--- a/frontend/src/app/visualization/barchart/histogram.component.html
+++ b/frontend/src/app/visualization/barchart/histogram.component.html
@@ -28,7 +28,7 @@
         <div class="block">
             The results for your search include too many documents to count all matches.
             Only a sample of the first {{percentageDocumentsSearched}}% of documents for each bin are analyzed;
-            the match for other documents is extrapolated.
+            the matches in other documents are extrapolated based on the sample.
         </div>
 
         <ia-full-data-button (requestFullData)="requestFullData()"></ia-full-data-button>

--- a/frontend/src/app/visualization/barchart/timeline.component.html
+++ b/frontend/src/app/visualization/barchart/timeline.component.html
@@ -31,8 +31,9 @@
     <div class="message-body">
         <div class="block">
         The results for your search include too many documents to count all matches.
-        Only the first {{percentageDocumentsSearched}}% of documents for each bin are analyzed;
-        the rest are assumed to have only one match for your query.
+        Only a sample of the first {{percentageDocumentsSearched}}% of documents for each bin are analyzed;
+        the rest are assumed to contain linearly decreasing matches between the end of the sample
+        to one match.
         </div>
 
         <ia-full-data-button (requestFullData)="requestFullData()"></ia-full-data-button>

--- a/frontend/src/app/visualization/barchart/timeline.component.html
+++ b/frontend/src/app/visualization/barchart/timeline.component.html
@@ -32,8 +32,7 @@
         <div class="block">
         The results for your search include too many documents to count all matches.
         Only a sample of the first {{percentageDocumentsSearched}}% of documents for each bin are analyzed;
-        the rest are assumed to contain linearly decreasing matches between the end of the sample
-        to one match.
+        the match for other documents is extrapolated.
         </div>
 
         <ia-full-data-button (requestFullData)="requestFullData()"></ia-full-data-button>

--- a/frontend/src/app/visualization/barchart/timeline.component.html
+++ b/frontend/src/app/visualization/barchart/timeline.component.html
@@ -32,7 +32,7 @@
         <div class="block">
         The results for your search include too many documents to count all matches.
         Only a sample of the first {{percentageDocumentsSearched}}% of documents for each bin are analyzed;
-        the match for other documents is extrapolated.
+        the matches in other documents are extrapolated based on the sample.
         </div>
 
         <ia-full-data-button (requestFullData)="requestFullData()"></ia-full-data-button>


### PR DESCRIPTION
Instead of fitting a curve over the matches, this branch now goes back to sampling a sizeable batch of the data first, and estimating then by assuming linear decay between the end of the sampling interval and match 1. This means we'll probably overestimate (instead of underestimate) the real number of matches in some cases, but fitting an exponential curve over the data proved not feasible due to fluctuations in the data (see #959). We may still decide that the estimate of decay is not worth it and roll back the changes related so our estimate is back to `sampled_matches + n_not_analyzed_docs`. What do you think, @lukavdplas?

This branch does introduce one essential (frontend) fix though: sorting by relevance rather than date (or other sort, which used to be kept in the query model) when requesting the top hits in the `visualization.term_frequency.get_match_count` function.

