### PR TITLE
Refactor visualisation selection

### DIFF
--- a/frontend/src/app/models/visualization-selector.spec.ts
+++ b/frontend/src/app/models/visualization-selector.spec.ts
@@ -1,0 +1,78 @@
+import * as _ from 'lodash';
+import { mockCorpus3 } from '../../mock-data/corpus';
+import { SimpleStore } from '../store/simple-store';
+import { Store } from '../store/types';
+import { Corpus } from './corpus';
+import { QueryModel } from './query';
+import { VisualizationSelector } from './visualization-selector';
+
+describe('VisualizationSelector', () => {
+    let store: Store;
+    let corpus: Corpus;
+    let query: QueryModel;
+    let selector: VisualizationSelector;
+
+    beforeEach(() => {
+        corpus = _.cloneDeep(mockCorpus3);
+        corpus.fields[0].visualizations = ['resultscount', 'termfrequency'];
+        corpus.fields[1].visualizations = ['wordcloud'];
+        corpus.fields[2].visualizations = ['resultscount', 'termfrequency'];
+
+    });
+
+    beforeEach(() => {
+        store = new SimpleStore();
+        query = new QueryModel(corpus);
+    });
+
+    it('should initialise with default values', () => {
+        selector = new VisualizationSelector(store, query);
+        expect(selector.state$.value).toEqual({
+            name: 'resultscount',
+            field: corpus.fields[0]
+        });
+    });
+
+    it('should intialise from parameters', () => {
+        store.paramUpdates$.next({
+            visualize: 'wordcloud',
+            visualizedField: 'speech'
+        });
+
+        selector = new VisualizationSelector(store, query);
+        expect(selector.state$.value).toEqual({
+            name: 'wordcloud',
+            field: corpus.fields[1]
+        });
+    });
+
+    it('should set the visualisation type', () => {
+        selector = new VisualizationSelector(store, query);
+        selector.setVisualizationType('termfrequency');
+        expect(selector.state$.value).toEqual({
+            name: 'termfrequency',
+            field: corpus.fields[0]
+        });
+
+        selector.setVisualizationType('wordcloud');
+        expect(selector.state$.value).toEqual({
+            name: 'wordcloud',
+            field: corpus.fields[1],
+        });
+    });
+
+    it('should set the visualisation field', () => {
+        selector = new VisualizationSelector(store, query);
+        selector.setVisualizedField(corpus.fields[2]);
+        expect(selector.state$.value).toEqual({
+            name: 'resultscount',
+            field: corpus.fields[2],
+        });
+
+        selector.setVisualizedField(corpus.fields[1]);
+        expect(selector.state$.value).toEqual({
+            name: 'wordcloud',
+            field: corpus.fields[1],
+        });
+    });
+});

--- a/frontend/src/app/models/visualization-selector.spec.ts
+++ b/frontend/src/app/models/visualization-selector.spec.ts
@@ -33,6 +33,14 @@ describe('VisualizationSelector', () => {
         });
     });
 
+    it('should update the store on init', () => {
+        selector = new VisualizationSelector(store, query);
+        expect(store.currentParams()).toEqual({
+            visualize: 'resultscount',
+            visualizedField: 'great_field',
+        });
+    });
+
     it('should intialise from parameters', () => {
         store.paramUpdates$.next({
             visualize: 'wordcloud',

--- a/frontend/src/app/models/visualization-selector.ts
+++ b/frontend/src/app/models/visualization-selector.ts
@@ -54,6 +54,12 @@ export class VisualizationSelector extends StoreSync<VisualizationSelection> {
         ).subscribe(() => this.checkActiveOption());
     }
 
+    /**
+     * set the visualisation type.
+     *
+     * preserves the visualisation field, unless it is not available for the
+     * given visualisation.
+     */
     setVisualizationType(name: string) {
         const selection = findByName(this.options, name);
         const currentField = this.state$.value.field;
@@ -64,6 +70,11 @@ export class VisualizationSelector extends StoreSync<VisualizationSelection> {
         }
     }
 
+    /** set the visualised corpus field.
+     *
+     * preserves the visualisation type, unless it is not available for the
+     * given field.
+     */
     setVisualizedField(field: CorpusField) {
         const currentVisualisation = this.state$.value.name;
 
@@ -94,6 +105,9 @@ export class VisualizationSelector extends StoreSync<VisualizationSelection> {
         }
     }
 
+    /**
+     * generates a list of options for visualisation types.
+     */
     private getVisualizationOptions(query: QueryModel): VisualizationOption[] {
         const hasVisualizations = (field: CorpusField) => field.visualizations?.length;
 
@@ -115,6 +129,10 @@ export class VisualizationSelector extends StoreSync<VisualizationSelection> {
         });
     }
 
+    /**
+     * observable of when the given visualisation type should be disabled
+     * based on the query state.
+     */
     private disabled$(name: string, query: QueryModel): Observable<boolean> {
         const now = timer();
         const updates = merge(now, query.update);
@@ -123,6 +141,9 @@ export class VisualizationSelector extends StoreSync<VisualizationSelection> {
         );
     }
 
+    /** whether the given visualisation type should be disabled based on the
+     * _current_ query state.
+     */
     private disabled(name: string, query: QueryModel): boolean {
         if (REQUIRE_SEARCH_TERM.includes(name)) {
             return _.isEmpty(query.queryText);
@@ -131,6 +152,11 @@ export class VisualizationSelector extends StoreSync<VisualizationSelection> {
         }
     }
 
+    /** returns the default state for the visualisation selector.
+     *
+     * filters the pre-generated list of options based on the query state,
+     * and picks the first enabled option.
+     */
     private getDefaultOption(
         options: VisualizationOption[], query: QueryModel
     ): VisualizationSelection {
@@ -139,6 +165,9 @@ export class VisualizationSelector extends StoreSync<VisualizationSelection> {
         return { name: selected.name, field: _.first(selected.fields) };
     }
 
+    /**
+     * synchronous function to check the currently active visualisation option.
+     */
     private activeOption(state: VisualizationSelection): VisualizationOption {
         return findByName(this.options, state.name);
     }

--- a/frontend/src/app/models/visualization-selector.ts
+++ b/frontend/src/app/models/visualization-selector.ts
@@ -5,7 +5,7 @@ import { Store } from '../store/types';
 import { QueryModel } from './query';
 import { findByName } from '../utils/utils';
 import * as _ from 'lodash';
-import { Observable, of } from 'rxjs';
+import { Observable, merge, of, timer } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 export interface VisualizationSelection {
@@ -113,11 +113,13 @@ export class VisualizationSelector extends StoreSync<VisualizationSelection> {
 
     private disabled$(name: string, query: QueryModel): Observable<boolean> {
         if (REQUIRE_SEARCH_TERM.includes(name)) {
-            return query.update.pipe(
-                map(() => !!query.queryText)
+            const now = timer();
+            const updates = merge(now, query.update);
+            return updates.pipe(
+                map(() => _.isEmpty(query.queryText)),
             );
         } else {
-            return of(true);
+            return of(false);
         }
     }
 

--- a/frontend/src/app/models/visualization-selector.ts
+++ b/frontend/src/app/models/visualization-selector.ts
@@ -1,0 +1,128 @@
+import { Params } from '@angular/router';
+import { StoreSync } from '../store/store-sync';
+import { CorpusField } from './corpus';
+import { Store } from '../store/types';
+import { QueryModel } from './query';
+import { findByName } from '../utils/utils';
+import * as _ from 'lodash';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export interface VisualizationSelection {
+    name: string;
+    field: CorpusField;
+}
+
+export interface VisualizationOption {
+    name: string;
+    label: string;
+    fields: CorpusField[];
+    disabled$: Observable<boolean>;
+}
+
+const REQUIRE_SEARCH_TERM = ['termfrequency', 'ngram'];
+
+const DISPLAY_NAMES = {
+    resultscount: 'Number of results',
+    termfrequency: 'Frequency of the search term',
+    ngram: 'Neighbouring words',
+    wordcloud: 'Most frequent words',
+};
+
+export class VisualizationSelector extends StoreSync<VisualizationSelection> {
+    options: VisualizationOption[];
+    activeOption$: Observable<VisualizationOption>;
+
+    defaultState: VisualizationSelection;
+
+    protected keysInStore = ['visualize', 'visualizedField'];
+
+    constructor(
+        store: Store,
+        public query: QueryModel,
+    ) {
+        super(store);
+        this.options = this.getVisualizationOptions(this.query);
+        this.defaultState = this.getDefaultOption(this.options);
+        this.connectToStore();
+        this.activeOption$ = this.state$.pipe(
+            map(state => findByName(this.options, state.name))
+        );
+    }
+
+    setVisualizationType(name: string) {
+        const selection = findByName(this.options, name);
+        const currentField = this.state$.value.field;
+        if (selection.fields.includes(currentField)) {
+            this.setParams({name});
+        } else {
+            this.setParams({name, field: selection.fields[0]});
+        }
+    }
+
+    setVisualizedField(field: CorpusField) {
+        const currentVisualisation = this.state$.value.name;
+
+        if (field.visualizations.includes(currentVisualisation)) {
+            this.setParams({field});
+        } else {
+            this.setParams({field, name: field.visualizations[0]});
+        }
+    }
+
+    protected stateToStore(state: VisualizationSelection): Params {
+        return {
+            visualize: state.name || null,
+            visualizedField: state.field?.name || null,
+        };
+    }
+
+    protected storeToState(params: Params): VisualizationSelection {
+        const name = params['visualize'];
+
+        if (name) {
+            const fieldName = params['visualizedField'];
+            const field = findByName(this.query.corpus.fields, fieldName);
+
+            return { name, field };
+        } else {
+            return this.defaultState;
+        }
+    }
+
+    private getVisualizationOptions(query: QueryModel): VisualizationOption[] {
+        const hasVisualizations = (field: CorpusField) => field.visualizations?.length;
+
+        const fields = query.corpus.fields.filter(hasVisualizations);
+        const names = _.uniq(
+            _.flatMap(fields, field => field.visualizations)
+        );
+
+        return names.map(name => {
+            const label = DISPLAY_NAMES[name];
+            const filteredFields = fields.filter(field => field.visualizations.includes(name));
+            const disabled$ = this.disabled$(name, query);
+            return {
+                name,
+                label,
+                fields: filteredFields,
+                disabled$,
+            };
+        });
+    }
+
+    private disabled$(name: string, query: QueryModel): Observable<boolean> {
+        if (REQUIRE_SEARCH_TERM.includes(name)) {
+            return query.update.pipe(
+                map(() => !!query.queryText)
+            );
+        } else {
+            return of(true);
+        }
+    }
+
+    private getDefaultOption(options: VisualizationOption[]): VisualizationSelection {
+        const selected = _.first(options);
+        return { name: selected.name, field: _.first(selected.fields) };
+    }
+}

--- a/frontend/src/app/models/visualization-selector.ts
+++ b/frontend/src/app/models/visualization-selector.ts
@@ -44,7 +44,7 @@ export class VisualizationSelector extends StoreSync<VisualizationSelection> {
         super(store);
         this.options = this.getVisualizationOptions(this.query);
         this.defaultState = this.getDefaultOption(this.options, this.query);
-        this.connectToStore();
+        this.connectToStore(true);
         this.activeOption$ = this.state$.pipe(
             map(this.activeOption.bind(this))
         );

--- a/frontend/src/app/shared/dropdown/dropdown-item.directive.ts
+++ b/frontend/src/app/shared/dropdown/dropdown-item.directive.ts
@@ -13,11 +13,29 @@ export class DropdownItemDirective {
 
     @Input() value;
 
+    @Input() disabled: boolean;
+
     @Output() onSelect = new Subject<any>();
 
     focused = new BehaviorSubject<boolean>(false);
 
     constructor(private elementRef: ElementRef, private dropdownService: DropdownService) { }
+
+    /** value bound to [disabled] attribute in the DOM
+     *
+     * If `this.disabled === false`, the bound value is `undefined`
+     *
+     * This is bound to `disabled` attribute which is used as a CSS selector,
+     * but that attribute is not supported for the menuitem role, so we also bind it
+     * to `aria-disabled`. C.f. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role
+     */
+    @HostBinding('attr.disabled')
+    @HostBinding('attr.aria-disabled')
+    get disabledAttribute() {
+        if (this.disabled) {
+            return true;
+        };
+    }
 
     @HostBinding('class.is-active')
     get isActive(): boolean {
@@ -38,9 +56,11 @@ export class DropdownItemDirective {
     @HostListener('keydown.enter')
     @HostListener('keydown.space')
     select() {
-        this.onSelect.next(this.value);
-        this.dropdownService.selection$.next(this.value);
-        return false;
+        if (!this.disabled) {
+            this.onSelect.next(this.value);
+            this.dropdownService.selection$.next(this.value);
+            return false;
+        }
     }
 
     @HostListener('keydown.arrowdown')

--- a/frontend/src/app/store/router-store.service.ts
+++ b/frontend/src/app/store/router-store.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Params, Router } from '@angular/router';
 import { Store } from './types';
 import { Observable, Subject } from 'rxjs';
-import { bufferTime, debounceTime, filter, map } from 'rxjs/operators';
+import { bufferTime, filter, map } from 'rxjs/operators';
 import { mergeAllParams } from '../utils/params';
 import * as _ from 'lodash';
 

--- a/frontend/src/app/store/router-store.service.ts
+++ b/frontend/src/app/store/router-store.service.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@angular/core';
 import { Params, Router } from '@angular/router';
 import { Store } from './types';
 import { Observable, Subject } from 'rxjs';
-import { bufferTime, debounceTime, map } from 'rxjs/operators';
+import { bufferTime, debounceTime, filter, map } from 'rxjs/operators';
 import { mergeAllParams } from '../utils/params';
+import * as _ from 'lodash';
 
 /**
  * Synchronises stored parameters with the route query parameters
@@ -21,6 +22,7 @@ export class RouterStoreService implements Store {
         this.params$ = this.router.routerState.root.queryParams;
         this.paramUpdates$.pipe(
             bufferTime(100),
+            filter(_.negate(_.isEmpty)),
             map(mergeAllParams),
         ).subscribe(this.navigate.bind(this));
     }

--- a/frontend/src/app/store/router-store.service.ts
+++ b/frontend/src/app/store/router-store.service.ts
@@ -2,7 +2,8 @@ import { Injectable } from '@angular/core';
 import { Params, Router } from '@angular/router';
 import { Store } from './types';
 import { Observable, Subject } from 'rxjs';
-import { debounceTime } from 'rxjs/operators';
+import { bufferTime, debounceTime, map } from 'rxjs/operators';
+import { mergeAllParams } from '../utils/params';
 
 /**
  * Synchronises stored parameters with the route query parameters
@@ -19,7 +20,8 @@ export class RouterStoreService implements Store {
     ) {
         this.params$ = this.router.routerState.root.queryParams;
         this.paramUpdates$.pipe(
-            debounceTime(100),
+            bufferTime(100),
+            map(mergeAllParams),
         ).subscribe(this.navigate.bind(this));
     }
 

--- a/frontend/src/app/store/simple-store.ts
+++ b/frontend/src/app/store/simple-store.ts
@@ -3,7 +3,7 @@ import { Store } from './types';
 import { Params } from '@angular/router';
 import * as _ from 'lodash';
 import { map, scan } from 'rxjs/operators';
-import { omitNullParameters } from '../utils/params';
+import { mergeParams, omitNullParameters } from '../utils/params';
 
 /** simple store that does not depend on services or routing
  *
@@ -16,7 +16,7 @@ export class SimpleStore implements Store {
 
     constructor() {
         this.paramUpdates$.pipe(
-            scan(this.merge),
+            scan(mergeParams),
             map(omitNullParameters),
             map(obj => _.mapValues(obj, _.toString))
         ).subscribe(params =>
@@ -26,9 +26,5 @@ export class SimpleStore implements Store {
 
     currentParams(): Params {
         return this.params$.value;
-    }
-
-    private merge(current: Params, next: Params): Params {
-        return  _.assign(_.clone(current), next);
     }
 };

--- a/frontend/src/app/store/store-sync.ts
+++ b/frontend/src/app/store/store-sync.ts
@@ -63,11 +63,17 @@ export abstract class StoreSync<State extends object> {
      *
      * should probably called in the constructor of the child class. (Not called in
      * the parent constructor because you may want access to the child class data)
-     * */
-    protected connectToStore() {
+     *
+     * @param signalStoreUpdate if true, the model will immediately signal the output
+     * of `stateToStore` to the store after connecting. This is useful if the model should
+     * always explicitly store its value, rather than having an empty "default".
+     */
+    protected connectToStore(signalStoreUpdate=false) {
         this.state$ = new BehaviorSubject(this.storeToState(this.store.currentParams()));
         this.subscribeToStore();
-        this.store.paramUpdates$.next(this.stateToStore(this.state$.value));
+        if (signalStoreUpdate) {
+            this.store.paramUpdates$.next(this.stateToStore(this.state$.value));
+        }
     }
 
     /** called on initialisation: subscribes to the store until the model is completed */

--- a/frontend/src/app/store/store-sync.ts
+++ b/frontend/src/app/store/store-sync.ts
@@ -67,6 +67,7 @@ export abstract class StoreSync<State extends object> {
     protected connectToStore() {
         this.state$ = new BehaviorSubject(this.storeToState(this.store.currentParams()));
         this.subscribeToStore();
+        this.store.paramUpdates$.next(this.stateToStore(this.state$.value));
     }
 
     /** called on initialisation: subscribes to the store until the model is completed */

--- a/frontend/src/app/utils/params.ts
+++ b/frontend/src/app/utils/params.ts
@@ -6,11 +6,21 @@ import { PageParameters, PageResultsParameters, RESULTS_PER_PAGE } from '../mode
 import { findByName } from './utils';
 import { SimpleStore } from '../store/simple-store';
 
+// general utility functions
+
 /** omit keys that mapp to null */
 export const omitNullParameters = (params: {[key: string]: any}): {[key: string]: any} => {
     const nullKeys = _.keys(params).filter(key => params[key] === null);
     return _.omit(params, nullKeys);
 };
+
+export const mergeParams = (current: Params, next: Params): Params =>
+    _.assign(_.clone(current), next);
+
+export const mergeAllParams = (values: Params[]): Params =>
+    _.reduce(values, mergeParams);
+
+// conversion between models and parameters
 
 export const queryFromParams = (params: Params): string =>
     params['query'];

--- a/frontend/src/app/visualization/visualization.component.html
+++ b/frontend/src/app/visualization/visualization.component.html
@@ -1,117 +1,126 @@
-<div *ngIf="noVisualizations">
-    <b> This corpus has no fields with associated visualizations. </b>
-</div>
-
-<div class="columns" *ngIf="!noVisualizations" #viscontrol>
-    <div class="column">
-        <div class="field" *ngIf="visDropdown">
-            <label class="label">
-                What do you want to visualise?
-            </label>
-            <div class="control">
-                <ia-dropdown [value]="visualizationTypeDropdownValue"
-                    (onChange)="changeVisualizationType($event.value)">
-                    <span iaDropdownLabel>{{visualizationTypeDropdownValue?.label}}</span>
-                    <div iaDropdownMenu>
-                        <a *ngFor="let option of visDropdown"
-                            iaDropdownItem [value]="option">
-                            {{option.label}}
-                        </a>
+<ng-container *ngIf="selector; else loading">
+    <ng-container *ngIf="selector.options; else noVisualizations">
+        <div class="columns">
+            <div class="column">
+                <div class="field">
+                    <label class="label">
+                        What do you want to visualise?
+                    </label>
+                    <div class="control">
+                        <ia-dropdown [value]="selector.activeOption$ | async">
+                            <span iaDropdownLabel>{{(selector.activeOption$ | async).label}}</span>
+                            <div iaDropdownMenu>
+                                <a *ngFor="let option of selector.options"
+                                    iaDropdownItem [value]="option"
+                                    (onSelect)="setVisualizationType($event)">
+                                    {{option.label}}
+                                </a>
+                            </div>
+                        </ia-dropdown>
                     </div>
-                </ia-dropdown>
+                </div>
+            </div>
+            <div class="column" *ngIf="(selector.activeOption$ | async).fields as fields">
+                <div class="field">
+                    <label class="label" *ngIf="selector.state$ | async as state">
+                        <span *ngIf="state.name === 'resultscount' || state.name === 'termfrequency'">
+                            Compare frequency by:
+                        </span>
+                        <span *ngIf="state.name === 'wordcloud' || state.name === 'ngram'">
+                            Count frequencies in:
+                        </span>
+                    </label>
+                    <div class="control">
+                        <ia-dropdown *ngIf="fields.length > 1"
+                            [value]="(selector.state$ | async).field">
+                            <span iaDropdownLabel>{{(selector.state$ | async).field?.displayName}}</span>
+                            <div iaDropdownMenu>
+                                <a *ngFor="let field of fields"
+                                    iaDropdownItem [value]="field"
+                                    (onSelect)="setVisualizedField($event)">
+                                    {{field.displayName}}
+                                </a>
+                            </div>
+                        </ia-dropdown>
+
+                        <input *ngIf="fields.length === 1" class="input is-static" type="text" [value]="fields[0].displayName">
+                    </div>
+                </div>
+            </div>
+
+            <div class="column is-narrow">
+                <div class="field has-addons">
+                    <!-- Buttons for switching between table and graphical representation -->
+                    <div class="control">
+                        <button class="button" [class.is-primary]="!freqtable" (click)="freqtable = false">
+                            <fa-icon [icon]="visualizationIcons.chart" aria-label="view chart"></fa-icon>
+                        </button>
+                    </div>
+                    <div class="control">
+                        <button class="button" [class.is-primary]="freqtable" (click)="freqtable = true">
+                            <fa-icon [icon]="visualizationIcons.table" aria-label="view table"></fa-icon>
+                        </button>
+                    </div>
+                </div>
             </div>
         </div>
-    </div>
 
-    <div class="column">
-        <label class="field" *ngIf="fieldDropdown">
-            <label class="label">
-                <span *ngIf="visualizationType === 'resultscount' || visualizationType === 'termfrequency'">
-                    Compare frequency by:
-                </span>
-                <span *ngIf="visualizationType === 'wordcloud' || visualizationType === 'ngram'">
-                    Count frequencies in:
-                </span>
-            </label>
-            <div class="control">
-                <ia-dropdown *ngIf="fieldDropdown.length > 1" [value]="visualizedFieldDropdownValue"
-                    (onChange)="changeVisualizedField($event.value)">
-                    <span iaDropdownLabel>{{visualizedFieldDropdownValue?.label}}</span>
-                    <div iaDropdownMenu>
-                        <a *ngFor="let option of fieldDropdown"
-                            iaDropdownItem [value]="option">
-                            {{option.label}}
-                        </a>
-                    </div>
-                </ia-dropdown>
-                <input *ngIf="fieldDropdown.length === 1" class="input is-static" type="text" [value]="visualizedFieldDropdownValue?.label">
+        <div class="message is-danger" *ngIf="error$ | async as error">
+            <div class="message-header">
+                Something went wrong
             </div>
-        </label>
-    </div>
-
-    <div class="column is-narrow">
-        <div class="field has-addons">
-            <!-- Buttons for switching between table and graphical representation -->
-            <div class="control">
-                <button class="button" [class.is-primary]="!freqtable" (click)="freqtable = false">
-                    <fa-icon [icon]="visualizationIcons.chart" aria-label="view chart"></fa-icon>
-                </button>
-            </div>
-            <div class="control">
-                <button class="button" [class.is-primary]="freqtable" (click)="freqtable = true">
-                    <fa-icon [icon]="visualizationIcons.table" aria-label="view table"></fa-icon>
-                </button>
+            <div class="message-body">
+                {{error}}
             </div>
         </div>
-    </div>
-</div>
 
-<ng-container *ngIf="visualExists; else noVisualsMessage">
-    <div class="block">
-        <ng-container [ngSwitch]="visualizationType">
-            <ng-container *ngSwitchCase="'resultscount'">
-                <ia-timeline *ngIf="visualizedField.displayType === 'date'" [corpus]="corpus" [queryModel]="queryModel"
-                [visualizedField]="visualizedField" [frequencyMeasure]="'documents'"
-                [asTable]="freqtable" [palette]="palette"
-                (error)="setErrorMessage($event)"
-                (totalTokenCountAvailable)="showTokenCountOption = $event"></ia-timeline>
-            <ia-histogram *ngIf="visualizedField.displayType !== 'date'" [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
-                [asTable]="freqtable" [palette]="palette"
-                (error)="setErrorMessage($event)"
-                (totalTokenCountAvailable)="showTokenCountOption = $event"></ia-histogram>
-            </ng-container>
-            <ng-container *ngSwitchCase="'termfrequency'">
-                <ia-timeline *ngIf="visualizedField.displayType === 'date'" [corpus]="corpus" [queryModel]="queryModel"
-                    [visualizedField]="visualizedField" [frequencyMeasure]="'tokens'"
+        <div class="block">
+            <ng-container [ngSwitch]="visualizationType">
+                <ng-container *ngSwitchCase="'resultscount'">
+                    <ia-timeline *ngIf="visualizedField.displayType === 'date'" [corpus]="corpus" [queryModel]="queryModel"
+                    [visualizedField]="visualizedField" [frequencyMeasure]="'documents'"
                     [asTable]="freqtable" [palette]="palette"
                     (error)="setErrorMessage($event)"
                     (totalTokenCountAvailable)="showTokenCountOption = $event"></ia-timeline>
                 <ia-histogram *ngIf="visualizedField.displayType !== 'date'" [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
-                    [frequencyMeasure]="'tokens'"
                     [asTable]="freqtable" [palette]="palette"
                     (error)="setErrorMessage($event)"
                     (totalTokenCountAvailable)="showTokenCountOption = $event"></ia-histogram>
+                </ng-container>
+                <ng-container *ngSwitchCase="'termfrequency'">
+                    <ia-timeline *ngIf="visualizedField.displayType === 'date'" [corpus]="corpus" [queryModel]="queryModel"
+                        [visualizedField]="visualizedField" [frequencyMeasure]="'tokens'"
+                        [asTable]="freqtable" [palette]="palette"
+                        (error)="setErrorMessage($event)"
+                        (totalTokenCountAvailable)="showTokenCountOption = $event"></ia-timeline>
+                    <ia-histogram *ngIf="visualizedField.displayType !== 'date'" [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
+                        [frequencyMeasure]="'tokens'"
+                        [asTable]="freqtable" [palette]="palette"
+                        (error)="setErrorMessage($event)"
+                        (totalTokenCountAvailable)="showTokenCountOption = $event"></ia-histogram>
+                </ng-container>
+                <ia-wordcloud *ngSwitchCase=" 'wordcloud' " [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
+                    [resultsCount]="resultsCount" [asTable]="freqtable" [palette]="palette"
+                    (wordcloudError)="setErrorMessage($event)"></ia-wordcloud>
+                <ia-ngram *ngSwitchCase=" 'ngram' " [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
+                    [asTable]="freqtable" [palette]="palette"
+                    (ngramError)="setErrorMessage($event)"></ia-ngram>
             </ng-container>
-            <ia-wordcloud *ngSwitchCase=" 'wordcloud' " [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
-                [resultsCount]="resultsCount" [asTable]="freqtable" [palette]="palette"
-                (wordcloudError)="setErrorMessage($event['message'])"></ia-wordcloud>
-            <ia-ngram *ngSwitchCase=" 'ngram' " [corpus]="corpus" [queryModel]="queryModel" [visualizedField]="visualizedField"
-                [asTable]="freqtable" [palette]="palette"
-                (ngramError)="setErrorMessage($event)"></ia-ngram>
-        </ng-container>
-    </div>
+        </div>
+
+        <ia-visualization-footer [tableView]="freqtable" [manualPage]="manualPage"
+            [chartElementID]="chartElementId" [imageFileName]="imageFileName"
+            (palette)="palette = $event">
+        </ia-visualization-footer>
+    </ng-container>
 </ng-container>
 
-<ia-visualization-footer [tableView]="freqtable" [manualPage]="manualPage"
-    [chartElementID]="chartElementId" [imageFileName]="imageFileName"
-    (palette)="palette = $event">
-</ia-visualization-footer>
+<ng-template #loading>
+    <div class="is-loading" aria-label="loading results"></div>
+</ng-template>
 
-<ng-template #noVisualsMessage>
-    <b> {{foundNoVisualsMessage}} </b>
-    <div class="container" *ngIf="errorMessage && errorMessage.length > 0">
-        <div class="notification is-warning">
-            {{errorMessage}}
-        </div>
+<ng-template #noVisualizations>
+    <div class="block message">
+        This corpus has no fields with associated visualizations.
     </div>
 </ng-template>

--- a/frontend/src/app/visualization/visualization.component.html
+++ b/frontend/src/app/visualization/visualization.component.html
@@ -15,6 +15,11 @@
                                     [disabled]="option.disabled$ | async"
                                     (onSelect)="setVisualizationType($event)">
                                     {{option.label}}
+
+                                    <span *ngIf="option.disabled$ | async"
+                                        class="icon" iaBalloon="this visualisation requires a search term">
+                                        <fa-icon [icon]="actionIcons.help"></fa-icon>
+                                    </span>
                                 </a>
                             </div>
                         </ia-dropdown>

--- a/frontend/src/app/visualization/visualization.component.html
+++ b/frontend/src/app/visualization/visualization.component.html
@@ -12,6 +12,7 @@
                             <div iaDropdownMenu>
                                 <a *ngFor="let option of selector.options"
                                     iaDropdownItem [value]="option"
+                                    [disabled]="option.disabled$ | async"
                                     (onSelect)="setVisualizationType($event)">
                                     {{option.label}}
                                 </a>

--- a/frontend/src/app/visualization/visualization.component.ts
+++ b/frontend/src/app/visualization/visualization.component.ts
@@ -7,7 +7,7 @@ import {
 } from '@angular/core';
 import * as _ from 'lodash';
 import { Corpus, CorpusField, QueryModel } from '../models/index';
-import { visualizationIcons } from '../shared/icons';
+import { actionIcons, visualizationIcons } from '../shared/icons';
 import { RouterStoreService } from '../store/router-store.service';
 import { VisualizationOption, VisualizationSelector } from '../models/visualization-selector';
 import { Observable, Subject, merge } from 'rxjs';
@@ -34,6 +34,7 @@ export class VisualizationComponent implements OnChanges, OnDestroy {
         termfrequency: 'termfrequency',
     };
 
+    actionIcons = actionIcons;
     visualizationIcons = visualizationIcons;
 
     public palette: string[];

--- a/frontend/src/app/visualization/visualization.component.ts
+++ b/frontend/src/app/visualization/visualization.component.ts
@@ -1,59 +1,32 @@
 import {
     Component,
-    DoCheck,
     Input,
     OnChanges,
+    OnDestroy,
     SimpleChanges,
 } from '@angular/core';
 import * as _ from 'lodash';
-import { SelectItem } from 'primeng/api';
-import { ActivatedRoute, Params, Router } from '@angular/router';
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
 import { Corpus, CorpusField, QueryModel } from '../models/index';
-import { ParamDirective } from '../param/param-directive';
-import { ParamService } from '../services';
-import { findByName } from '../utils/utils';
 import { visualizationIcons } from '../shared/icons';
+import { RouterStoreService } from '../store/router-store.service';
+import { VisualizationOption, VisualizationSelector } from '../models/visualization-selector';
+import { Observable, Subject, merge } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Component({
     selector: 'ia-visualization',
     templateUrl: './visualization.component.html',
     styleUrls: ['./visualization.component.scss'],
 })
-export class VisualizationComponent
-    extends ParamDirective
-    implements OnChanges
-{
+export class VisualizationComponent implements OnChanges, OnDestroy {
     @Input() public corpus: Corpus;
     @Input() public queryModel: QueryModel;
 
-    public allVisualizationFields: CorpusField[];
+    selector: VisualizationSelector;
 
-    public showTableButtons: boolean;
 
-    public visualizationType: string;
-    public filteredVisualizationFields: CorpusField[];
-    public visualizedField: CorpusField;
-
-    public noResults = 'Did not find data to visualize.';
-    public foundNoVisualsMessage: string = this.noResults;
-    public errorMessage = '';
-    public noVisualizations: boolean;
-
-    public visDropdown: SelectItem[];
-    public fieldDropdown: SelectItem[];
-    public visualizationTypeDropdownValue: SelectItem;
-    public visualizedFieldDropdownValue: SelectItem;
-
-    public visualizations: string[];
     public freqtable = false;
-    public visualizationsDisplayNames = {
-        resultscount: 'Number of results',
-        termfrequency: 'Frequency of the search term',
-        ngram: 'Neighbouring words',
-        wordcloud: 'Most frequent words',
-    };
+
     public manualPages = {
         ngram: 'ngrams',
         wordcloud: 'wordcloud',
@@ -63,28 +36,29 @@ export class VisualizationComponent
 
     visualizationIcons = visualizationIcons;
 
-    public visualExists = false;
-
     public palette: string[];
-    public params: Params = {};
 
-    nullableParameters = ['visualize', 'visualizedField'];
+    error$: Observable<string|undefined>;
 
-    private reset$ = new Subject<void>();
-    private destroy$ = new Subject<void>();
+    private errorInChild$ = new Subject<string>();
 
     constructor(
-        route: ActivatedRoute,
-        router: Router,
-        paramService: ParamService
+        private routerStoreService: RouterStoreService,
     ) {
-        super(route, router, paramService);
     }
 
     get manualPage(): string {
         if (this.visualizationType) {
             return this.manualPages[this.visualizationType];
         }
+    }
+
+    get visualizationType(): string {
+        return this.selector.state$.value.name;
+    }
+
+    get visualizedField(): CorpusField {
+        return this.selector.state$.value.field;
     }
 
     get chartElementId(): string {
@@ -110,147 +84,28 @@ export class VisualizationComponent
 
     ngOnChanges(changes: SimpleChanges) {
         if (changes.queryModel || changes.corpus) {
-            this.reset$.next();
-            this.initialize();
-        }
-    }
+            this.selector = new VisualizationSelector(this.routerStoreService, this.queryModel);
 
-    setVistypeDropdown() {
-        this.allVisualizationFields = [];
-        if (this.corpus && this.corpus.fields) {
-            this.allVisualizationFields = this.corpus.fields.filter(
-                (field) => field.visualizations?.length
+            const errorReset$ = this.selector.state$.pipe(
+                map(_.constant(undefined))
             );
-        }
-        const visualisationTypes = _.uniq(
-            _.flatMap(
-                this.allVisualizationFields,
-                (field) => field.visualizations
-            )
-        );
-        const filteredTypes = visualisationTypes.filter((vt) =>
-            this.includeVisualisationType(vt, this.queryModel)
-        );
-        this.visDropdown = this.vistypesToDropdown(filteredTypes);
-    }
-
-    initialize() {
-        this.refreshVisualisations();
-        this.queryModel?.update
-            .pipe(takeUntil(this.destroy$), takeUntil(this.reset$))
-            .subscribe(() => this.refreshVisualisations());
-    }
-
-    refreshVisualisations() {
-        this.setVistypeDropdown();
-        this.showTableButtons = true;
-        if (!this.allVisualizationFields.length) {
-            this.noVisualizations = true;
-        } else {
-            this.noVisualizations = false;
-            this.setVisualizationType(
-                this.allVisualizationFields[0].visualizations[0]
-            );
-            this.updateParams();
+            this.error$ = merge(errorReset$, this.errorInChild$);
         }
     }
 
-    teardown() {
-        this.reset$.complete();
-        this.destroy$.next();
-        this.destroy$.complete();
+    ngOnDestroy(): void {
+        this.selector?.complete();
     }
 
-    setStateFromParams(params: Params) {
-        if (params.has('visualize')) {
-            this.setVisualizationType(params.get('visualize'));
-            const visualizedField = findByName(
-                this.corpus.fields,
-                params.get('visualizedField')
-            );
-            this.setVisualizedField(visualizedField);
-        }
-        this.visualizationTypeDropdownValue =
-            this.visDropdown.find(
-                (item) => item.value === this.visualizationType
-            ) || this.visDropdown[0];
-    }
-
-    updateParams() {
-        this.params['visualize'] = this.visualizationType;
-        this.params['visualizedField'] = this.visualizedField.name;
-        this.setParams(this.params);
-    }
-
-    setVisualizationType(visType: string) {
-        this.visualizationType = visType;
-        this.filteredVisualizationFields = this.allVisualizationFields.filter(
-            (field) => field.visualizations.includes(visType)
-        );
-        this.fieldDropdown = this.fieldsToDropdown(
-            this.filteredVisualizationFields
-        );
-        this.visualizedField = this.filteredVisualizationFields[0];
-        this.visualizedFieldDropdownValue =
-            this.fieldDropdown.find(
-                (item) => item.value === this.visualizedField
-            ) || this.fieldDropdown[0];
-    }
-
-    changeVisualizationType(visType: string) {
-        this.setVisualizationType(visType);
-        this.updateParams();
+    setVisualizationType(selection: VisualizationOption) {
+        this.selector.setVisualizationType(selection.name);
     }
 
     setVisualizedField(selectedField: CorpusField) {
-        this.errorMessage = '';
-        this.visualExists = true;
-
-        this.visualizedField = selectedField;
-        this.visualizedFieldDropdownValue = this.fieldDropdown.find(
-            (item) => item.value === this.visualizedField
-        );
-
-        this.foundNoVisualsMessage = 'Retrieving data...';
-    }
-
-    changeVisualizedField(selectedField: CorpusField) {
-        this.setVisualizedField(selectedField);
-        this.updateParams();
+        this.selector.setVisualizedField(selectedField);
     }
 
     setErrorMessage(message: string) {
-        this.visualExists = false;
-        this.foundNoVisualsMessage = this.noResults;
-        this.errorMessage = message;
-    }
-
-    private includeVisualisationType(
-        visType: string,
-        queryModel: QueryModel
-    ): boolean {
-        const requiresSearchTerm = _.includes(
-            ['termfrequency', 'ngram'],
-            visType
-        );
-        return !requiresSearchTerm || !!queryModel.queryText;
-    }
-
-    private vistypesToDropdown(
-        visTypes: string[]
-    ): { label: string; value: string }[] {
-        return visTypes.map((visType) => ({
-            label: this.visualizationsDisplayNames[visType],
-            value: visType,
-        }));
-    }
-
-    private fieldsToDropdown(
-        fields: CorpusField[]
-    ): { label: string; value: CorpusField }[] {
-        return fields.map((field) => ({
-            label: field.displayName || field.name,
-            value: field,
-        }));
+        this.errorInChild$.next(message);
     }
 }

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -60,3 +60,13 @@
 a.dropdown-item:focus {
     @extend a, .dropdown-item, :hover;
 }
+
+a.dropdown-item[disabled] {
+    color: $grey;
+    cursor: not-allowed;
+
+    &:hover {
+        background-color: inherit;
+        color: $grey;
+    }
+}


### PR DESCRIPTION
- part of #1403 : visualisation selection is now based on a `VisualizationSelector` class that uses the `StoreSync` functionality.
- close #1374 : reloading the visualisation page now works as it should, without lifecycle errors.
- if the user has not entered a search term, the term frequency and ngram visualisations are disabled rather than hidden (close #1371)
- dropdown items now support `[disabled]` input.
- error messages now have a header, which makes them a bit clearer.
- error messages don't replace the visualisation content, they just appear above it. This makes more sense to me, but I'm fine going back to the old behaviour.