### PR TITLE
Fix missing word model labels

### DIFF
--- a/frontend/src/app/word-models/similarity-chart/similarity-chart.component.html
+++ b/frontend/src/app/word-models/similarity-chart/similarity-chart.component.html
@@ -4,7 +4,7 @@
             <div class="control">
                 <label class="label">Show as:</label>
                 <label class="radio" *ngFor="let style of ['line', 'bar']">
-                    <input type="radio" [checked]="graphStyle.value==style" (click)="graphStyle.next(style)" (keydown.enter)="graphStyle.next(style)">
+                    <input type="radio" [checked]="graphStyle.value===style" (click)="graphStyle.next(style)" (keydown.enter)="graphStyle.next(style)">
                     {{style | titlecase}}
                 </label>
             </div>

--- a/frontend/src/app/word-models/similarity-chart/similarity-chart.component.ts
+++ b/frontend/src/app/word-models/similarity-chart/similarity-chart.component.ts
@@ -32,7 +32,7 @@ export class SimilarityChartComponent implements OnInit, OnChanges, OnDestroy {
     tableHeaders: FreqTableHeaders;
     tableData: WordSimilarity[];
 
-    averages: Number[];
+    averages: number[];
 
     graphStyle = new BehaviorSubject<'line'|'bar'>('line');
 
@@ -109,7 +109,7 @@ export class SimilarityChartComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     formatLabel(value: number): string {
-        const index = this.averages.indexOf(value)
+        const index = this.averages.indexOf(value);
         return this.timeIntervals[index];
     }
 
@@ -119,12 +119,11 @@ export class SimilarityChartComponent implements OnInit, OnChanges, OnDestroy {
         return avg;
     }
 
-    formatDataPoint(point: any, style: string): {x: number, y: number} | number {
-        if (style == 'line') {
-            return {x: this.getAverageTime(point.time), y: point.similarity}
-        }
-        else {
-            return point.similarity
+    formatDataPoint(point: any, style: string): {x: number; y: number} | number {
+        if (style === 'line') {
+            return {x: this.getAverageTime(point.time), y: point.similarity};
+        } else {
+            return point.similarity;
         }
     }
 
@@ -214,9 +213,7 @@ export class SimilarityChartComponent implements OnInit, OnChanges, OnDestroy {
                 tooltip: {
                     displayColors: true,
                     callbacks: {
-                        title: (tooltipItems: TooltipItem<ChartType>[]): string => {
-                            return this.formatLabel(tooltipItems[0].parsed.x)
-                        },
+                        title: (tooltipItems: TooltipItem<ChartType>[]): string => this.formatLabel(tooltipItems[0].parsed.x),
                         labelColor: (tooltipItem: any): any => {
                             const color = tooltipItem.dataset.borderColor;
                             return {
@@ -239,7 +236,7 @@ export class SimilarityChartComponent implements OnInit, OnChanges, OnDestroy {
 
         if (style === 'line') {
             options.plugins.legend.labels = {
-                boxHeight: 0, // flat boxes so the border is a line
+                pointStyle: 'rectRounded'
             };
             options.elements.point.radius = 4;
             options.plugins.legend.labels.usePointStyle = true;


### PR DESCRIPTION
Close #1315 : the colors next to the labels were missing. They are now reintroduced.
<img width="789" alt="Screenshot 2023-12-14 at 14 03 53" src="https://github.com/UUDigitalHumanitieslab/I-analyzer/assets/11174072/2dcaf315-a857-46a5-845b-33acdb0521d3">
