### PR TITLE
close #1246 set highlight as switched off

### DIFF
--- a/frontend/src/app/search/highlight-selector.component.ts
+++ b/frontend/src/app/search/highlight-selector.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
 import { QueryModel } from '../models';
 import { Subscription } from 'rxjs';
 
@@ -8,17 +8,17 @@ import { Subscription } from 'rxjs';
   templateUrl: './highlight-selector.component.html',
   styleUrls: ['./highlight-selector.component.scss']
 })
-export class HighlightSelectorComponent implements OnChanges, OnDestroy {
+export class HighlightSelectorComponent implements OnChanges, OnDestroy, OnInit {
     @Input() queryModel: QueryModel;
+    public highlight = 0;
     private highlightSubscription: Subscription;
-    public highlight: number = 0;
 
     constructor() {
     }
 
     ngOnInit() {
         this.highlightSubscription = this.queryModel.update.subscribe(() => {
-            this.setStateFromQueryModel()
+            this.setStateFromQueryModel();
         });
     }
 
@@ -29,7 +29,7 @@ export class HighlightSelectorComponent implements OnChanges, OnDestroy {
     }
 
     ngOnDestroy(): void {
-        this.queryModel.setHighlight(0);
+        this.queryModel.setHighlight(0, true);
         this.highlightSubscription.unsubscribe();
     }
 
@@ -38,13 +38,13 @@ export class HighlightSelectorComponent implements OnChanges, OnDestroy {
     }
 
     updateHighlightSize(instruction?: string) {
-        if (instruction == 'on' && this.queryModel.highlightSize == 0) {
+        if (instruction === 'on' && this.queryModel.highlightSize === 0) {
             this.queryModel.setHighlight(200);
-        } else if (instruction == 'more' && this.queryModel.highlightSize < 800) {
+        } else if (instruction === 'more' && this.queryModel.highlightSize < 800) {
             this.queryModel.setHighlight(this.queryModel.highlightSize + 200);
-        } else if (instruction == 'less' && this.queryModel.highlightSize > 200) {
+        } else if (instruction === 'less' && this.queryModel.highlightSize > 200) {
             this.queryModel.setHighlight(this.queryModel.highlightSize - 200);
-        } else if (instruction == 'off') {
+        } else if (instruction === 'off') {
             this.queryModel.setHighlight(0, true);
         }
     }


### PR DESCRIPTION
This seems to fix bug #1246. Reviewing this code, I realized that the setup with two ways of communicating changes of the queryModel to components, one through a `queryModel.update` Subject, and one through an `@Input` for `search-component`'s children, is rather hard to grasp. Worth revisiting (see #1247 ).