### PR TITLE
Feature/angular lifecycle fix

### DIFF
--- a/frontend/src/app/visualization/barchart/barchart.directive.ts
+++ b/frontend/src/app/visualization/barchart/barchart.directive.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/member-ordering */
-import { Directive, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Directive, EventEmitter, Host, HostBinding, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 
 import * as _ from 'lodash';
 
@@ -30,6 +30,8 @@ const barchartID = 'barchart';
 export abstract class BarchartDirective<
     DataPoint extends TimelineDataPoint | HistogramDataPoint
 > implements OnChanges, OnInit, OnDestroy {
+    @HostBinding('style.display') display = 'block'; // needed for loading spinner positioning
+
     public showHint: boolean;
 
     // rawData: a list of series
@@ -77,7 +79,8 @@ export abstract class BarchartDirective<
         },
     };
 
-    @Output() isLoading = new BehaviorSubject<boolean>(false);
+    isLoading$ = new BehaviorSubject<boolean>(false);
+
     // eslint-disable-next-line @angular-eslint/no-output-native
     @Output() error = new EventEmitter();
 
@@ -146,6 +149,11 @@ export abstract class BarchartDirective<
         chartDefault.elements.bar.hoverBackgroundColor = selectColor();
         chartDefault.plugins.tooltip.displayColors = false;
         chartDefault.plugins.tooltip.intersect = false;
+    }
+
+    @HostBinding('class.is-loading')
+    get isLoading() {
+        return this.isLoading$.value;
     }
 
     ngOnInit(): void {
@@ -250,7 +258,7 @@ export abstract class BarchartDirective<
      * This function should be called after (potential) changes to parameters.
      */
     prepareChart() {
-        showLoading(this.isLoading, this.loadData());
+        showLoading(this.isLoading$, this.loadData());
     }
 
     /** load data for the graph (if needed), update the graph and freqtable. */

--- a/frontend/src/app/visualization/barchart/histogram.component.html
+++ b/frontend/src/app/visualization/barchart/histogram.component.html
@@ -6,7 +6,7 @@
 
 <div class="block">
     <ia-barchart-options
-        [queryText]="queryText" [showTokenCountOption]="totalTokenCountAvailable" [isLoading]="isLoading.value"
+        [queryText]="queryText" [showTokenCountOption]="totalTokenCountAvailable" [isLoading]="isLoading"
         [frequencyMeasure]="frequencyMeasure"
         [freqTable]="asTable" [histogram]="true"
         (chartParameters)="onOptionChange($event)" (queriesChanged)="updateQueries($event)"  (clearQueries)="clearAddedQueries()">
@@ -23,7 +23,7 @@
     </ia-freqtable>
 </div>
 
-<div class="message is-warning" *ngIf="!isLoading.value && documentLimitExceeded && frequencyMeasure === 'tokens'">
+<div class="message is-warning" *ngIf="!isLoading && documentLimitExceeded && frequencyMeasure === 'tokens'">
     <div class="message-body">
         <div class="block">
             The results for your search include too many documents to count all matches.

--- a/frontend/src/app/visualization/barchart/timeline.component.html
+++ b/frontend/src/app/visualization/barchart/timeline.component.html
@@ -10,7 +10,7 @@
 
 <div class="block">
     <ia-barchart-options
-        [queryText]="queryText" [showTokenCountOption]="totalTokenCountAvailable" [isLoading]="isLoading.value"
+        [queryText]="queryText" [showTokenCountOption]="totalTokenCountAvailable" [isLoading]="isLoading"
         [freqTable]="asTable" [histogram]="false"
         [frequencyMeasure]="frequencyMeasure"
         (chartParameters)="onOptionChange($event)" (queriesChanged)="updateQueries($event)" (clearQueries)="clearAddedQueries()">
@@ -27,7 +27,7 @@
     </ia-freqtable>
 </div>
 
-<div class="message is-warning" *ngIf="!isLoading.value && documentLimitExceeded && frequencyMeasure === 'tokens'">
+<div class="message is-warning" *ngIf="!isLoading && documentLimitExceeded && frequencyMeasure === 'tokens'">
     <div class="message-body">
         <div class="block">
         The results for your search include too many documents to count all matches.

--- a/frontend/src/app/visualization/barchart/timeline.component.ts
+++ b/frontend/src/app/visualization/barchart/timeline.component.ts
@@ -249,7 +249,7 @@ export class TimelineComponent
                 this.currentTimeCategory !== initialTimeCategory)
         ) {
             showLoading(
-                this.isLoading,
+                this.isLoading$,
                 this.loadZoomedInData(
                     chart,
                     min,

--- a/frontend/src/app/visualization/ngram/ngram.component.ts
+++ b/frontend/src/app/visualization/ngram/ngram.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostBinding, Input, OnChanges, Output, SimpleChanges, ViewChild } from '@angular/core';
 import * as _ from 'lodash';
 import { Corpus, FreqTableHeaders, QueryModel, CorpusField, NgramResults, NgramParameters } from '../../models';
 import { ApiService, NotificationService, ParamService, VisualizationService } from '../../services';
@@ -12,12 +12,15 @@ import { formIcons } from '../../shared/icons';
     styleUrls: ['./ngram.component.scss'],
 })
 export class NgramComponent extends ParamDirective implements OnChanges {
+    @HostBinding('style.display') display = 'block'; // needed for loading spinner positioning
+
     @Input() queryModel: QueryModel;
     @Input() corpus: Corpus;
     @Input() visualizedField: CorpusField;
     @Input() asTable: boolean;
     @Input() palette: string[];
-    @Output() isLoading = new EventEmitter<boolean>();
+    @HostBinding('class.is-loading') isLoading = false;
+
     @Output() ngramError = new EventEmitter<string>();
 
     @ViewChild('chart-container') chartContainer: ElementRef;
@@ -195,7 +198,7 @@ export class NgramComponent extends ParamDirective implements OnChanges {
     }
 
     loadGraph() {
-        this.isLoading.emit(true);
+        this.isLoading = true;
 
         this.lastParameters = _.clone(this.currentParameters);
         const cachedResult = this.getCachedResult(this.currentParameters);
@@ -229,14 +232,14 @@ export class NgramComponent extends ParamDirective implements OnChanges {
         console.log(error);
         this.currentResults = undefined;
         this.ngramError.emit(error.message);
-        this.isLoading.emit(false);
+        this.isLoading = false;
     }
 
     onDataLoaded(result: NgramResults) {
         this.currentResults = result;
         this.tableData = this.makeTableData(result);
 
-        this.isLoading.emit(false);
+        this.isLoading = false;
     }
 
     makeTableData(result: NgramResults): any[] {

--- a/frontend/src/app/visualization/visualization.component.html
+++ b/frontend/src/app/visualization/visualization.component.html
@@ -57,31 +57,31 @@
                 <ia-timeline *ngIf="visualizedField.displayType === 'date'" [corpus]="corpus" [queryModel]="queryModel"
                 [visualizedField]="visualizedField" [frequencyMeasure]="'documents'"
                 [asTable]="freqtable" [palette]="palette"
-                (isLoading)="onIsLoading($event)" (error)="setErrorMessage($event)"
+                (error)="setErrorMessage($event)"
                 (totalTokenCountAvailable)="showTokenCountOption = $event"></ia-timeline>
             <ia-histogram *ngIf="visualizedField.displayType !== 'date'" [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
                 [asTable]="freqtable" [palette]="palette"
-                (isLoading)="onIsLoading($event)" (error)="setErrorMessage($event)"
+                (error)="setErrorMessage($event)"
                 (totalTokenCountAvailable)="showTokenCountOption = $event"></ia-histogram>
             </ng-container>
             <ng-container *ngSwitchCase="'termfrequency'">
                 <ia-timeline *ngIf="visualizedField.displayType === 'date'" [corpus]="corpus" [queryModel]="queryModel"
                     [visualizedField]="visualizedField" [frequencyMeasure]="'tokens'"
                     [asTable]="freqtable" [palette]="palette"
-                    (isLoading)="onIsLoading($event)" (error)="setErrorMessage($event)"
+                    (error)="setErrorMessage($event)"
                     (totalTokenCountAvailable)="showTokenCountOption = $event"></ia-timeline>
                 <ia-histogram *ngIf="visualizedField.displayType !== 'date'" [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
                     [frequencyMeasure]="'tokens'"
                     [asTable]="freqtable" [palette]="palette"
-                    (isLoading)="onIsLoading($event)" (error)="setErrorMessage($event)"
+                    (error)="setErrorMessage($event)"
                     (totalTokenCountAvailable)="showTokenCountOption = $event"></ia-histogram>
             </ng-container>
             <ia-wordcloud *ngSwitchCase=" 'wordcloud' " [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
                 [resultsCount]="resultsCount" [asTable]="freqtable" [palette]="palette"
-                (isLoading)="onIsLoading($event)" (wordcloudError)="setErrorMessage($event['message'])"></ia-wordcloud>
+                (wordcloudError)="setErrorMessage($event['message'])"></ia-wordcloud>
             <ia-ngram *ngSwitchCase=" 'ngram' " [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
                 [asTable]="freqtable" [palette]="palette"
-                (isLoading)="onIsLoading($event)" (ngramError)="setErrorMessage($event)"></ia-ngram>
+                (ngramError)="setErrorMessage($event)"></ia-ngram>
         </ng-container>
     </div>
 </ng-container>

--- a/frontend/src/app/visualization/visualization.component.ts
+++ b/frontend/src/app/visualization/visualization.component.ts
@@ -23,7 +23,7 @@ import { visualizationIcons } from '../shared/icons';
 })
 export class VisualizationComponent
     extends ParamDirective
-    implements DoCheck, OnChanges
+    implements OnChanges
 {
     @Input() public corpus: Corpus;
     @Input() public queryModel: QueryModel;
@@ -64,14 +64,11 @@ export class VisualizationComponent
     visualizationIcons = visualizationIcons;
 
     public visualExists = false;
-    public isLoading = false;
 
     public palette: string[];
     public params: Params = {};
 
     nullableParameters = ['visualize', 'visualizedField'];
-
-    private childComponentLoading = false;
 
     private reset$ = new Subject<void>();
     private destroy$ = new Subject<void>();
@@ -108,12 +105,6 @@ export class VisualizationComponent
     get imageFileName(): string {
         if (this.visualizationType && this.corpus && this.visualizedField) {
             return `${this.visualizationType}_${this.corpus.name}_${this.visualizedField.name}.png`;
-        }
-    }
-
-    ngDoCheck() {
-        if (this.isLoading !== this.childComponentLoading) {
-            this.isLoading = this.childComponentLoading;
         }
     }
 
@@ -232,10 +223,6 @@ export class VisualizationComponent
         this.visualExists = false;
         this.foundNoVisualsMessage = this.noResults;
         this.errorMessage = message;
-    }
-
-    onIsLoading(event: boolean) {
-        this.childComponentLoading = event;
     }
 
     private includeVisualisationType(

--- a/frontend/src/app/visualization/wordcloud/wordcloud.component.ts
+++ b/frontend/src/app/visualization/wordcloud/wordcloud.component.ts
@@ -1,5 +1,5 @@
 import {
-    Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges
+    Component, EventEmitter, HostBinding, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges
 } from '@angular/core';
 
 
@@ -37,6 +37,8 @@ const unitScale = (min: number, max: number): (frequency: number) => number => {
     styleUrls: ['./wordcloud.component.scss'],
 })
 export class WordcloudComponent implements OnChanges, OnDestroy {
+    @HostBinding('style.display') display = 'block'; // needed for loading spinner positioning
+
     @Input() visualizedField: CorpusField;
     @Input() queryModel: QueryModel;
     @Input() corpus: Corpus;
@@ -45,7 +47,8 @@ export class WordcloudComponent implements OnChanges, OnDestroy {
     @Input() palette: string[];
 
     @Output() wordcloudError = new EventEmitter();
-    @Output() isLoading = new BehaviorSubject<boolean>(false);
+
+    isLoading$ = new BehaviorSubject<boolean>(false);
 
     tableHeaders: FreqTableHeaders = [
         { key: 'key', label: 'Term' },
@@ -58,6 +61,11 @@ export class WordcloudComponent implements OnChanges, OnDestroy {
     private batchSize = 1000;
 
     constructor(private visualizationService: VisualizationService) {}
+
+    @HostBinding('class.is-loading')
+    get isLoading() {
+        return this.isLoading$.value;
+    }
 
     get readyToLoad() {
         return (
@@ -88,7 +96,7 @@ export class WordcloudComponent implements OnChanges, OnDestroy {
 
     loadData() {
         showLoading(
-            this.isLoading,
+            this.isLoading$,
             this.visualizationService
                 .getWordcloudData(
                     this.visualizedField.name,

--- a/frontend/src/app/word-models/related-words/related-words.component.ts
+++ b/frontend/src/app/word-models/related-words/related-words.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, HostBinding, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import * as _ from 'lodash';
@@ -15,13 +15,16 @@ import { formIcons } from '../../shared/icons';
     styleUrls: ['./related-words.component.scss'],
 })
 export class RelatedWordsComponent extends ParamDirective implements OnChanges {
+    @HostBinding('style.display') display = 'block'; // needed for loading spinner positioning
+
     @Input() queryText: string;
     @Input() corpus: Corpus;
     @Input() asTable: boolean;
     @Input() palette: string[];
 
     @Output() relatedWordsError = new EventEmitter();
-    @Output() isLoading = new BehaviorSubject<boolean>(false);
+
+    isLoading$ = new BehaviorSubject<boolean>(false);
 
     neighbours = 5;
 
@@ -42,6 +45,11 @@ export class RelatedWordsComponent extends ParamDirective implements OnChanges {
         super(route, router, paramService);
     }
 
+    @HostBinding('class.is-loading')
+    get isLoading() {
+        return this.isLoading$.value;
+    }
+
     ngOnChanges(changes: SimpleChanges) {
         if (changes.corpus || changes.queryText) {
             this.getData();
@@ -58,7 +66,7 @@ export class RelatedWordsComponent extends ParamDirective implements OnChanges {
 
     getData(): void {
         this.setParams({ neighbours: this.neighbours });
-        showLoading(this.isLoading, this.getTotalData());
+        showLoading(this.isLoading$, this.getTotalData());
     }
 
     getTotalData(): Promise<void> {

--- a/frontend/src/app/word-models/word-models.component.html
+++ b/frontend/src/app/word-models/word-models.component.html
@@ -51,14 +51,12 @@
                             <ia-related-words *ngIf="tab === 'relatedwords'"
                                 [corpus]="corpus" [queryText]="activeQuery"
                                 [asTable]="asTable" [palette]="palette"
-                                (isLoading)="onIsLoading($event)"
                                 (relatedWordsError)="setErrorMessage($event)">
                             </ia-related-words>
 
                             <ia-word-similarity *ngIf="tab === 'wordsimilarity'"
                                 [corpus]="corpus" [queryText]="activeQuery"
                                 [asTable]="asTable" [palette]="palette"
-                                (isLoading)="onIsLoading($event)"
                                 (wordSimilarityError)="setErrorMessage($event)">
                             </ia-word-similarity>
                         </div>

--- a/frontend/src/app/word-models/word-models.component.ts
+++ b/frontend/src/app/word-models/word-models.component.ts
@@ -1,4 +1,4 @@
-import { Component, DoCheck, ElementRef, HostListener, ViewChild } from '@angular/core';
+import { Component, ElementRef, HostListener, ViewChild } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import * as _ from 'lodash';
 
@@ -12,7 +12,7 @@ import { visualizationIcons } from '../shared/icons';
     templateUrl: './word-models.component.html',
     styleUrls: ['./word-models.component.scss'],
 })
-export class WordModelsComponent extends ParamDirective implements DoCheck {
+export class WordModelsComponent extends ParamDirective {
     @ViewChild('searchSection', { static: false })
     public searchSection: ElementRef;
     public isScrolledDown: boolean;
@@ -44,8 +44,6 @@ export class WordModelsComponent extends ParamDirective implements DoCheck {
 
     visualizationIcons = visualizationIcons;
 
-    childComponentLoading: boolean;
-    isLoading: boolean;
     errorMessage: string;
 
     queryFeedback: QueryFeedback;
@@ -76,12 +74,6 @@ export class WordModelsComponent extends ParamDirective implements DoCheck {
         // mark that the search results have been scrolled down and we should some border
         this.isScrolledDown =
             this.searchSection.nativeElement.getBoundingClientRect().y === 0;
-    }
-
-    ngDoCheck() {
-        if (this.isLoading !== this.childComponentLoading) {
-            this.isLoading = this.childComponentLoading;
-        }
     }
 
     async initialize(): Promise<void> {
@@ -143,10 +135,6 @@ export class WordModelsComponent extends ParamDirective implements DoCheck {
                 similarTerms: result.similar_keys,
             };
         }
-    }
-
-    onIsLoading(isLoading: boolean): void {
-        this.childComponentLoading = isLoading;
     }
 
     setErrorMessage(event: { message: string }): void {

--- a/frontend/src/app/word-models/word-similarity/word-similarity.component.ts
+++ b/frontend/src/app/word-models/word-similarity/word-similarity.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, HostBinding, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import * as _ from 'lodash';
 import { BehaviorSubject } from 'rxjs';
 import { showLoading } from '../../utils/utils';
@@ -11,13 +11,16 @@ import { WordmodelsService } from '../../services';
     styleUrls: ['./word-similarity.component.scss'],
 })
 export class WordSimilarityComponent implements OnChanges {
+    @HostBinding('style.display') display = 'block'; // needed for loading spinner positioning
+
     @Input() queryText: string;
     @Input() corpus: Corpus;
     @Input() asTable: boolean;
     @Input() palette: string[];
 
     @Output() wordSimilarityError = new EventEmitter();
-    @Output() isLoading = new BehaviorSubject<boolean>(false);
+
+    isLoading$ = new BehaviorSubject<boolean>(false);
 
     comparisonTermLimit = Infinity;
     comparisonTerms: string[] = [];
@@ -28,6 +31,11 @@ export class WordSimilarityComponent implements OnChanges {
     data: WordSimilarity[];
 
     constructor(private wordModelsService: WordmodelsService) {}
+
+    @HostBinding('class.is-loading')
+    get isLoading() {
+        return this.isLoading$.value;
+    }
 
     get tableFileName(): string {
         return `word similarity - ${this.queryText} - ${this.corpus?.title}`;
@@ -53,7 +61,7 @@ export class WordSimilarityComponent implements OnChanges {
 
     getData(): void {
         showLoading(
-            this.isLoading,
+            this.isLoading$,
             Promise.all(
                 this.comparisonTerms.map((term) =>
                     this.wordModelsService.getWordSimilarity(


### PR DESCRIPTION
Fixes the NgDoCheck / NgOnChanges lifecycle conflict in the visualisation component (close #1365 )

This is done the way I suggest in that issue, by letting visualisations handle their own loading spinner rather than setting it from the parent component. For consistency, this is also implemented for the word model component.