### PR TITLE
docker: add backend dependence on elasticsearch service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       - db
       - celery
       - redis
+      - elasticsearch
     environment:
       SQL_DATABASE: $SQL_DATABASE
       SQL_USER: $SQL_USER


### PR DESCRIPTION
Close #1186: Realized that the backend does not depend on elasticsearch in the docker configuration yet. Changed that now - locally, Elasticsearch dependent tests are now run.