### PR TITLE
fix #1359: change condition for word models request

### DIFF
--- a/frontend/src/app/word-models/word-models.component.ts
+++ b/frontend/src/app/word-models/word-models.component.ts
@@ -72,8 +72,9 @@ export class WordModelsComponent extends ParamDirective implements DoCheck {
     teardown() {}
 
     setStateFromParams(params: Params) {
-        this.queryText = params.get('query');
-        if (this.queryText) {
+        const queryFromParams = params.get('query');
+        if (queryFromParams !== this.activeQuery) {
+            this.queryText = queryFromParams;
             this.activeQuery = this.queryText;
             this.validateQuery();
             if (this.queryFeedback === undefined) {


### PR DESCRIPTION
Close #1359. The problem with repeated requests in case of a word that was missing in the word models was caused by a faulty condition in the `setStateFromParams` function.