### PR TITLE
Fix rendering of geopoint array

### DIFF
--- a/frontend/src/app/document-view/document-view.component.html
+++ b/frontend/src/app/document-view/document-view.component.html
@@ -23,9 +23,7 @@
                                 [attr.lang]="document.language(field)"
                                 [innerHtml]="formatInnerHtml(field)">
                             </td>
-                            <td *ngIf="isGeoPointField(field)">
-                                Lat: {{document.fieldValue(field).coordinates[1]}}, Lon: {{document.fieldValue(field).coordinates[0]}}
-                            </td>
+                            <td *ngIf="isGeoPointField(field)">{{displayGeoPointField(field)}}</td>
                             <td *ngIf="isUrlField(field)">
                                 <a href={{document.fieldValue(field)}} target="_blank">{{document.fieldValue(field)}}</a>
                             </td>

--- a/frontend/src/app/document-view/document-view.component.html
+++ b/frontend/src/app/document-view/document-view.component.html
@@ -18,10 +18,13 @@
                     <ng-container *ngFor="let field of propertyFields">
                         <tr *ngIf="document.fieldValue(field)">
                             <th [iaBalloon]="field.description" iaBalloonPosition="up" iaBalloonLength="medium">{{field.displayName}}</th>
-                            <td *ngIf="!isUrlField(field)"
+                            <td *ngIf="!isUrlField(field) && !isGeoPointField(field)"
                                 data-test-field-value
                                 [attr.lang]="document.language(field)"
                                 [innerHtml]="formatInnerHtml(field)">
+                            </td>
+                            <td *ngIf="isGeoPointField(field)">
+                                Lat: {{document.fieldValue(field).coordinates[1]}}, Lon: {{document.fieldValue(field).coordinates[0]}}
                             </td>
                             <td *ngIf="isUrlField(field)">
                                 <a href={{document.fieldValue(field)}} target="_blank">{{document.fieldValue(field)}}</a>

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -73,7 +73,7 @@ export class DocumentViewComponent implements OnChanges {
     }
 
     isGeoPointField(field: CorpusField) {
-        return field.name === 'coordinates';
+        return field.mappingType === 'geo_point';
     }
 
     /**

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -76,6 +76,15 @@ export class DocumentViewComponent implements OnChanges {
         return field.mappingType === 'geo_point';
     }
 
+    displayGeoPointField(field: CorpusField) {
+        let latitude = this.document.fieldValue(field)[field.name][1];
+        let longitude = this.document.fieldValue(field)[field.name][0];
+        // Round to 2 decimal places
+        latitude = Math.round(latitude * 100) / 100;
+        longitude = Math.round(longitude * 100) / 100;
+        return `Lat: ${latitude}; Lon: ${longitude}`;
+    }
+
     /**
      * Checks if user has selected fields in the queryModel and whether current field is among them
      * Used to check which fields need to be highlighted

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -72,6 +72,10 @@ export class DocumentViewComponent implements OnChanges {
         return field.name === 'url' || field.name.startsWith('url_');
     }
 
+    isGeoPointField(field: CorpusField) {
+        return field.name === 'coordinates';
+    }
+
     /**
      * Checks if user has selected fields in the queryModel and whether current field is among them
      * Used to check which fields need to be highlighted

--- a/frontend/src/app/models/corpus.ts
+++ b/frontend/src/app/models/corpus.ts
@@ -112,7 +112,7 @@ export class CorpusField {
     downloadable: boolean;
     name: string;
     filterOptions: FieldFilterOptions;
-    mappingType: 'text' | 'keyword' | 'boolean' | 'date' | 'integer' | null;
+    mappingType: 'text' | 'keyword' | 'boolean' | 'date' | 'integer' | 'geo_point' | null;
     language: string;
 
     constructor(data: ApiCorpusField) {


### PR DESCRIPTION
The coordinates field was rendered as `[object Object]`.

The coordinates [should be](https://www.elastic.co/guide/en/elasticsearch/reference/8.12/geo-point.html) `Geopoint expressed as an array with the format: [ lon, lat]`.

I'm leaving this in draft in case we want to use a different representation in the elasticsearch index, because the order of lat/lon is inconsistent in some of the current indexed data.