### PR TITLE
do not pip-compile on container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,8 +10,7 @@ RUN pip install --upgrade pip
 RUN pip install pip-tools
 # make a directory in the container
 WORKDIR /backend
-# copy files from the host system to the directory in the container
-COPY requirements.in /backend/
-RUN pip-compile
+# copy requirements from the host system to the directory in the container
+COPY requirements.txt /backend/
 # run pip install on container
 RUN pip install -r requirements.txt


### PR DESCRIPTION
This PR fixes a problem with the internal requirements of django-auth in the Docker container being compiled to a version that's incompatible with our current code base.