### PR TITLE
Bugfix/parse weird doc ids

### DIFF
--- a/backend/tag/tests/test_views.py
+++ b/backend/tag/tests/test_views.py
@@ -95,8 +95,12 @@ def test_patch_document_tags(auth_client, auth_user_tag, mock_corpus, auth_user_
         { 'tags': [auth_user_tag.id] }
     )
 
+
     assert status.is_success(response.status_code)
     assert len(response.data['tags']) == auth_user_tag.count == 1
+
+    doc = TaggedDocument.objects.get(doc_id=new_doc)
+    assert doc.tags.count() == 1
 
     response = patch_request({
         'tags': []
@@ -104,6 +108,7 @@ def test_patch_document_tags(auth_client, auth_user_tag, mock_corpus, auth_user_
 
     assert status.is_success(response.status_code)
     assert auth_user_tag.count == 0
+
 
 def test_assign_multiple_tags_at_once(auth_client, multiple_tags, mock_corpus, auth_user_corpus_acces):
     doc = 'test'
@@ -135,7 +140,6 @@ def test_assign_multiple_tags_one_by_one(auth_client, multiple_tags, mock_corpus
 
         assert status.is_success(response.status_code)
         doc = TaggedDocument.objects.get(doc_id=doc)
-        n_tags = doc.tags.count()
         assert doc.tags.count() == i + 1
 
 def test_patch_tags_contamination(auth_client, auth_user_tag, admin_user_tag, mock_corpus, mock_corpus_obj, auth_user_corpus_acces):

--- a/backend/tag/urls.py
+++ b/backend/tag/urls.py
@@ -1,6 +1,6 @@
-from django.urls import path
+from django.urls import path, re_path
 from .views import DocumentTagsView
 
 urlpatterns = [
-    path('document_tags/<str:corpus>/<str:doc_id>', DocumentTagsView.as_view())
+    re_path(r'^document_tags/(?P<corpus>[A-Za-z\-_]+)/(?P<doc_id>).+$', DocumentTagsView.as_view())
 ]

--- a/backend/tag/urls.py
+++ b/backend/tag/urls.py
@@ -2,5 +2,5 @@ from django.urls import path, re_path
 from .views import DocumentTagsView
 
 urlpatterns = [
-    re_path(r'^document_tags/(?P<corpus>[A-Za-z\-_]+)/(?P<doc_id>).+$', DocumentTagsView.as_view())
+    re_path(r'^document_tags/(?P<corpus>[A-Za-z\-_]+)/(?P<doc_id>.+)$', DocumentTagsView.as_view())
 ]


### PR DESCRIPTION
Fixes all immediate issues when document IDs contain "weird" characters such as slashes, which messed up url parsing (close #1380)

In the future, we could consider a requirement that document IDs should be slugs? But that would require re-indexing.