### PR TITLE
Feature/results model

### DIFF
--- a/frontend/src/app/document-view/document-view.component.html
+++ b/frontend/src/app/document-view/document-view.component.html
@@ -31,7 +31,7 @@
 
     <div class="column is-7">
         <div class="box">
-            <ia-tabs>
+            <ia-tabs [activeTab]="activeTab">
                 <ng-template iaTabPanel *ngFor="let field of contentFields" [id]="field.name" [title]="field.displayName" [icon]="tabIcons.text">
                     <div class="content" [innerHtml]="highlightedInnerHtml(field)"></div>
                 </ng-template>

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -1,14 +1,15 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 
 import { CorpusField, FoundDocument, Corpus, QueryModel } from '../models/index';
 import { faBook, faImage } from '@fortawesome/free-solid-svg-icons';
+import { DocumentView } from '../models/document-page';
 
 @Component({
     selector: 'ia-document-view',
     templateUrl: './document-view.component.html',
     styleUrls: ['./document-view.component.scss']
 })
-export class DocumentViewComponent {
+export class DocumentViewComponent implements OnChanges {
 
     @Input()
     public document: FoundDocument;
@@ -20,13 +21,15 @@ export class DocumentViewComponent {
     public corpus: Corpus;
 
     @Input()
-    public documentTabIndex: number;
+    public view: DocumentView;
 
 
     tabIcons = {
         text: faBook,
         scan: faImage,
     };
+
+    activeTab: 'scan' | undefined;
 
     public imgNotFound: boolean;
     public imgPath: string;
@@ -46,6 +49,14 @@ export class DocumentViewComponent {
 
     get showScanTab() {
         return !!this.corpus.scan_image_type;
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if (changes.view) {
+            if (this.view === 'scan' && this.showScanTab) {
+                this.activeTab = 'scan';
+            }
+        }
     }
 
     isUrlField(field: CorpusField) {

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -3,6 +3,7 @@ import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { CorpusField, FoundDocument, Corpus, QueryModel } from '../models/index';
 import { faBook, faImage } from '@fortawesome/free-solid-svg-icons';
 import { DocumentView } from '../models/document-page';
+import * as _ from 'lodash';
 
 @Component({
     selector: 'ia-document-view',
@@ -29,7 +30,8 @@ export class DocumentViewComponent implements OnChanges {
         scan: faImage,
     };
 
-    activeTab: 'scan' | undefined;
+    /** active tab on opening */
+    activeTab: string;
 
     public imgNotFound: boolean;
     public imgPath: string;
@@ -53,10 +55,20 @@ export class DocumentViewComponent implements OnChanges {
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.view) {
-            if (this.view === 'scan' && this.showScanTab) {
-                this.activeTab = 'scan';
-            }
+            this.activeTab = this.tabFromView(this.view);
         }
+    }
+
+    /** get the tab from the view mode
+     *
+     * For "scan" view: select the scan tab if there is one
+     * For "content" view: select the first content field
+     */
+    tabFromView(view: DocumentView): string {
+        if (view === 'scan' && this.showScanTab) {
+            return 'scan';
+        }
+        return _.first(this.contentFields)['name'];
     }
 
     isUrlField(field: CorpusField) {

--- a/frontend/src/app/document/document-popup/document-popup.component.html
+++ b/frontend/src/app/document/document-popup/document-popup.component.html
@@ -1,0 +1,1 @@
+<p>document-popup works!</p>

--- a/frontend/src/app/document/document-popup/document-popup.component.html
+++ b/frontend/src/app/document/document-popup/document-popup.component.html
@@ -1,1 +1,55 @@
-<p>document-popup works!</p>
+<ng-container *ngIf="page?.focus$ | async as document">
+    <p-dialog [(visible)]="visible"
+        header="Document bla of bla">
+        Document...
+        <ng-template pTemplate="footer">
+            Footer
+        </ng-template>
+    </p-dialog>
+</ng-container>
+
+
+<!-- <p-dialog *ngIf="viewDocument$ | async as viewDocument" [visible]="true" width="100%"
+    [modal]="true" [responsive]="true" [maximizable]="true" [dismissableMask]="true" [draggable]="true" [resizable]="false" [blockScroll]="true"
+    header="Document {{viewDocument.position}} of {{totalResults}}">
+    <ia-document-view [document]="viewDocument" [queryModel]="queryModel" [corpus]="corpus" [documentTabIndex]="documentTabIndex"></ia-document-view>
+    <ng-template pTemplate="footer">
+        <div class="columns" style="text-align:left">
+            <div class="column">
+                <a *ngIf="viewDocument && viewDocument.position > 1"
+                    iaBalloon="view previous document" iaBalloonPosition="right"
+                    (click)="prevDocument(viewDocument)" (keydown.enter)="prevDocument(viewDocument)"
+                    role="button" tabindex="0">
+                    <span class="icon"><fa-icon [icon]="faArrowLeft">previous</fa-icon></span>
+                </a>
+            </div>
+            <div class="column" style="text-align:center">
+                <a [routerLink]="['/document', corpus.name, viewDocument.id]"
+                    iaBalloon="view this document on its own page" autofocus
+                    tabindex="0">
+                    <span class="icon">
+                        <fa-icon [icon]="linkIcon"></fa-icon>
+                    </span>
+                    <span>Link</span>
+                </a>
+                &nbsp;
+                <a *ngIf="viewDocument.hasContext" [routerLink]="['/search', corpus.name]" [queryParams]="viewDocument.contextQueryParams"
+                    iaBalloon="view all documents from this {{contextDisplayName}}"
+                    tabindex="0">
+                    <span class="icon">
+                        <fa-icon [icon]="contextIcon"></fa-icon>
+                    </span>
+                    <span>View {{contextDisplayName}}</span>
+                </a>
+            </div>
+            <div class="column" style="text-align:right">
+                <a *ngIf="viewDocument && viewDocument.position < totalResults"
+                    iaBalloon="view next document" iaBalloonPosition="left"
+                    (click)="nextDocument(viewDocument)" (keydown.enter)="nextDocument(viewDocument)"
+                    role="button" tabindex="0">
+                    <span class="icon"><fa-icon [icon]="faArrowRight">next</fa-icon></span>
+                </a>
+            </div>
+        </div>
+    </ng-template>
+</p-dialog> -->

--- a/frontend/src/app/document/document-popup/document-popup.component.html
+++ b/frontend/src/app/document/document-popup/document-popup.component.html
@@ -36,7 +36,7 @@
                     </a>
                 </div>
                 <div class="column" style="text-align:right">
-                    <a *ngIf="document.position < page.documents.length - 1"
+                    <a *ngIf="document.position < page.documents.length"
                         iaBalloon="view next document" iaBalloonPosition="left"
                         (click)="page.focusNext(document)" (keydown.enter)="page.focusNext(document)"
                         role="button" tabindex="0">

--- a/frontend/src/app/document/document-popup/document-popup.component.html
+++ b/frontend/src/app/document/document-popup/document-popup.component.html
@@ -1,9 +1,45 @@
 <ng-container *ngIf="page?.focus$ | async as document">
     <p-dialog [(visible)]="visible"
-        header="Document bla of bla">
+        header="Document {{document.position}} of {{page.total}}">
         Document...
         <ng-template pTemplate="footer">
-            Footer
+            <div class="columns" style="text-align:left">
+                <div class="column">
+                    <a *ngIf="document.position > 1"
+                        iaBalloon="view previous document" iaBalloonPosition="right"
+                        (click)="page.focusPrevious()" (keydown.enter)="page.focusPrevious()"
+                        role="button" tabindex="0">
+                        <span class="icon"><fa-icon [icon]="faArrowLeft">previous</fa-icon></span>
+                    </a>
+                </div>
+                <!-- <div class="column" style="text-align:center">
+                    <a [routerLink]="['/document', corpus.name, viewDocument.id]"
+                        iaBalloon="view this document on its own page" autofocus
+                        tabindex="0">
+                        <span class="icon">
+                            <fa-icon [icon]="linkIcon"></fa-icon>
+                        </span>
+                        <span>Link</span>
+                    </a>
+                    &nbsp;
+                    <a *ngIf="viewDocument.hasContext" [routerLink]="['/search', corpus.name]" [queryParams]="viewDocument.contextQueryParams"
+                        iaBalloon="view all documents from this {{contextDisplayName}}"
+                        tabindex="0">
+                        <span class="icon">
+                            <fa-icon [icon]="contextIcon"></fa-icon>
+                        </span>
+                        <span>View {{contextDisplayName}}</span>
+                    </a>
+                </div> -->
+                <div class="column" style="text-align:right">
+                    <a *ngIf="document.position < page.documents.length - 1"
+                        iaBalloon="view next document" iaBalloonPosition="left"
+                        (click)="page.focusNext()" (keydown.enter)="page.focusNext()"
+                        role="button" tabindex="0">
+                        <span class="icon"><fa-icon [icon]="faArrowRight">next</fa-icon></span>
+                    </a>
+                </div>
+            </div>
         </ng-template>
     </p-dialog>
 </ng-container>
@@ -14,42 +50,6 @@
     header="Document {{viewDocument.position}} of {{totalResults}}">
     <ia-document-view [document]="viewDocument" [queryModel]="queryModel" [corpus]="corpus" [documentTabIndex]="documentTabIndex"></ia-document-view>
     <ng-template pTemplate="footer">
-        <div class="columns" style="text-align:left">
-            <div class="column">
-                <a *ngIf="viewDocument && viewDocument.position > 1"
-                    iaBalloon="view previous document" iaBalloonPosition="right"
-                    (click)="prevDocument(viewDocument)" (keydown.enter)="prevDocument(viewDocument)"
-                    role="button" tabindex="0">
-                    <span class="icon"><fa-icon [icon]="faArrowLeft">previous</fa-icon></span>
-                </a>
-            </div>
-            <div class="column" style="text-align:center">
-                <a [routerLink]="['/document', corpus.name, viewDocument.id]"
-                    iaBalloon="view this document on its own page" autofocus
-                    tabindex="0">
-                    <span class="icon">
-                        <fa-icon [icon]="linkIcon"></fa-icon>
-                    </span>
-                    <span>Link</span>
-                </a>
-                &nbsp;
-                <a *ngIf="viewDocument.hasContext" [routerLink]="['/search', corpus.name]" [queryParams]="viewDocument.contextQueryParams"
-                    iaBalloon="view all documents from this {{contextDisplayName}}"
-                    tabindex="0">
-                    <span class="icon">
-                        <fa-icon [icon]="contextIcon"></fa-icon>
-                    </span>
-                    <span>View {{contextDisplayName}}</span>
-                </a>
-            </div>
-            <div class="column" style="text-align:right">
-                <a *ngIf="viewDocument && viewDocument.position < totalResults"
-                    iaBalloon="view next document" iaBalloonPosition="left"
-                    (click)="nextDocument(viewDocument)" (keydown.enter)="nextDocument(viewDocument)"
-                    role="button" tabindex="0">
-                    <span class="icon"><fa-icon [icon]="faArrowRight">next</fa-icon></span>
-                </a>
-            </div>
         </div>
     </ng-template>
 </p-dialog> -->

--- a/frontend/src/app/document/document-popup/document-popup.component.html
+++ b/frontend/src/app/document/document-popup/document-popup.component.html
@@ -1,16 +1,16 @@
-<ng-container *ngIf="page?.focus$ | async as document">
+<ng-container *ngIf="document">
     <p-dialog [(visible)]="visible" width="100%"
         [responsive]="true" [maximizable]="true" [dismissableMask]="true" [draggable]="true" [resizable]="false" [blockScroll]="true"
         header="Document {{document.position}} of {{page.total}}">
 
-        <ia-document-view [document]="document" [queryModel]="queryModel" [corpus]="document.corpus" [documentTabIndex]="0"></ia-document-view>
+        <ia-document-view [document]="document" [queryModel]="queryModel" [corpus]="document.corpus" [view]="view"></ia-document-view>
 
         <ng-template pTemplate="footer">
             <div class="columns" style="text-align:left">
                 <div class="column">
                     <a *ngIf="document.position > 1"
                         iaBalloon="view previous document" iaBalloonPosition="right"
-                        (click)="page.focusPrevious()" (keydown.enter)="page.focusPrevious()"
+                        (click)="page.focusPrevious(document)" (keydown.enter)="page.focusPrevious(document)"
                         role="button" tabindex="0">
                         <span class="icon"><fa-icon [icon]="faArrowLeft">previous</fa-icon></span>
                     </a>
@@ -38,7 +38,7 @@
                 <div class="column" style="text-align:right">
                     <a *ngIf="document.position < page.documents.length - 1"
                         iaBalloon="view next document" iaBalloonPosition="left"
-                        (click)="page.focusNext()" (keydown.enter)="page.focusNext()"
+                        (click)="page.focusNext(document)" (keydown.enter)="page.focusNext(document)"
                         role="button" tabindex="0">
                         <span class="icon"><fa-icon [icon]="faArrowRight">next</fa-icon></span>
                     </a>

--- a/frontend/src/app/document/document-popup/document-popup.component.html
+++ b/frontend/src/app/document/document-popup/document-popup.component.html
@@ -1,7 +1,10 @@
 <ng-container *ngIf="page?.focus$ | async as document">
-    <p-dialog [(visible)]="visible"
+    <p-dialog [(visible)]="visible" width="100%"
+        [responsive]="true" [maximizable]="true" [dismissableMask]="true" [draggable]="true" [resizable]="false" [blockScroll]="true"
         header="Document {{document.position}} of {{page.total}}">
-        Document...
+
+        <ia-document-view [document]="document" [queryModel]="queryModel" [corpus]="document.corpus" [documentTabIndex]="0"></ia-document-view>
+
         <ng-template pTemplate="footer">
             <div class="columns" style="text-align:left">
                 <div class="column">
@@ -12,8 +15,8 @@
                         <span class="icon"><fa-icon [icon]="faArrowLeft">previous</fa-icon></span>
                     </a>
                 </div>
-                <!-- <div class="column" style="text-align:center">
-                    <a [routerLink]="['/document', corpus.name, viewDocument.id]"
+                <div class="column" style="text-align:center">
+                    <a [routerLink]="documentPageLink"
                         iaBalloon="view this document on its own page" autofocus
                         tabindex="0">
                         <span class="icon">
@@ -22,7 +25,8 @@
                         <span>Link</span>
                     </a>
                     &nbsp;
-                    <a *ngIf="viewDocument.hasContext" [routerLink]="['/search', corpus.name]" [queryParams]="viewDocument.contextQueryParams"
+                    <a *ngIf="document.hasContext"
+                        [routerLink]="['/search', document.corpus.name]" [queryParams]="document.contextQueryParams"
                         iaBalloon="view all documents from this {{contextDisplayName}}"
                         tabindex="0">
                         <span class="icon">
@@ -30,7 +34,7 @@
                         </span>
                         <span>View {{contextDisplayName}}</span>
                     </a>
-                </div> -->
+                </div>
                 <div class="column" style="text-align:right">
                     <a *ngIf="document.position < page.documents.length - 1"
                         iaBalloon="view next document" iaBalloonPosition="left"
@@ -43,13 +47,3 @@
         </ng-template>
     </p-dialog>
 </ng-container>
-
-
-<!-- <p-dialog *ngIf="viewDocument$ | async as viewDocument" [visible]="true" width="100%"
-    [modal]="true" [responsive]="true" [maximizable]="true" [dismissableMask]="true" [draggable]="true" [resizable]="false" [blockScroll]="true"
-    header="Document {{viewDocument.position}} of {{totalResults}}">
-    <ia-document-view [document]="viewDocument" [queryModel]="queryModel" [corpus]="corpus" [documentTabIndex]="documentTabIndex"></ia-document-view>
-    <ng-template pTemplate="footer">
-        </div>
-    </ng-template>
-</p-dialog> -->

--- a/frontend/src/app/document/document-popup/document-popup.component.spec.ts
+++ b/frontend/src/app/document/document-popup/document-popup.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DocumentPopupComponent } from './document-popup.component';
+
+describe('DocumentPopupComponent', () => {
+    let component: DocumentPopupComponent;
+    let fixture: ComponentFixture<DocumentPopupComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [DocumentPopupComponent]
+        })
+            .compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(DocumentPopupComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+});

--- a/frontend/src/app/document/document-popup/document-popup.component.ts
+++ b/frontend/src/app/document/document-popup/document-popup.component.ts
@@ -1,15 +1,25 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { DocumentPage } from '../../models/results';
+import { filter } from 'rxjs/operators';
+import * as _ from 'lodash';
 
 @Component({
     selector: 'ia-document-popup',
     templateUrl: './document-popup.component.html',
     styleUrls: ['./document-popup.component.scss']
 })
-export class DocumentPopupComponent implements OnInit {
+export class DocumentPopupComponent implements OnChanges {
+    @Input() page: DocumentPage;
 
-    constructor() { }
+    visible = true;
 
-    ngOnInit(): void {
+    ngOnChanges(changes: SimpleChanges): void {
+        if (changes.page) {
+            this.page.focus$.pipe(
+                filter(focus => !!focus),
+            ).subscribe(() =>
+                this.visible = true
+            );
+        }
     }
-
 }

--- a/frontend/src/app/document/document-popup/document-popup.component.ts
+++ b/frontend/src/app/document/document-popup/document-popup.component.ts
@@ -2,7 +2,8 @@ import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { DocumentPage } from '../../models/results';
 import { filter } from 'rxjs/operators';
 import * as _ from 'lodash';
-import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
+import { faArrowLeft, faArrowRight, faBookOpen, faLink } from '@fortawesome/free-solid-svg-icons';
+import { FoundDocument, QueryModel } from '../../models';
 
 @Component({
     selector: 'ia-document-popup',
@@ -11,11 +12,30 @@ import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
 })
 export class DocumentPopupComponent implements OnChanges {
     @Input() page: DocumentPage;
+    @Input() queryModel: QueryModel;
 
     visible = true;
 
     faArrowLeft = faArrowLeft;
     faArrowRight = faArrowRight;
+    linkIcon = faLink;
+    contextIcon = faBookOpen;
+
+    get documentPageLink(): string[] {
+        if (this.focusedDocument) {
+            return ['/document', this.focusedDocument.corpus.name, this.focusedDocument.id];
+        }
+    }
+
+    get contextDisplayName(): string {
+        if (this.focusedDocument.corpus.documentContext) {
+            return this.focusedDocument.corpus.documentContext.displayName;
+        }
+    }
+
+    private get focusedDocument(): FoundDocument {
+        return this.page?.focus$.value;
+    }
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.page) {

--- a/frontend/src/app/document/document-popup/document-popup.component.ts
+++ b/frontend/src/app/document/document-popup/document-popup.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { DocumentPage } from '../../models/page-results';
+import { DocumentPage } from '../../models/document-page';
 import { filter } from 'rxjs/operators';
 import * as _ from 'lodash';
 import { faArrowLeft, faArrowRight, faBookOpen, faLink } from '@fortawesome/free-solid-svg-icons';

--- a/frontend/src/app/document/document-popup/document-popup.component.ts
+++ b/frontend/src/app/document/document-popup/document-popup.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { DocumentPage } from '../../models/results';
 import { filter } from 'rxjs/operators';
 import * as _ from 'lodash';
+import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
     selector: 'ia-document-popup',
@@ -12,6 +13,9 @@ export class DocumentPopupComponent implements OnChanges {
     @Input() page: DocumentPage;
 
     visible = true;
+
+    faArrowLeft = faArrowLeft;
+    faArrowRight = faArrowRight;
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.page) {

--- a/frontend/src/app/document/document-popup/document-popup.component.ts
+++ b/frontend/src/app/document/document-popup/document-popup.component.ts
@@ -1,16 +1,17 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { DocumentPage, DocumentView } from '../../models/document-page';
-import { filter } from 'rxjs/operators';
+import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { DocumentFocus, DocumentPage, DocumentView } from '../../models/document-page';
+import { filter, takeUntil } from 'rxjs/operators';
 import * as _ from 'lodash';
 import { faArrowLeft, faArrowRight, faBookOpen, faLink } from '@fortawesome/free-solid-svg-icons';
 import { FoundDocument, QueryModel } from '../../models';
+import { Subject } from 'rxjs';
 
 @Component({
     selector: 'ia-document-popup',
     templateUrl: './document-popup.component.html',
     styleUrls: ['./document-popup.component.scss']
 })
-export class DocumentPopupComponent implements OnChanges {
+export class DocumentPopupComponent implements OnChanges, OnDestroy {
     @Input() page: DocumentPage;
     @Input() queryModel: QueryModel;
 
@@ -23,6 +24,8 @@ export class DocumentPopupComponent implements OnChanges {
     faArrowRight = faArrowRight;
     linkIcon = faLink;
     contextIcon = faBookOpen;
+
+    private refresh$ = new Subject<void>();
 
     get documentPageLink(): string[] {
         if (this.document) {
@@ -38,13 +41,27 @@ export class DocumentPopupComponent implements OnChanges {
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.page) {
+            this.refresh$.next();
+
             this.page.focus$.pipe(
-                filter(focus => !!focus),
-            ).subscribe(focus => {
-                this.document = focus.document;
-                this.view = focus.view;
-                this.visible = true;
-            });
+                takeUntil(this.refresh$),
+            ).subscribe(this.focusUpdate.bind(this));
+        }
+    }
+
+    ngOnDestroy(): void {
+        this.refresh$.next();
+        this.refresh$.complete();
+    }
+
+    focusUpdate(focus?: DocumentFocus): void {
+        if (focus) {
+            this.document = focus.document;
+            this.view = focus.view;
+            this.visible = true;
+        } else {
+            this.document = undefined;
+            this.visible = false;
         }
     }
 }

--- a/frontend/src/app/document/document-popup/document-popup.component.ts
+++ b/frontend/src/app/document/document-popup/document-popup.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { DocumentPage } from '../../models/results';
+import { DocumentPage } from '../../models/page-results';
 import { filter } from 'rxjs/operators';
 import * as _ from 'lodash';
 import { faArrowLeft, faArrowRight, faBookOpen, faLink } from '@fortawesome/free-solid-svg-icons';

--- a/frontend/src/app/document/document-popup/document-popup.component.ts
+++ b/frontend/src/app/document/document-popup/document-popup.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { DocumentPage } from '../../models/document-page';
+import { DocumentPage, DocumentView } from '../../models/document-page';
 import { filter } from 'rxjs/operators';
 import * as _ from 'lodash';
 import { faArrowLeft, faArrowRight, faBookOpen, faLink } from '@fortawesome/free-solid-svg-icons';
@@ -14,6 +14,9 @@ export class DocumentPopupComponent implements OnChanges {
     @Input() page: DocumentPage;
     @Input() queryModel: QueryModel;
 
+    document: FoundDocument;
+    view: DocumentView;
+
     visible = true;
 
     faArrowLeft = faArrowLeft;
@@ -22,28 +25,26 @@ export class DocumentPopupComponent implements OnChanges {
     contextIcon = faBookOpen;
 
     get documentPageLink(): string[] {
-        if (this.focusedDocument) {
-            return ['/document', this.focusedDocument.corpus.name, this.focusedDocument.id];
+        if (this.document) {
+            return ['/document', this.document.corpus.name, this.document.id];
         }
     }
 
     get contextDisplayName(): string {
-        if (this.focusedDocument.corpus.documentContext) {
-            return this.focusedDocument.corpus.documentContext.displayName;
+        if (this.document.corpus.documentContext) {
+            return this.document.corpus.documentContext.displayName;
         }
-    }
-
-    private get focusedDocument(): FoundDocument {
-        return this.page?.focus$.value;
     }
 
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.page) {
             this.page.focus$.pipe(
                 filter(focus => !!focus),
-            ).subscribe(() =>
-                this.visible = true
-            );
+            ).subscribe(focus => {
+                this.document = focus.document;
+                this.view = focus.view;
+                this.visible = true;
+            });
         }
     }
 }

--- a/frontend/src/app/document/document-popup/document-popup.component.ts
+++ b/frontend/src/app/document/document-popup/document-popup.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'ia-document-popup',
+    templateUrl: './document-popup.component.html',
+    styleUrls: ['./document-popup.component.scss']
+})
+export class DocumentPopupComponent implements OnInit {
+
+    constructor() { }
+
+    ngOnInit(): void {
+    }
+
+}

--- a/frontend/src/app/document/document.module.ts
+++ b/frontend/src/app/document/document.module.ts
@@ -6,6 +6,7 @@ import { ImageViewModule } from '../image-view/image-view.module';
 import { SearchRelevanceComponent } from '../search';
 import { CorpusModule } from '../corpus-header/corpus.module';
 import { TagModule } from '../tag/tag.module';
+import { DocumentPopupComponent } from './document-popup/document-popup.component';
 
 
 
@@ -14,6 +15,7 @@ import { TagModule } from '../tag/tag.module';
         DocumentViewComponent,
         DocumentPageComponent,
         SearchRelevanceComponent,
+        DocumentPopupComponent,
     ],
     imports: [
         CorpusModule,

--- a/frontend/src/app/document/document.module.ts
+++ b/frontend/src/app/document/document.module.ts
@@ -7,6 +7,7 @@ import { SearchRelevanceComponent } from '../search';
 import { CorpusModule } from '../corpus-header/corpus.module';
 import { TagModule } from '../tag/tag.module';
 import { DocumentPopupComponent } from './document-popup/document-popup.component';
+import { DialogModule } from 'primeng/dialog';
 
 
 
@@ -18,6 +19,7 @@ import { DocumentPopupComponent } from './document-popup/document-popup.componen
         DocumentPopupComponent,
     ],
     imports: [
+        DialogModule,
         CorpusModule,
         SharedModule,
         ImageViewModule,
@@ -25,6 +27,7 @@ import { DocumentPopupComponent } from './document-popup/document-popup.componen
     ], exports: [
         DocumentViewComponent,
         DocumentPageComponent,
+        DocumentPopupComponent,
         SearchRelevanceComponent,
     ]
 })

--- a/frontend/src/app/models/document-page.ts
+++ b/frontend/src/app/models/document-page.ts
@@ -1,0 +1,45 @@
+import { BehaviorSubject } from 'rxjs';
+import { FoundDocument } from './found-document';
+import { CorpusField } from './corpus';
+import * as _ from 'lodash';
+
+
+export class DocumentPage {
+    focus$ = new BehaviorSubject<FoundDocument>(undefined);
+
+    constructor(
+        public documents: FoundDocument[],
+        public total: number,
+        public fields?: CorpusField[]
+    ) {
+        this.documents.forEach((d, i) => d.position = i + 1);
+    }
+
+    focus(document: FoundDocument) {
+        this.focus$.next(document);
+    }
+
+    focusNext() {
+        this.focusShift(1);
+    }
+
+    focusPrevious() {
+        this.focusShift(-1);
+    }
+
+    blur() {
+        this.focus$.next(undefined);
+    }
+
+    private focusShift(shift: number) {
+        const document = this.focus$.value;
+        if (document) {
+            this.focusPosition(document.position + shift);
+        }
+    }
+
+    private focusPosition(position: number) {
+        const index = _.clamp(position - 1, 0, this.documents.length - 1);
+        this.focus(this.documents[index]);
+    }
+}

--- a/frontend/src/app/models/document-page.ts
+++ b/frontend/src/app/models/document-page.ts
@@ -37,10 +37,12 @@ export class DocumentPage {
         this.focus$.next(undefined);
     }
 
+    /** set focus to a position relative to the given document */
     private focusShift(document: FoundDocument, shift: number) {
         this.focusPosition(document.position + shift);
     }
 
+    /** focus on the document at the given position in the page */
     private focusPosition(position: number) {
         const index = _.clamp(position - 1, 0, this.documents.length - 1);
         this.focus(this.documents[index]);

--- a/frontend/src/app/models/document-page.ts
+++ b/frontend/src/app/models/document-page.ts
@@ -1,11 +1,17 @@
-import { BehaviorSubject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { FoundDocument } from './found-document';
 import { CorpusField } from './corpus';
 import * as _ from 'lodash';
 
+export type DocumentView = 'content' | 'scan';
+
+export interface DocumentFocus {
+    document: FoundDocument;
+    view: DocumentView;
+}
 
 export class DocumentPage {
-    focus$ = new BehaviorSubject<FoundDocument>(undefined);
+    focus$ = new Subject<DocumentFocus>();
 
     constructor(
         public documents: FoundDocument[],
@@ -15,27 +21,24 @@ export class DocumentPage {
         this.documents.forEach((d, i) => d.position = i + 1);
     }
 
-    focus(document: FoundDocument) {
-        this.focus$.next(document);
+    focus(document: FoundDocument, view: DocumentView = 'content') {
+        this.focus$.next({ document, view });
     }
 
-    focusNext() {
-        this.focusShift(1);
+    focusNext(document: FoundDocument) {
+        this.focusShift(document, 1);
     }
 
-    focusPrevious() {
-        this.focusShift(-1);
+    focusPrevious(document: FoundDocument) {
+        this.focusShift(document, -1);
     }
 
     blur() {
         this.focus$.next(undefined);
     }
 
-    private focusShift(shift: number) {
-        const document = this.focus$.value;
-        if (document) {
-            this.focusPosition(document.position + shift);
-        }
+    private focusShift(document: FoundDocument, shift: number) {
+        this.focusPosition(document.position + shift);
     }
 
     private focusPosition(position: number) {

--- a/frontend/src/app/models/page-results.ts
+++ b/frontend/src/app/models/page-results.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, Observable, combineLatest, from } from 'rxjs';
+import { BehaviorSubject, Observable, combineLatest, from, of } from 'rxjs';
 import { QueryModel } from './query';
 import { map } from 'rxjs/operators';
 import { FoundDocument } from './found-document';
@@ -70,7 +70,7 @@ export class PageResults extends Results<PageResultsParameters, DocumentPage> {
             size: RESULTS_PER_PAGE,
         });
         this.from$ = this.parameters$.pipe(
-            map(parameters => parameters.from)
+            map(parameters => parameters.from + 1)
         );
         this.to$ = combineLatest([this.parameters$, this.result$]).pipe(
             map(this.highestDocumentIndex)

--- a/frontend/src/app/models/page-results.ts
+++ b/frontend/src/app/models/page-results.ts
@@ -1,0 +1,90 @@
+import { BehaviorSubject, Observable, combineLatest, from } from 'rxjs';
+import { QueryModel } from './query';
+import { map } from 'rxjs/operators';
+import { EsQuery } from './elasticsearch';
+import { FoundDocument } from './found-document';
+import { SearchService } from '../services';
+import { SearchResults } from './search-results';
+import { CorpusField } from './corpus';
+import * as _ from 'lodash';
+import { Results } from './results';
+
+
+export interface PageResultsParameters {
+    from: number;
+    size: number;
+}
+;
+
+export class DocumentPage {
+    focus$ = new BehaviorSubject<FoundDocument>(undefined);
+
+    constructor(
+        public documents: FoundDocument[],
+        public total: number,
+        public fields?: CorpusField[]
+    ) {
+        this.documents.forEach((d, i) => d.position = i + 1);
+    }
+
+    focus(document: FoundDocument) {
+        this.focus$.next(document);
+    }
+
+    focusNext() {
+        this.focusShift(1);
+    }
+
+    focusPrevious() {
+        this.focusShift(-1);
+    }
+
+    blur() {
+        this.focus$.next(undefined);
+    }
+
+    private focusShift(shift: number) {
+        const document = this.focus$.value;
+        if (document) {
+            this.focusPosition(document.position + shift);
+        }
+    }
+
+    private focusPosition(position: number) {
+        const index = _.clamp(position - 1, 0, this.documents.length - 1);
+        this.focus(this.documents[index]);
+    }
+}
+const parseResults = (results: SearchResults): DocumentPage => new DocumentPage(results.documents, results.total.value, results.fields);
+
+export class PageResults extends Results<PageResultsParameters, DocumentPage> {
+    from$: Observable<number>;
+    to$: Observable<number>;
+
+    constructor(
+        private searchService: SearchService,
+        query: QueryModel,
+        params: PageResultsParameters
+    ) {
+        super(query, params);
+        this.from$ = this.parameters$.pipe(
+            map(parameters => parameters.from)
+        );
+        this.to$ = combineLatest([this.parameters$, this.result$]).pipe(
+            map(this.highestDocumentIndex)
+        );
+    }
+
+    fetch([esQuery, params]: [EsQuery, PageResultsParameters]): Observable<DocumentPage> {
+        return from(this.searchService.loadResults(
+            this.query, params.from, params.size
+        )).pipe(
+            map(parseResults)
+        );
+    }
+
+    private highestDocumentIndex([parameters, result]: [PageResultsParameters, DocumentPage]) {
+        const limit = parameters.from + parameters.size;
+        return _.min([limit, result.total]);
+    }
+}

--- a/frontend/src/app/models/page-results.ts
+++ b/frontend/src/app/models/page-results.ts
@@ -7,14 +7,15 @@ import { SearchService } from '../services';
 import { SearchResults } from './search-results';
 import { CorpusField } from './corpus';
 import * as _ from 'lodash';
-import { Results } from './results';
+import { HasEsQuery, Results } from './results';
 
 
-export interface PageResultsParameters {
+export interface PageParameters {
     from: number;
     size: number;
 }
-;
+
+export type PageResultsParameters = HasEsQuery & PageParameters;
 
 export class DocumentPage {
     focus$ = new BehaviorSubject<FoundDocument>(undefined);
@@ -75,7 +76,15 @@ export class PageResults extends Results<PageResultsParameters, DocumentPage> {
         );
     }
 
-    fetch([esQuery, params]: [EsQuery, PageResultsParameters]): Observable<DocumentPage> {
+    setEsQuery(esQuery: EsQuery, currentParameters: PageResultsParameters): PageResultsParameters {
+        return {
+            esQuery,
+            from: 0,
+            size: currentParameters.size
+        };
+    }
+
+    fetch(params: PageResultsParameters): Observable<DocumentPage> {
         return from(this.searchService.loadResults(
             this.query, params.from, params.size
         )).pipe(

--- a/frontend/src/app/models/page-results.ts
+++ b/frontend/src/app/models/page-results.ts
@@ -1,12 +1,10 @@
-import { BehaviorSubject, Observable, combineLatest, from, of } from 'rxjs';
+import { Observable, combineLatest, from, of } from 'rxjs';
 import { QueryModel } from './query';
 import { map } from 'rxjs/operators';
-import { FoundDocument } from './found-document';
 import { SearchService } from '../services';
 import { SearchResults } from './search-results';
-import { CorpusField } from './corpus';
-import * as _ from 'lodash';
 import { Results } from './results';
+import { DocumentPage } from './document-page';
 
 const RESULTS_PER_PAGE = 20;
 
@@ -15,45 +13,6 @@ export interface PageResultsParameters {
     size: number;
 }
 
-export class DocumentPage {
-    focus$ = new BehaviorSubject<FoundDocument>(undefined);
-
-    constructor(
-        public documents: FoundDocument[],
-        public total: number,
-        public fields?: CorpusField[]
-    ) {
-        this.documents.forEach((d, i) => d.position = i + 1);
-    }
-
-    focus(document: FoundDocument) {
-        this.focus$.next(document);
-    }
-
-    focusNext() {
-        this.focusShift(1);
-    }
-
-    focusPrevious() {
-        this.focusShift(-1);
-    }
-
-    blur() {
-        this.focus$.next(undefined);
-    }
-
-    private focusShift(shift: number) {
-        const document = this.focus$.value;
-        if (document) {
-            this.focusPosition(document.position + shift);
-        }
-    }
-
-    private focusPosition(position: number) {
-        const index = _.clamp(position - 1, 0, this.documents.length - 1);
-        this.focus(this.documents[index]);
-    }
-}
 const parseResults = (results: SearchResults): DocumentPage =>
     new DocumentPage(results.documents, results.total.value, results.fields);
 

--- a/frontend/src/app/models/page-results.ts
+++ b/frontend/src/app/models/page-results.ts
@@ -13,7 +13,7 @@ export interface PageResultsParameters {
     size: number;
 }
 
-const parseResults = (results: SearchResults): DocumentPage =>
+const resultsToPage = (results: SearchResults): DocumentPage =>
     new DocumentPage(results.documents, results.total.value, results.fields);
 
 export class PageResults extends Results<PageResultsParameters, DocumentPage> {
@@ -36,6 +36,7 @@ export class PageResults extends Results<PageResultsParameters, DocumentPage> {
         );
     }
 
+    /** Parameters to re-assign when the query model is updated. */
     assignOnQueryUpdate(): Partial<PageResultsParameters> {
         return {
             from: 0
@@ -46,7 +47,7 @@ export class PageResults extends Results<PageResultsParameters, DocumentPage> {
         return from(this.searchService.loadResults(
             this.query, params.from, params.size
         )).pipe(
-            map(parseResults)
+            map(resultsToPage)
         );
     }
 

--- a/frontend/src/app/models/page-results.ts
+++ b/frontend/src/app/models/page-results.ts
@@ -6,7 +6,7 @@ import { SearchResults } from './search-results';
 import { Results } from './results';
 import { DocumentPage } from './document-page';
 
-const RESULTS_PER_PAGE = 20;
+export const RESULTS_PER_PAGE = 20;
 
 export interface PageResultsParameters {
     from: number;

--- a/frontend/src/app/models/query.spec.ts
+++ b/frontend/src/app/models/query.spec.ts
@@ -4,7 +4,6 @@ import { QueryModel } from './query';
 import { SearchFilter } from './field-filter';
 import { convertToParamMap } from '@angular/router';
 import * as _ from 'lodash';
-import { EsQuery } from './elasticsearch';
 
 const corpus: Corpus = {
     name: 'mock-corpus',
@@ -208,32 +207,5 @@ describe('QueryModel', () => {
         filter.setToValue(new Date('Jan 2 1850'));
         expect(query.filterForField(mockFieldDate).currentData.min).toEqual(new Date('Jan 2 1850'));
         expect(clone.filterForField(mockFieldDate).currentData.min).toEqual(new Date('Jan 1 1850'));
-    });
-
-    it('should present an esQuery observable', async () => {
-        const q1: EsQuery = {
-            query: {
-                match_all: {}
-            }
-        };
-        expect(query.esQuery$.value).toEqual(q1);
-
-        query.setQueryText('test');
-
-        const q2: EsQuery = {
-            query: {
-                bool: {
-                    must: {
-                        simple_query_string: {
-                            query: 'test',
-                            lenient: true,
-                            default_operator: 'or',
-                        }
-                    },
-                    filter: [],
-                }
-            }
-        };
-        expect(query.esQuery$.value).toEqual(q2);
     });
 });

--- a/frontend/src/app/models/query.spec.ts
+++ b/frontend/src/app/models/query.spec.ts
@@ -1,10 +1,10 @@
 import { mockField2, mockFieldDate, mockFieldMultipleChoice } from '../../mock-data/corpus';
 import { Corpus, } from './corpus';
 import { QueryModel } from './query';
-import { DateFilter, MultipleChoiceFilter, SearchFilter } from './field-filter';
+import { SearchFilter } from './field-filter';
 import { convertToParamMap } from '@angular/router';
 import * as _ from 'lodash';
-import { paramsHaveChanged } from '../utils/params';
+import { EsQuery } from './elasticsearch';
 
 const corpus: Corpus = {
     name: 'mock-corpus',
@@ -208,5 +208,32 @@ describe('QueryModel', () => {
         filter.setToValue(new Date('Jan 2 1850'));
         expect(query.filterForField(mockFieldDate).currentData.min).toEqual(new Date('Jan 2 1850'));
         expect(clone.filterForField(mockFieldDate).currentData.min).toEqual(new Date('Jan 1 1850'));
+    });
+
+    it('should present an esQuery observable', async () => {
+        const q1: EsQuery = {
+            query: {
+                match_all: {}
+            }
+        };
+        expect(query.esQuery$.value).toEqual(q1);
+
+        query.setQueryText('test');
+
+        const q2: EsQuery = {
+            query: {
+                bool: {
+                    must: {
+                        simple_query_string: {
+                            query: 'test',
+                            lenient: true,
+                            default_operator: 'or',
+                        }
+                    },
+                    filter: [],
+                }
+            }
+        };
+        expect(query.esQuery$.value).toEqual(q2);
     });
 });

--- a/frontend/src/app/models/query.ts
+++ b/frontend/src/app/models/query.ts
@@ -1,6 +1,5 @@
 import { convertToParamMap, ParamMap } from '@angular/router';
-import * as _ from 'lodash';
-import { BehaviorSubject, combineLatest, Observable, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { Corpus, CorpusField, EsFilter, SortBy, SortConfiguration, SortDirection, } from '../models/index';
 import { EsQuery } from '../models';
 import { combineSearchClauseAndFilters, makeHighlightSpecification } from '../utils/es-query';
@@ -9,7 +8,6 @@ import {
     queryFromParams, searchFieldsFromParams
 } from '../utils/params';
 import { SearchFilter } from './field-filter';
-import { map } from 'rxjs/operators';
 
 /** This is the query object as it is saved in the database.*/
 export class QueryDb {
@@ -81,8 +79,6 @@ export class QueryModel {
 
 	update = new Subject<void>();
 
-    esQuery$: BehaviorSubject<EsQuery>;
-
     constructor(corpus: Corpus, params?: ParamMap) {
 		this.corpus = corpus;
         this.filters = this.corpus.fields.map(field => field.makeSearchFilter());
@@ -91,9 +87,6 @@ export class QueryModel {
             this.setFromParams(params);
         }
         this.subscribeToFilterUpdates();
-
-        this.esQuery$ = new BehaviorSubject(this.toEsQuery());
-        this.update.subscribe(() => this.esQuery$.next(this.toEsQuery()));
     }
 
     get activeFilters() {

--- a/frontend/src/app/models/results.ts
+++ b/frontend/src/app/models/results.ts
@@ -1,0 +1,13 @@
+import { BehaviorSubject, Observable } from 'rxjs';
+import { QueryModel } from './query';
+
+abstract class Results<Parameters, Result> {
+    parameters$: BehaviorSubject<Parameters>;
+    result$: Observable<Result>;
+
+    constructor(
+        public query: QueryModel,
+        initialParameters: Parameters,
+    ) {
+    }
+}

--- a/frontend/src/app/models/results.ts
+++ b/frontend/src/app/models/results.ts
@@ -1,5 +1,11 @@
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, combineLatest, from } from 'rxjs';
 import { QueryModel } from './query';
+import { map, mergeMap } from 'rxjs/operators';
+import { EsQuery } from './elasticsearch';
+import { SortBy, SortDirection } from './sort';
+import { FoundDocument } from './found-document';
+import { SearchService } from '../services';
+import { SearchResults } from './search-results';
 
 abstract class Results<Parameters, Result> {
     parameters$: BehaviorSubject<Parameters>;
@@ -9,5 +15,53 @@ abstract class Results<Parameters, Result> {
         public query: QueryModel,
         initialParameters: Parameters,
     ) {
+        this.parameters$ = new BehaviorSubject(initialParameters);
+        this.result$ = combineLatest([query.esQuery$, this.parameters$]).pipe(
+            mergeMap(this.fetch)
+        );
+    }
+
+    setParameters(parameters: Parameters) {
+        this.parameters$.next(parameters);
+    }
+
+    abstract fetch(data: [EsQuery, Parameters]): Observable<Result>;
+}
+
+interface DocumentResultsParameters {
+    sortBy: SortBy;
+    sortDirection: SortDirection;
+    highlight?: number;
+}
+
+export interface PageResultsParameters {
+    from: number;
+    size: number;
+};
+
+export class DocumentPage {
+    focus$ = new BehaviorSubject<FoundDocument>(undefined);
+
+    constructor(public documents: FoundDocument[], public total: number) { }
+}
+
+const parseResults = (results: SearchResults): DocumentPage =>
+    new DocumentPage(results.documents, results.total.value);
+
+export class PageResults extends Results<PageResultsParameters, DocumentPage> {
+    constructor(
+        private searchService: SearchService,
+        query: QueryModel,
+        params: PageResultsParameters,
+    ) {
+        super(query, params);
+    }
+
+    fetch([esQuery, params]: [EsQuery, PageResultsParameters]): Observable<DocumentPage> {
+        return from(this.searchService.loadResults(
+            this.query, params.from, params.size
+        )).pipe(
+            map(parseResults)
+        );
     }
 }

--- a/frontend/src/app/models/results.ts
+++ b/frontend/src/app/models/results.ts
@@ -7,6 +7,7 @@ import { FoundDocument } from './found-document';
 import { SearchService } from '../services';
 import { SearchResults } from './search-results';
 import { CorpusField } from './corpus';
+import * as _ from 'lodash';
 
 abstract class Results<Parameters, Result> {
     parameters$: BehaviorSubject<Parameters>;
@@ -47,14 +48,36 @@ export class DocumentPage {
         public documents: FoundDocument[],
         public total: number,
         public fields?: CorpusField[]
-    ) { }
+    ) {
+        this.documents.forEach((d, i) => d.position = i + 1);
+    }
 
     focus(document: FoundDocument) {
         this.focus$.next(document);
     }
 
+    focusNext() {
+        this.focusShift(1);
+    }
+
+    focusPrevious() {
+        this.focusShift(-1);
+    }
+
     blur() {
         this.focus$.next(undefined);
+    }
+
+    private focusShift(shift: number) {
+        const document = this.focus$.value;
+        if (document) {
+            this.focusPosition(document.position + shift);
+        }
+    }
+
+    private focusPosition(position: number) {
+        const index = _.clamp(position - 1, 0, this.documents.length - 1);
+        this.focus(this.documents[index]);
     }
 }
 

--- a/frontend/src/app/models/results.ts
+++ b/frontend/src/app/models/results.ts
@@ -1,7 +1,6 @@
 import { BehaviorSubject, Observable, merge, of } from 'rxjs';
 import { QueryModel } from './query';
-import { catchError, map, mergeMap, tap } from 'rxjs/operators';
-import { EsQuery } from './elasticsearch';
+import { catchError, map, mergeMap, share, shareReplay, tap } from 'rxjs/operators';
 import * as _ from 'lodash';
 
 
@@ -26,6 +25,7 @@ export abstract class Results<Parameters, Result> {
                 this.error$.next(err);
                 return of(undefined);
             }),
+            shareReplay(1),
         );
         this.loading$ = this.makeLoadingObservable();
     }

--- a/frontend/src/app/models/results.ts
+++ b/frontend/src/app/models/results.ts
@@ -1,15 +1,10 @@
-import { BehaviorSubject, Observable, Subject, combineLatest, from, merge, of } from 'rxjs';
+import { BehaviorSubject, Observable, combineLatest, merge, of } from 'rxjs';
 import { QueryModel } from './query';
-import { catchError, map, mergeMap, share, tap } from 'rxjs/operators';
+import { catchError, map, mergeMap } from 'rxjs/operators';
 import { EsQuery } from './elasticsearch';
-import { SortBy, SortDirection } from './sort';
-import { FoundDocument } from './found-document';
-import { SearchService } from '../services';
-import { SearchResults } from './search-results';
-import { CorpusField } from './corpus';
-import * as _ from 'lodash';
 
-abstract class Results<Parameters, Result> {
+
+export abstract class Results<Parameters, Result> {
     parameters$: BehaviorSubject<Parameters>;
     result$: Observable<Result>;
     error$: BehaviorSubject<any>;
@@ -54,88 +49,4 @@ abstract class Results<Parameters, Result> {
 
 }
 
-interface DocumentResultsParameters {
-    sortBy: SortBy;
-    sortDirection: SortDirection;
-    highlight?: number;
-}
 
-export interface PageResultsParameters {
-    from: number;
-    size: number;
-};
-
-export class DocumentPage {
-    focus$ = new BehaviorSubject<FoundDocument>(undefined);
-
-    constructor(
-        public documents: FoundDocument[],
-        public total: number,
-        public fields?: CorpusField[]
-    ) {
-        this.documents.forEach((d, i) => d.position = i + 1);
-    }
-
-    focus(document: FoundDocument) {
-        this.focus$.next(document);
-    }
-
-    focusNext() {
-        this.focusShift(1);
-    }
-
-    focusPrevious() {
-        this.focusShift(-1);
-    }
-
-    blur() {
-        this.focus$.next(undefined);
-    }
-
-    private focusShift(shift: number) {
-        const document = this.focus$.value;
-        if (document) {
-            this.focusPosition(document.position + shift);
-        }
-    }
-
-    private focusPosition(position: number) {
-        const index = _.clamp(position - 1, 0, this.documents.length - 1);
-        this.focus(this.documents[index]);
-    }
-}
-
-const parseResults = (results: SearchResults): DocumentPage =>
-    new DocumentPage(results.documents, results.total.value, results.fields);
-
-export class PageResults extends Results<PageResultsParameters, DocumentPage> {
-    from$: Observable<number>;
-    to$: Observable<number>;
-
-    constructor(
-        private searchService: SearchService,
-        query: QueryModel,
-        params: PageResultsParameters,
-    ) {
-        super(query, params);
-        this.from$ = this.parameters$.pipe(
-            map(parameters => parameters.from)
-        );
-        this.to$ = combineLatest([this.parameters$, this.result$]).pipe(
-            map(this.highestDocumentIndex)
-        );
-    }
-
-    fetch([esQuery, params]: [EsQuery, PageResultsParameters]): Observable<DocumentPage> {
-        return from(this.searchService.loadResults(
-            this.query, params.from, params.size
-        )).pipe(
-            map(parseResults)
-        );
-    }
-
-    private highestDocumentIndex([parameters, result]: [PageResultsParameters, DocumentPage]) {
-        const limit = parameters.from + parameters.size;
-        return _.min([limit, result.total]);
-    }
-}

--- a/frontend/src/app/search/pagination/pagination.component.ts
+++ b/frontend/src/app/search/pagination/pagination.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 
-import { PageResultsParameters } from '../../models/results';
+import { PageResultsParameters } from '../../models/page-results';
 
 @Component({
   selector: 'ia-pagination',

--- a/frontend/src/app/search/pagination/pagination.component.ts
+++ b/frontend/src/app/search/pagination/pagination.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 
-import { PageResultsParameters } from '../../models/page-results';
+import { PageParameters } from '../../models/page-results';
 
 @Component({
   selector: 'ia-pagination',
@@ -17,7 +17,7 @@ export class PaginationComponent implements OnChanges {
     public currentPage: number;
 
     @Output('parameters')
-    public loadResultsEvent = new EventEmitter<PageResultsParameters>();
+    public loadResultsEvent = new EventEmitter<PageParameters>();
 
 
     constructor() { }

--- a/frontend/src/app/search/pagination/pagination.component.ts
+++ b/frontend/src/app/search/pagination/pagination.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 
-import { SearchParameters } from '../../models/index';
+import { PageResultsParameters } from '../../models/results';
 
 @Component({
   selector: 'ia-pagination',
@@ -16,8 +16,8 @@ export class PaginationComponent implements OnChanges {
     public currentPages: number[];
     public currentPage: number;
 
-    @Output('loadResults')
-    public loadResultsEvent = new EventEmitter<SearchParameters>();
+    @Output('parameters')
+    public loadResultsEvent = new EventEmitter<PageResultsParameters>();
 
 
     constructor() { }

--- a/frontend/src/app/search/pagination/pagination.component.ts
+++ b/frontend/src/app/search/pagination/pagination.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
 
-import { PageParameters } from '../../models/page-results';
+import { PageResultsParameters } from '../../models/page-results';
 
 @Component({
   selector: 'ia-pagination',
@@ -17,7 +17,7 @@ export class PaginationComponent implements OnChanges {
     public currentPage: number;
 
     @Output('parameters')
-    public loadResultsEvent = new EventEmitter<PageParameters>();
+    public loadResultsEvent = new EventEmitter<PageResultsParameters>();
 
 
     constructor() { }

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -14,17 +14,6 @@
         </div>
 
         <div class="level">
-            <h2 class="subtitle" *ngIf="page.total <= 5">
-                {page.total, plural, =1 {1 hit} other {{{page.total}} hits}}
-            </h2>
-            <h2 class="subtitle" *ngIf="page.total > 5">
-                {{page.total}} results.
-                <!-- Showing results {{fromIndex+1}} - {{fromIndex+resultsPerPage > totalResults? totalResults : fromIndex+resultsPerPage}}: -->
-            </h2>
-            <ng-content *ngIf="!(queryText===null || queryText==='')" select="ia-highlight-selector"></ng-content>
-        </div>
-
-        <div class="level">
             <div class="level-left has-text-centered">
                 <div>
                     <p class="heading">Sort By</p>
@@ -57,7 +46,6 @@
                                         <td>
                                             <ng-container *ngFor="let highlight of document.highlight[field.name]">
                                                 <div ngPreserveWhitespaces style="word-break:break-word" [innerHtml]="highlight"></div>
-                                                 insert ellipsis [...] in between snippets or at the end of a single snippet
                                                 <hr *ngIf="highlight !== document.highlight[field.name][document.highlight[field.name].length-1]">
                                             </ng-container>
                                         </td>

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -6,7 +6,9 @@
             </h2>
             <h2 class="subtitle" *ngIf="page.total > 5">
                 {{page.total}} results.
-                <!-- Showing results {{fromIndex+1}} - {{fromIndex+resultsPerPage > totalResults? totalResults : fromIndex+resultsPerPage}}: -->
+                Showing results {{(pageResults.from$ | async) + 1}}
+                -
+                {{(pageResults.to$ | async)}}
             </h2>
             <ia-highlight-selector *ngIf="!!queryModel.queryText" [queryModel]="queryModel"></ia-highlight-selector>
         </div>
@@ -29,12 +31,12 @@
                     <ia-search-sorting [queryModel]="queryModel"></ia-search-sorting>
                 </div>
             </div>
-            <!-- <div class="level-right has-text-centered" *ngIf="results.total.value > resultsPerPage" >
+            <div class="level-right has-text-centered" *ngIf="page.total > resultsPerPage" >
                 <div>
                     <p class="heading">Pages</p>
-                    <ia-pagination [totalResults]="totalResults" [fromIndex]="fromIndex" (loadResults)=loadResults($event)></ia-pagination>
+                    <ia-pagination [totalResults]="page.total" [fromIndex]="pageResults.from$ | async" (parameters)="setParameters($event)"></ia-pagination>
                 </div>
-            </div> -->
+            </div>
         </div>
     </section>
 

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="pageResults?.result$ | async as page; else loading">
+<ng-container *ngIf="pageResults?.result$ | async as page; else noResult">
     <section class="section results-navigation" #resultsNavigation [ngClass]="{'is-scrolled-down': isScrolledDown}">
         <div class="level">
             <h2 class="subtitle" *ngIf="page.total <= 5">
@@ -40,7 +40,7 @@
         </div>
     </section>
 
-    <section *ngIf="page.documents.length; else noResults" aria-label="search results">
+    <section *ngIf="page.documents.length; else noHits" aria-label="search results">
         <div class="hits" [ngClass]="{'is-loading':isLoading}">
             <article *ngFor="let document of page.documents" class="document box">
                 <div class="columns">
@@ -90,14 +90,16 @@
     <ia-document-popup [page]="page" [queryModel]="queryModel"></ia-document-popup>
 </ng-container>
 
-<ng-template #loading>
-    <div class="is-loading" aria-label="loading results"></div>
-</ng-template>
-
-<ng-template #noResults>
+<ng-template #noHits>
     <section aria-label="search results">
         No results
     </section>
 </ng-template>
 
-<!-- <ia-error *ngIf="showError" [showError]="showError"></ia-error> -->
+<ng-template #noResult>
+    <ia-error *ngIf="error$ | async as error; else loading" [showError]="error"></ia-error>
+</ng-template>
+
+<ng-template #loading>
+    <div class="is-loading" aria-label="loading results"></div>
+</ng-template>

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -1,18 +1,18 @@
 <ng-container *ngIf="pageResults?.result$ | async as page; else noResult">
-    <section class="section results-navigation" #resultsNavigation [ngClass]="{'is-scrolled-down': isScrolledDown}">
-        <div class="level">
-            <h2 class="subtitle" *ngIf="page.total <= 5">
-                {page.total, plural, =1 {1 hit} other {{{page.total}} hits}}
-            </h2>
-            <h2 class="subtitle" *ngIf="page.total > 5">
-                {{page.total}} results.
-                Showing results {{pageResults.from$ | async}}
-                -
-                {{(pageResults.to$ | async)}}
-            </h2>
-            <ia-highlight-selector *ngIf="!!queryModel.queryText" [queryModel]="queryModel"></ia-highlight-selector>
-        </div>
+    <div class="level">
+        <h2 class="subtitle" *ngIf="page.total <= 5">
+            {page.total, plural, =1 {1 hit} other {{{page.total}} hits}}
+        </h2>
+        <h2 class="subtitle" *ngIf="page.total > 5">
+            {{page.total}} results.
+            Showing results {{pageResults.from$ | async}}
+            -
+            {{(pageResults.to$ | async)}}
+        </h2>
+        <ia-highlight-selector *ngIf="!!queryModel.queryText" [queryModel]="queryModel"></ia-highlight-selector>
+    </div>
 
+    <section class="section results-navigation" #resultsNavigation [ngClass]="{'is-scrolled-down': isScrolledDown}">
         <div class="level">
             <div class="level-left has-text-centered">
                 <div>

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -76,7 +76,7 @@
         </div>
     </section>
 
-    <ia-document-popup [page]="page"></ia-document-popup>
+    <ia-document-popup [page]="page" [queryModel]="queryModel"></ia-document-popup>
 </ng-container>
 
 <ng-template #loading>

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -1,16 +1,27 @@
 <ng-container *ngIf="pageResults?.result$ | async as page; else loading">
-    <div class="level">
-        <h2 class="subtitle" *ngIf="page.total <= 5">
-            {page.total, plural, =1 {1 hit} other {{{page.total}} hits}}
-        </h2>
-        <h2 class="subtitle" *ngIf="page.total > 5">
-            {{page.total}} results.
-            <!-- Showing results {{fromIndex+1}} - {{fromIndex+resultsPerPage > totalResults? totalResults : fromIndex+resultsPerPage}}: -->
-        </h2>
-        <ia-highlight-selector *ngIf="!!queryModel.queryText" [queryModel]="queryModel"></ia-highlight-selector>
-    </div>
-
     <section class="section results-navigation" #resultsNavigation [ngClass]="{'is-scrolled-down': isScrolledDown}">
+        <div class="level">
+            <h2 class="subtitle" *ngIf="page.total <= 5">
+                {page.total, plural, =1 {1 hit} other {{{page.total}} hits}}
+            </h2>
+            <h2 class="subtitle" *ngIf="page.total > 5">
+                {{page.total}} results.
+                <!-- Showing results {{fromIndex+1}} - {{fromIndex+resultsPerPage > totalResults? totalResults : fromIndex+resultsPerPage}}: -->
+            </h2>
+            <ia-highlight-selector *ngIf="!!queryModel.queryText" [queryModel]="queryModel"></ia-highlight-selector>
+        </div>
+
+        <div class="level">
+            <h2 class="subtitle" *ngIf="page.total <= 5">
+                {page.total, plural, =1 {1 hit} other {{{page.total}} hits}}
+            </h2>
+            <h2 class="subtitle" *ngIf="page.total > 5">
+                {{page.total}} results.
+                <!-- Showing results {{fromIndex+1}} - {{fromIndex+resultsPerPage > totalResults? totalResults : fromIndex+resultsPerPage}}: -->
+            </h2>
+            <ng-content *ngIf="!(queryText===null || queryText==='')" select="ia-highlight-selector"></ng-content>
+        </div>
+
         <div class="level">
             <div class="level-left has-text-centered">
                 <div>

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -6,7 +6,7 @@
             </h2>
             <h2 class="subtitle" *ngIf="page.total > 5">
                 {{page.total}} results.
-                Showing results {{(pageResults.from$ | async) + 1}}
+                Showing results {{pageResults.from$ | async}}
                 -
                 {{(pageResults.to$ | async)}}
             </h2>

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -76,7 +76,9 @@
                             </div>
                             <search-relevance [value]="document.relevance"></search-relevance>
                         </ng-container>
-                        <button *ngIf="document.fieldValues.image_path" class="button scan-button is-primary is-inverted" iaBalloon="View Scan" (click)="goToScan(document, $event)">
+                        <button *ngIf="document.fieldValues.image_path" class="button scan-button is-primary is-inverted"
+                            iaBalloon="View Scan" aria-label="view scan"
+                            (click)="goToScan(page, document, $event)">
                             <span class="icon">
                                 <i class="fa fa-newspaper-o fa-3x" aria-hidden="true"></i>
                             </span>

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -41,7 +41,7 @@
     </section>
 
     <section *ngIf="page.documents.length; else noHits" aria-label="search results">
-        <div class="hits" [ngClass]="{'is-loading':isLoading}">
+        <div class="hits" [ngClass]="{'is-loading': pageResults.loading$ | async }">
             <article *ngFor="let document of page.documents" class="document box">
                 <div class="columns">
                     <div class="column is-flex" tabindex="0" role="button"

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -39,9 +39,9 @@
                         <table class="table is-fullwidth">
                             <ng-container *ngFor="let field of page.fields">
                                 <tr *ngIf="document.fieldValue(field)">
-                                    <td>
-                                        <b>{{field.displayName}}: </b>
-                                    </td>
+                                    <th>
+                                        {{field.displayName}}:
+                                    </th>
                                     <ng-container *ngIf="document.highlight && document.highlight[field.name]; else unhighlightedRow">
                                         <td>
                                             <ng-container *ngFor="let highlight of document.highlight[field.name]">

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -1,10 +1,4 @@
-<ng-container *ngIf="results===undefined || !results.total; else resultsBlock">
-    <h2 class="subtitle">
-        0 hits
-    </h2>
-</ng-container>
-<ng-template #resultsBlock>
-
+<ng-container *ngIf="pageResults?.result$ | async as page; else loading">
     <div class="level">
         <h2 class="subtitle" *ngIf="results.total <= 5">
             {results.total.value, plural, =1 {1 hit} other {{{results.total.value}} hits}}
@@ -34,94 +28,65 @@
         </div>
     </div>
     </section>
-    <div class="hits" [ngClass]="{'is-loading':isLoading}">
-        <div *ngFor="let document of results.documents" class="document box" role="button">
-            <div class="columns">
-                <div class="column is-flex" tabindex="0" (click)="onViewDocument(document)" (keydown.enter)="onViewDocument(document)" role="button">
-                    <table class="table is-fullwidth">
-                        <ng-container *ngFor="let field of results.fields">
-                            <tr *ngIf="document.fieldValue(field)">
-                                <th>
-                                    {{field.displayName}}:
-                                </th>
-                                <ng-container *ngIf="document.highlight && document.highlight[field.name]; else unhighlightedRow">
+
+    <section *ngIf="page.documents.length; else noResults" aria-label="search results">
+        <div class="hits" [ngClass]="{'is-loading':isLoading}">
+            <article *ngFor="let document of page.documents" class="document box">
+                <div class="columns">
+                    <div class="column is-flex" tabindex="0" role="button"
+                        (click)="page.focus(document)"
+                        (keydown.enter)="page.focus(document)">
+                        <table class="table is-fullwidth">
+                            <ng-container *ngFor="let field of page.fields">
+                                <tr *ngIf="document.fieldValue(field)">
                                     <td>
-                                        <ng-container *ngFor="let highlight of document.highlight[field.name]">
-                                            <div ngPreserveWhitespaces style="word-break:break-word" [innerHtml]="highlight"></div>
-                                            <!-- insert ellipsis [...] in between snippets or at the end of a single snippet -->
-                                            <hr *ngIf="highlight != document.highlight[field.name][document.highlight[field.name].length-1]">
-                                        </ng-container>
+                                        <b>{{field.displayName}}: </b>
                                     </td>
-                                </ng-container>
-                                <ng-template #unhighlightedRow>
-                                    <td style="word-break:break-word" [innerHtml]="document.fieldValue(field) | highlight:query:true"></td>
-                                </ng-template>
-                            </tr>
+                                    <ng-container *ngIf="document.highlight && document.highlight[field.name]; else unhighlightedRow">
+                                        <td>
+                                            <ng-container *ngFor="let highlight of document.highlight[field.name]">
+                                                <div ngPreserveWhitespaces style="word-break:break-word" [innerHtml]="highlight"></div>
+                                                 insert ellipsis [...] in between snippets or at the end of a single snippet
+                                                <hr *ngIf="highlight !== document.highlight[field.name][document.highlight[field.name].length-1]">
+                                            </ng-container>
+                                        </td>
+                                    </ng-container>
+                                    <ng-template #unhighlightedRow>
+                                        <td style="word-break:break-word" [innerHtml]="document.fieldValue(field) | highlight:query:true"></td>
+                                    </ng-template>
+                                </tr>
+                            </ng-container>
+                        </table>
+                    </div>
+                    <div class="column is-one-quarter">
+                        <ng-container *ngIf="document.relevance">
+                            <div class="relevance-score">
+                                <span>Relevance: {{document.relevance * 100 | number:'1.0-0' }}%</span>
+                            </div>
+                            <search-relevance [value]="document.relevance"></search-relevance>
                         </ng-container>
-                    </table>
+                        <button *ngIf="document.fieldValues.image_path" class="button scan-button is-primary is-inverted" iaBalloon="View Scan" (click)="goToScan(document, $event)">
+                            <span class="icon">
+                                <i class="fa fa-newspaper-o fa-3x" aria-hidden="true"></i>
+                            </span>
+                        </button>
+                    </div>
                 </div>
-                <div class="column is-one-quarter">
-                    <ng-container *ngIf="document.relevance">
-                        <div class="relevance-score">
-                            <span>Relevance: {{document.relevance * 100 | number:'1.0-0' }}%</span>
-                        </div>
-                        <search-relevance [value]="document.relevance"></search-relevance>
-                    </ng-container>
-                    <button *ngIf="document.fieldValues.image_path" class="button scan-button is-primary is-inverted" iaBalloon="View Scan" (click)="goToScan(document, $event)">
-                        <span class="icon">
-                            <i class="fa fa-newspaper-o fa-3x" aria-hidden="true"></i>
-                        </span>
-                    </button>
-                </div>
-            </div>
+            </article>
         </div>
-    </div>
+    </section>
+
+    <ia-document-popup [page]="page"></ia-document-popup>
+</ng-container>
+
+<ng-template #loading>
+    <div class="is-loading" aria-label="loading results"></div>
 </ng-template>
 
-<!-- show the selected document -->
-<p-dialog [(visible)]="showDocument" width="100%"
-    [modal]="true" [responsive]="true" [maximizable]="true" [dismissableMask]="true" [draggable]="true" [resizable]="false" [blockScroll]="true"
-    *ngIf="viewDocument" header="Document {{viewDocument.position}} of {{totalResults}}">
-    <ia-document-view [document]="viewDocument" [queryModel]="queryModel" [corpus]="corpus" [documentTabIndex]="documentTabIndex"></ia-document-view>
-    <ng-template pTemplate="footer">
-        <div class="columns" style="text-align:left">
-            <div class="column">
-                <a *ngIf="viewDocument && viewDocument.position > 1"
-                    iaBalloon="view previous document" iaBalloonPosition="right"
-                    (click)="prevDocument(viewDocument)" (keydown.enter)="prevDocument(viewDocument)"
-                    role="button" tabindex="0">
-                    <span class="icon"><fa-icon [icon]="faArrowLeft">previous</fa-icon></span>
-                </a>
-            </div>
-            <div class="column" style="text-align:center">
-                <a [routerLink]="['/document', corpus.name, viewDocument.id]"
-                    iaBalloon="view this document on its own page" autofocus
-                    tabindex="0">
-                    <span class="icon">
-                        <fa-icon [icon]="linkIcon"></fa-icon>
-                    </span>
-                    <span>Link</span>
-                </a>
-                &nbsp;
-                <a *ngIf="viewDocument.hasContext" [routerLink]="['/search', corpus.name]" [queryParams]="viewDocument.contextQueryParams"
-                    iaBalloon="view all documents from this {{contextDisplayName}}"
-                    tabindex="0">
-                    <span class="icon">
-                        <fa-icon [icon]="contextIcon"></fa-icon>
-                    </span>
-                    <span>View {{contextDisplayName}}</span>
-                </a>
-            </div>
-            <div class="column" style="text-align:right">
-                <a *ngIf="viewDocument && viewDocument.position < totalResults"
-                    iaBalloon="view next document" iaBalloonPosition="left"
-                    (click)="nextDocument(viewDocument)" (keydown.enter)="nextDocument(viewDocument)"
-                    role="button" tabindex="0">
-                    <span class="icon"><fa-icon [icon]="faArrowRight">next</fa-icon></span>
-                </a>
-            </div>
-        </div>
-    </ng-template>
-</p-dialog>
+<ng-template #noResults>
+    <section aria-label="search results">
+        No results
+    </section>
+</ng-template>
 
-<ia-error *ngIf="showError" [showError]="showError"></ia-error>
+<!-- <ia-error *ngIf="showError" [showError]="showError"></ia-error> -->

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -1,32 +1,30 @@
 <ng-container *ngIf="pageResults?.result$ | async as page; else loading">
     <div class="level">
-        <h2 class="subtitle" *ngIf="results.total <= 5">
-            {results.total.value, plural, =1 {1 hit} other {{{results.total.value}} hits}}
+        <h2 class="subtitle" *ngIf="page.total <= 5">
+            {page.total, plural, =1 {1 hit} other {{{page.total}} hits}}
         </h2>
-        <h2 class="subtitle" *ngIf="results.total.value > 5">
-            {{results.total.value}} results.
-            Showing results {{fromIndex+1}} - {{fromIndex+resultsPerPage > totalResults? totalResults : fromIndex+resultsPerPage}}:
+        <h2 class="subtitle" *ngIf="page.total > 5">
+            {{page.total}} results.
+            <!-- Showing results {{fromIndex+1}} - {{fromIndex+resultsPerPage > totalResults? totalResults : fromIndex+resultsPerPage}}: -->
         </h2>
-        <ng-content *ngIf="!(queryText===null || queryText==='')" select="ia-highlight-selector"></ng-content>
+        <ia-highlight-selector *ngIf="!!queryModel.queryText" [queryModel]="queryModel"></ia-highlight-selector>
     </div>
 
     <section class="section results-navigation" #resultsNavigation [ngClass]="{'is-scrolled-down': isScrolledDown}">
-
-    <div class="level">
-
-    <div class="level-left has-text-centered">
-        <div>
-            <p class="heading">Sort By</p>
-            <ia-search-sorting [queryModel]="queryModel"></ia-search-sorting>
+        <div class="level">
+            <div class="level-left has-text-centered">
+                <div>
+                    <p class="heading">Sort By</p>
+                    <ia-search-sorting [queryModel]="queryModel"></ia-search-sorting>
+                </div>
+            </div>
+            <!-- <div class="level-right has-text-centered" *ngIf="results.total.value > resultsPerPage" >
+                <div>
+                    <p class="heading">Pages</p>
+                    <ia-pagination [totalResults]="totalResults" [fromIndex]="fromIndex" (loadResults)=loadResults($event)></ia-pagination>
+                </div>
+            </div> -->
         </div>
-    </div>
-    <div class="level-right has-text-centered" *ngIf="results.total.value > resultsPerPage" >
-        <div>
-            <p class="heading">Pages</p>
-            <ia-pagination [totalResults]="totalResults" [fromIndex]="fromIndex" (loadResults)=loadResults($event)></ia-pagination>
-        </div>
-        </div>
-    </div>
     </section>
 
     <section *ngIf="page.documents.length; else noResults" aria-label="search results">

--- a/frontend/src/app/search/search-results.component.html
+++ b/frontend/src/app/search/search-results.component.html
@@ -34,7 +34,7 @@
             <div class="level-right has-text-centered" *ngIf="page.total > resultsPerPage" >
                 <div>
                     <p class="heading">Pages</p>
-                    <ia-pagination [totalResults]="page.total" [fromIndex]="pageResults.from$ | async" (parameters)="setParameters($event)"></ia-pagination>
+                    <ia-pagination [totalResults]="totalDisplayed(page.total)" [fromIndex]="pageResults.from$ | async" (parameters)="setParameters($event)"></ia-pagination>
                 </div>
             </div>
         </div>

--- a/frontend/src/app/search/search-results.component.spec.ts
+++ b/frontend/src/app/search/search-results.component.spec.ts
@@ -41,10 +41,9 @@ describe('Search Results Component', () => {
                 relation: 'gte'
             }
         };
-        component.corpus = _.merge(mockCorpus, fields);
-        component.fromIndex = 0;
+        const corpus = _.merge(mockCorpus, fields);
         component.resultsPerPage = 20;
-        const query = new QueryModel(component.corpus);
+        const query = new QueryModel(corpus);
         query.setQueryText('wally');
         query.setHighlight(10);
         component.queryModel = query;

--- a/frontend/src/app/search/search-results.component.spec.ts
+++ b/frontend/src/app/search/search-results.component.spec.ts
@@ -7,7 +7,8 @@ import { CorpusField, FoundDocument, QueryModel } from '../models/index';
 
 import { SearchResultsComponent } from './search-results.component';
 import { makeDocument } from '../../mock-data/constructor-helpers';
-import { DocumentPage, PageResults } from '../models/page-results';
+import { PageResults } from '../models/page-results';
+import { DocumentPage } from '../models/document-page';
 import { of } from 'rxjs';
 import { By } from '@angular/platform-browser';
 

--- a/frontend/src/app/search/search-results.component.spec.ts
+++ b/frontend/src/app/search/search-results.component.spec.ts
@@ -7,7 +7,44 @@ import { CorpusField, FoundDocument, QueryModel } from '../models/index';
 
 import { SearchResultsComponent } from './search-results.component';
 import { makeDocument } from '../../mock-data/constructor-helpers';
+import { DocumentPage, PageResults } from '../models/page-results';
+import { of } from 'rxjs';
+import { By } from '@angular/platform-browser';
 
+const createField = (name: string): CorpusField => {
+    const field = _.cloneDeep(mockField);
+    field.name = name;
+    return field;
+};
+
+const documents: FoundDocument[] = [
+    makeDocument(
+        {
+            a: '1',
+            b: '2',
+            c: 'Hide-and-seek!'
+        }, mockCorpus, '1', 1,
+        {
+            c: ['Where is <span>Wally?</span>', 'I cannot find <span>Wally</span> anywhere!']
+        }
+    ),
+    makeDocument(
+        {
+            a: '3',
+            b: '4',
+            c: 'Wally is here'
+        }, mockCorpus, '2', 0.5
+    )
+];
+
+const fields = ['a', 'b', 'c'].map(createField);
+
+class MockResults extends PageResults {
+    fetch() {
+        const page = new DocumentPage(documents, 2, fields);
+        return of(page);
+    }
+}
 
 describe('Search Results Component', () => {
     let component: SearchResultsComponent;
@@ -19,51 +56,44 @@ describe('Search Results Component', () => {
 
     beforeEach(() => {
         fixture = TestBed.createComponent(SearchResultsComponent);
-        const fields = ['a', 'b', 'c'].map(createField);
+
         component = fixture.componentInstance;
-        component.results = {
-            fields,
-            documents: [makeDocument({
-                a: '1',
-                b: '2',
-                c: 'Hide-and-seek!'
-            }, mockCorpus, '1', 1,
-            {
-                c: ['Where is <span>Wally?</span>', 'I cannot find <span>Wally</span> anywhere!']
-            }),
-            makeDocument({
-                a: '3',
-                b: '4',
-                c: 'Wally is here'
-            }, mockCorpus, '2', 0.5)],
-            total: {
-                value: 2,
-                relation: 'gte'
-            }
-        };
+    });
+
+    beforeEach(() => {
         const corpus = _.merge(mockCorpus, fields);
-        component.resultsPerPage = 20;
         const query = new QueryModel(corpus);
         query.setQueryText('wally');
         query.setHighlight(10);
         component.queryModel = query;
         fixture.detectChanges();
+        component.pageResults = new MockResults(undefined, component.queryModel);
     });
 
-    const createField = (name: string): CorpusField => {
-        const field = _.cloneDeep(mockField);
-        field.name = name;
-        return field;
-    };
 
     it('should be created', () => {
         expect(component).toBeTruthy();
     });
 
+    it('should show a loading spinner on opening', () => {
+        const loadingElement = fixture.debugElement.query(
+            By.css('.is-loading')
+        );
+        expect(loadingElement).toBeTruthy();
+    });
+
     it('should render result', async () => {
         await fixture.whenStable();
-        const compiled = fixture.debugElement.nativeElement;
-        expect(compiled.innerHTML).toContain('Wally is here');
+        fixture.detectChanges();
+
+        const element = fixture.debugElement;
+
+        const docs = element.queryAll(
+            By.css('article')
+        );
+        expect(docs.length).toBe(2);
+
+        expect(element.nativeElement.innerHTML).toContain('Wally is here');
     });
 });
 

--- a/frontend/src/app/search/search-results.component.ts
+++ b/frontend/src/app/search/search-results.component.ts
@@ -4,7 +4,7 @@ import { Component, ElementRef, EventEmitter, HostListener, Input, OnChanges, Ou
 import { User, SearchResults, FoundDocument, QueryModel, ResultOverview } from '../models/index';
 import { SearchService } from '../services';
 import { ShowError } from '../error/error.component';
-import { PageParameters, PageResults } from '../models/page-results';
+import { PageResultsParameters, PageResults } from '../models/page-results';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -54,12 +54,7 @@ export class SearchResultsComponent implements OnChanges {
 
     ngOnChanges(changes: SimpleChanges) {
         if (changes.queryModel) {
-            const params = {
-                esQuery: this.queryModel.toEsQuery(),
-                from: 0,
-                size: this.resultsPerPage,
-            };
-            this.pageResults = new PageResults(this.searchService, this.queryModel, params);
+            this.pageResults = new PageResults(this.searchService, this.queryModel);
             this.error$ = this.pageResults.error$.pipe(
                 map(this.parseError)
             );
@@ -69,7 +64,7 @@ export class SearchResultsComponent implements OnChanges {
         }
     }
 
-    setParameters(parameters: PageParameters) {
+    setParameters(parameters: PageResultsParameters) {
         this.pageResults?.setParameters(parameters);
     }
 

--- a/frontend/src/app/search/search-results.component.ts
+++ b/frontend/src/app/search/search-results.component.ts
@@ -69,6 +69,10 @@ export class SearchResultsComponent implements OnChanges {
         this.pageResults?.setParameters(parameters);
     }
 
+    totalDisplayed(totalResults: number) {
+        return Math.min(totalResults, MAXIMUM_DISPLAYED);
+    }
+
     @HostListener('window:scroll', [])
     onWindowScroll() {
         // mark that the search results were scrolled down beyond 68 pixels from top (position underneath sticky search bar)

--- a/frontend/src/app/search/search-results.component.ts
+++ b/frontend/src/app/search/search-results.component.ts
@@ -28,9 +28,6 @@ export class SearchResultsComponent implements OnChanges {
     @Input()
     public user: User;
 
-    @Output('view')
-    public viewEvent = new EventEmitter<{document: FoundDocument; tabIndex?: number}>();
-
     @Output('searched')
     public searchedEvent = new EventEmitter<ResultOverview>();
 

--- a/frontend/src/app/search/search-results.component.ts
+++ b/frontend/src/app/search/search-results.component.ts
@@ -6,7 +6,7 @@ import { SearchService } from '../services';
 import { ShowError } from '../error/error.component';
 import * as _ from 'lodash';
 import { faBookOpen, faArrowLeft, faArrowRight, faLink } from '@fortawesome/free-solid-svg-icons';
-import { PageResults } from '../models/results';
+import { PageResults, PageResultsParameters } from '../models/results';
 import { Observable } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 
@@ -90,6 +90,10 @@ export class SearchResultsComponent implements OnChanges {
             this.search();
             this.queryModel.update.subscribe(() => this.search());
         }
+    }
+
+    setParameters(parameters: PageResultsParameters) {
+        this.pageResults?.setParameters(parameters);
     }
 
     @HostListener('window:scroll', [])

--- a/frontend/src/app/search/search-results.component.ts
+++ b/frontend/src/app/search/search-results.component.ts
@@ -4,7 +4,7 @@ import { Component, ElementRef, EventEmitter, HostListener, Input, OnChanges, Ou
 import { User, SearchResults, FoundDocument, QueryModel, ResultOverview } from '../models/index';
 import { SearchService } from '../services';
 import { ShowError } from '../error/error.component';
-import { PageResults, PageResultsParameters } from '../models/results';
+import { PageResults, PageResultsParameters } from '../models/page-results';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 

--- a/frontend/src/app/search/search-results.component.ts
+++ b/frontend/src/app/search/search-results.component.ts
@@ -62,6 +62,9 @@ export class SearchResultsComponent implements OnChanges {
             this.error$ = this.pageResults.error$.pipe(
                 map(this.parseError)
             );
+            this.pageResults.result$.subscribe(result => {
+                this.searchedEvent.emit({ queryText: this.queryModel.queryText, resultsCount: result.total });
+            });
         }
     }
 

--- a/frontend/src/app/search/search-results.component.ts
+++ b/frontend/src/app/search/search-results.component.ts
@@ -7,6 +7,7 @@ import { ShowError } from '../error/error.component';
 import { PageResultsParameters, PageResults } from '../models/page-results';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { DocumentPage } from '../models/document-page';
 
 const MAXIMUM_DISPLAYED = 10000;
 
@@ -68,6 +69,11 @@ export class SearchResultsComponent implements OnChanges {
     totalDisplayed(totalResults: number) {
         return Math.min(totalResults, MAXIMUM_DISPLAYED);
     }
+
+    goToScan(page: DocumentPage, document: FoundDocument, event: Event) {
+        page.focus(document, 'scan');
+        event.stopPropagation();
+    };
 
     @HostListener('window:scroll', [])
     onWindowScroll() {

--- a/frontend/src/app/search/search-results.component.ts
+++ b/frontend/src/app/search/search-results.component.ts
@@ -5,6 +5,8 @@ import { User, SearchResults, FoundDocument, QueryModel, ResultOverview } from '
 import { SearchService } from '../services';
 import { ShowError } from '../error/error.component';
 import { PageResults, PageResultsParameters } from '../models/results';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 const MAXIMUM_DISPLAYED = 10000;
 
@@ -43,10 +45,7 @@ export class SearchResultsComponent implements OnChanges {
 
     public imgSrc: Uint8Array;
 
-    /**
-     * For failed searches.
-     */
-    public showError: false | undefined | ShowError;
+    error$: Observable<ShowError>;
 
     /** tab on which the focused document should be opened */
     public documentTabIndex: number;
@@ -60,6 +59,9 @@ export class SearchResultsComponent implements OnChanges {
                 size: this.resultsPerPage,
             };
             this.pageResults = new PageResults(this.searchService, this.queryModel, params);
+            this.error$ = this.pageResults.error$.pipe(
+                map(this.parseError)
+            );
         }
     }
 
@@ -76,11 +78,13 @@ export class SearchResultsComponent implements OnChanges {
         }
     }
 
-    private onError(error: any): void {
-        this.showError = {
-            date: (new Date()).toISOString(),
-            href: location.href,
-            message: error.message || 'An unknown error occurred'
-        };
+    private parseError(error): ShowError {
+        if (error) {
+            return {
+                date: (new Date()).toISOString(),
+                href: location.href,
+                message: error.message || 'An unknown error occurred'
+            };
+        }
     }
 }

--- a/frontend/src/app/search/search-results.component.ts
+++ b/frontend/src/app/search/search-results.component.ts
@@ -4,7 +4,7 @@ import { Component, ElementRef, EventEmitter, HostListener, Input, OnChanges, Ou
 import { User, SearchResults, FoundDocument, QueryModel, ResultOverview } from '../models/index';
 import { SearchService } from '../services';
 import { ShowError } from '../error/error.component';
-import { PageResults, PageResultsParameters } from '../models/page-results';
+import { PageParameters, PageResults } from '../models/page-results';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -55,6 +55,7 @@ export class SearchResultsComponent implements OnChanges {
     ngOnChanges(changes: SimpleChanges) {
         if (changes.queryModel) {
             const params = {
+                esQuery: this.queryModel.toEsQuery(),
                 from: 0,
                 size: this.resultsPerPage,
             };
@@ -68,7 +69,7 @@ export class SearchResultsComponent implements OnChanges {
         }
     }
 
-    setParameters(parameters: PageResultsParameters) {
+    setParameters(parameters: PageParameters) {
         this.pageResults?.setParameters(parameters);
     }
 

--- a/frontend/src/app/search/search.component.html
+++ b/frontend/src/app/search/search.component.html
@@ -55,10 +55,8 @@
             <div class="column is-9" *ngIf="queryModel">
                 <ia-tabs [activeTab]="showVisualization ? 'visualizations' : 'search-results'">
                     <ng-template iaTabPanel id="search-results" title="Search results" [icon]="tabIcons.searchResults">
-                        <ia-search-results #searchResults [corpus]="corpus" [queryModel]="queryModel" [user]="user"
+                        <ia-search-results #searchResults [queryModel]="queryModel" [user]="user"
                             (searched)="onSearched($event)" role="tabpanel">
-                            <ia-search-sorting [queryModel]="queryModel"></ia-search-sorting>
-                            <ia-highlight-selector [queryModel]="queryModel"></ia-highlight-selector>
                         </ia-search-results>
                     </ng-template>
                     <ng-template iaTabPanel id="visualizations" title="Visualizations" [icon]="tabIcons.visualizations">

--- a/frontend/src/app/search/search.module.ts
+++ b/frontend/src/app/search/search.module.ts
@@ -9,7 +9,6 @@ import { CorpusModule } from '../corpus-header/corpus.module';
 import { SearchSortingComponent } from './search-sorting.component';
 import { FilterModule } from '../filter/filter.module';
 import { DownloadModule } from '../download/download.module';
-import { DialogModule } from 'primeng/dialog';
 import { QueryService, SearchService } from '../services';
 import { VisualizationModule } from '../visualization/visualization.module';
 
@@ -28,7 +27,6 @@ import { VisualizationModule } from '../visualization/visualization.module';
         SearchSortingComponent,
     ],
     imports: [
-        DialogModule,
         CorpusModule,
         DocumentModule,
         DownloadModule,

--- a/frontend/src/app/services/elastic-search.service.spec.ts
+++ b/frontend/src/app/services/elastic-search.service.spec.ts
@@ -79,7 +79,7 @@ describe('ElasticSearchService', () => {
     it('should make a search request', async () => {
         const queryModel = new QueryModel(mockCorpus);
         const size = 2;
-        const response = service.search(queryModel, size);
+        const response = service.loadResults(queryModel, 0, size);
 
         const searchUrl = `/api/es/${mockCorpus.name}/_search?size=${size}`;
         httpTestingController.expectOne(searchUrl).flush(mockResponse);

--- a/frontend/src/app/services/elastic-search.service.ts
+++ b/frontend/src/app/services/elastic-search.service.ts
@@ -9,12 +9,11 @@ import {
 import * as _ from 'lodash';
 import { TagService } from './tag.service';
 import { QueryParameters } from '../models/search-requests';
+import { RESULTS_PER_PAGE } from '../models/page-results';
 
 
 @Injectable()
 export class ElasticSearchService {
-
-    private resultsPerPage = 20;
 
     constructor(private http: HttpClient, private tagService: TagService) {
     }
@@ -79,29 +78,17 @@ export class ElasticSearchService {
         };
     }
 
-
-
-    public async search(
-        queryModel: QueryModel,
-        size?: number,
-    ): Promise<SearchResults> {
-        const esQuery = queryModel.toEsQuery();
-
-        // Perform the search
-        const response = await this.execute(queryModel.corpus, esQuery, size || this.resultsPerPage);
-        return this.parseResponse(queryModel.corpus, response);
-    }
-
-
     /**
      * Load results for requested page
      */
     public async loadResults(
-        queryModel: QueryModel, from: number,
-        size: number): Promise<SearchResults> {
+        queryModel: QueryModel,
+        from: number,
+        size: number = RESULTS_PER_PAGE
+    ): Promise<SearchResults> {
         const esQuery = queryModel.toEsQuery();
         // Perform the search
-        const response = await this.execute(queryModel.corpus, esQuery, size || this.resultsPerPage, from);
+        const response = await this.execute(queryModel.corpus, esQuery, size, from);
         return this.parseResponse(queryModel.corpus, response);
     }
 

--- a/frontend/src/app/services/search.service.spec.ts
+++ b/frontend/src/app/services/search.service.spec.ts
@@ -45,7 +45,7 @@ describe('SearchService', () => {
 
     it('should search', inject([SearchService], async (service: SearchService) => {
         const queryModel = new QueryModel(mockCorpus);
-        const results = await service.search(queryModel);
+        const results = await service.loadResults(queryModel, 0, 20);
         expect(results).toBeTruthy();
         expect(results.total.value).toBeGreaterThan(0);
     }));

--- a/frontend/src/app/services/search.service.ts
+++ b/frontend/src/app/services/search.service.ts
@@ -30,16 +30,7 @@ export class SearchService {
             from,
             size
         );
-        results.fields = queryModel.corpus.fields.filter((field) => field.resultsOverview);
-        return results;
-    }
-
-    public async search(queryModel: QueryModel
-    ): Promise<SearchResults> {
-        const request = this.elasticSearchService.search(queryModel);
-        return request.then(results =>
-            this.filterResultsFields(results, queryModel)
-        );
+        return this.filterResultsFields(results, queryModel);
     }
 
     public async aggregateSearch(

--- a/frontend/src/mock-data/elastic-search.ts
+++ b/frontend/src/mock-data/elastic-search.ts
@@ -12,7 +12,7 @@ export class ElasticSearchServiceMock {
         return Promise.resolve(makeDocument({content: 'Hello world!'}));
     }
 
-    search(): Promise<SearchResults> {
+    loadResults(): Promise<SearchResults> {
         return Promise.resolve({
             total: {
                 relation: 'eq',


### PR DESCRIPTION
Frontend refactoring:

- Adds a `PageResults` model to represent search results.
- `PageResults` extends a `Results` model that is intended to be used in some other contexts in the future (e.g. aggregation requests)
- Cleans up the `SearchResultsComponent`
- Extracted a `DocumentPopupComponent` from the search results component

Content changes:

- The results page is now better at showing a loading spinner when its should
- Fixed an issue where clicking the scan button just opened the document without jumping to the scan tab
- Removed the logic where the first page shows more documents than subsequent pages. It's not really an issue to restore it, it just seemed a bit unnecessary to me.

close #1162 