### PR TITLE
versioning docs

### DIFF
--- a/documentation/Making-a-release.md
+++ b/documentation/Making-a-release.md
@@ -1,6 +1,6 @@
 # Making a release
 
-This is a quick checklist for developers.
+This is a quick checklist for developers publishing new releases. For more information about when to make releases and what to label them, see [Versioning](./Versioning.md).
 
 It's recommended that you use [git-flow to make releases](https://danielkummer.github.io/git-flow-cheatsheet/#release), but it's not technically required.
 
@@ -14,7 +14,7 @@ Check if anything ought to be included with the new release:
 
 ## Make a release branch
 
-Determine if your release is a major, minor, or patch release to figure out the version number.
+Determine if your release is a major, minor, or patch release to figure out the version number (see [Versioning](./Versioning.md)).
 
 Start a new branch for your releases. Use `git flow release start x.x.x` or `git flow hotfix start x.x.x`.
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -35,6 +35,7 @@ This directory contains documentation for developers.
 - [Email](./Email.md) (used for downloads and authentication)
 - [SAML](./SAML.md)
 
-## Other
+## Making releases
 
+- [Versioning](./Versioning.md)
 - [Making a release](./Making-a-release.md)

--- a/documentation/Versioning.md
+++ b/documentation/Versioning.md
@@ -1,0 +1,59 @@
+# Versioning
+
+This document describes how versions are labelled, when we bring out new versions of I-analyzer, and what you can expect when updating to a new version.
+
+If you're a developer, you can use this document to determine what the label should be for your new version. After that, walk through the checklist in [Making a release](./Making-a-release.md) to publish the new version.
+
+## Release labelling
+
+I-analyzer versions are based on [semantic versioning](https://semver.org/), so we distinguish between _major_, _minor_, and _patch_ releases. However, note that I-analyzer is primarily a user application and does not offer a public API, so it does _not_ conform to semantic versioning.
+
+Since I-analyzer is not centered on an API, it's not always obvious what is considered "breaking" change. The lists below gives a more detailed breakdown of what can be included in a patch, minor, or major release.
+
+A _patch_ release can include:
+
+- Fixes to bugs
+- Performance improvements
+- Changes to the backend API
+- Changes to the python or npm dependencies
+- Database migrations
+- Code quality improvements
+- Documentation improvements
+
+However, patch release cannot make meaningful changes to the frontend behaviour, deep routing in the frontend, or require updates in the server configuration.
+
+A _minor_ release can include:
+
+- Everything listed for patch releases
+- New functionality in the frontend
+- Layout changes to the frontend that don't remove functionality
+- Backwards compatible changes to routing in the frontend. A change is backwards compatible if URLs from older versions will still direct to the same content.
+- New corpus definitions
+- Changes to corpus definitions where updating existing definitions is not required, such as new options or source data types
+- Changes that require minor updates to the server configuration that are backwards compatible, such as a new Django setting or environment variable.
+
+A _major_ release can inclue:
+
+- Everything listed for minor releases
+- Removing functionality in the frontend
+- Backwards incompatible changes to routing in the frontend: URLs from older versions will no longer direct to the same content
+- Backwards incompatible changes to corpus definitions: these require updating existing definitions
+- Changes that require updating the server configuration in a way that is _not_ backwards compatible
+
+## When to make a release
+
+I-analyzer brings out regular releases every month. These are usually _minor_ releases that introduce a few new features and some bug fixes. For urgent bug fixes, we can also make _patch_ releases before the end of the month.
+
+## Updating to a new version
+
+If you're running an instance of I-analyzer and a new version is released:
+
+Updating after _patch_ releases is always recommended and should be straightforward. Make sure to:
+
+- Pull the latest version of the source code
+- Run `yarn postinstall` to update dependencies
+- Run `yarn django migrate` to run migrations
+
+On our own servers, the deployment script (`deploy.py`) takes care of all these steps.
+
+For _minor_ and _major_ releases, make sure to check the release notes to see if they require changes to the server configuration. Note that for major releases, these changes may require significant work or make your server incompatible with older versions of I-analyzer.


### PR DESCRIPTION
Adds documentation on versioning. Notably, I've tried to describe when a new version should be a patch/minor/major release, which I've found to be unclear on past occasions. Like many of our applications, I-analyzer cannot strictly conform to semver because it doesn't have an API, so I think it's useful to add some clarification.

It's also intended to provide some clarity for anyone who wants to host I-analyzer themselves.

This update is prescriptive rather than descriptive; read it as "going forward, we should do it like this". It mostly describes how we're already doing things, but not always.