### PR TITLE
document preview layout

### DIFF
--- a/frontend/src/app/document/document-preview/document-preview.component.html
+++ b/frontend/src/app/document/document-preview/document-preview.component.html
@@ -21,7 +21,7 @@
 
     <div class="columns is-vcentered">
         <div class="column is-narrow heading" *ngIf="document.relevance">
-            Relevance: {{document.relevance * 100 | number:'1.0-0' }}%
+            Relevance: <ia-search-relevance [value]="document.relevance"></ia-search-relevance>
         </div>
         <div class="column" role="presentation"></div>
         <div class="column field is-grouped is-narrow">

--- a/frontend/src/app/document/document-preview/document-preview.component.html
+++ b/frontend/src/app/document/document-preview/document-preview.component.html
@@ -1,41 +1,58 @@
-<div class="columns" *ngIf="page && document">
-    <div class="column is-flex" tabindex="0" role="button"
-        (click)="page.focus(document)"
-        (keydown.enter)="page.focus(document)">
-        <table class="table is-fullwidth">
-            <ng-container *ngFor="let field of page.fields">
-                <tr *ngIf="document.fieldValue(field)">
-                    <th [iaBalloon]="field.description" iaBalloonPosition="left" iaBalloonLength="medium">
-                        {{field.displayName}}:
-                    </th>
-                    <ng-container *ngIf="document.highlight && document.highlight[field.name]; else unhighlightedRow">
-                        <td>
-                            <ng-container *ngFor="let highlight of document.highlight[field.name]">
-                                <div ngPreserveWhitespaces style="word-break:break-word" [innerHtml]="highlight"></div>
-                                <hr *ngIf="highlight !== document.highlight[field.name][document.highlight[field.name].length-1]">
-                            </ng-container>
-                        </td>
-                    </ng-container>
-                    <ng-template #unhighlightedRow>
-                        <td style="word-break:break-word" [innerHtml]="document.fieldValue(field) | highlight:query:true"></td>
-                    </ng-template>
-                </tr>
-            </ng-container>
-        </table>
-    </div>
-    <div class="column is-one-quarter">
-        <ng-container *ngIf="document.relevance">
-            <div class="relevance-score">
-                <span>Relevance: {{document.relevance * 100 | number:'1.0-0' }}%</span>
-            </div>
-            <ia-search-relevance [value]="document.relevance"></ia-search-relevance>
+<ng-container *ngIf="page && document">
+    <table class="table is-fullwidth">
+        <ng-container *ngFor="let field of page.fields">
+            <tr *ngIf="document.fieldValue(field)">
+                <th [iaBalloon]="field.description" iaBalloonPosition="left" iaBalloonLength="medium">
+                    {{field.displayName}}:
+                </th>
+                <ng-container *ngIf="document.highlight && document.highlight[field.name]; else unhighlightedRow">
+                    <td>
+                        <ng-container *ngFor="let highlight of document.highlight[field.name]">
+                            <div ngPreserveWhitespaces style="word-break:break-word" [innerHtml]="highlight"></div>
+                            <hr *ngIf="highlight !== document.highlight[field.name][document.highlight[field.name].length-1]">
+                        </ng-container>
+                    </td>
+                </ng-container>
+                <ng-template #unhighlightedRow>
+                    <td style="word-break:break-word" [innerHtml]="document.fieldValue(field) | highlight:query:true"></td>
+                </ng-template>
+            </tr>
         </ng-container>
-        <button *ngIf="document.fieldValues.image_path" class="button scan-button is-primary is-inverted"
-            iaBalloon="View Scan" aria-label="view scan"
-            (click)="goToScan(page, document, $event)">
-            <span class="icon is-large">
-                <fa-icon [icon]="documentIcons.scanAlt" size="3x" aria-hidden="true"></fa-icon>
-            </span>
-        </button>
+    </table>
+
+
+    <div class="columns is-vcentered">
+        <div class="column is-narrow">
+            <ng-container *ngIf="document.relevance">
+                <div class="relevance-score heading">
+                    <span>Relevance: {{document.relevance * 100 | number:'1.0-0' }}%</span>
+                </div>
+            </ng-container>
+        </div>
+        <div class="column" role="presentation"></div>
+        <div class="column field is-grouped is-narrow">
+            <div class="control">
+                <button class="button is-primary" (click)="page.focus(document)">
+                    <span class="icon" aria-hidden="true"><fa-icon [icon]="actionIcons.view"></fa-icon></span>
+                    <span>
+                        View
+                    </span>
+                </button>
+            </div>
+            <div class="control" *ngIf="document.fieldValues.image_path">
+                <button class="button" (click)="goToScan(page, document, $event)" aria-label="view scan">
+                    <span class="icon" aria-hidden="true"><fa-icon [icon]="documentIcons.scanAlt"></fa-icon></span>
+                    <span>View scan</span>
+                </button>
+            </div>
+            <div class="control">
+                <a class="button" [routerLink]="documentUrl">
+                    <span class="icon" aria-hidden="true"><fa-icon [icon]="actionIcons.link"></fa-icon></span>
+                    <span>
+                        Link
+                    </span>
+                </a>
+            </div>
+        </div>
     </div>
-</div>
+</ng-container>

--- a/frontend/src/app/document/document-preview/document-preview.component.html
+++ b/frontend/src/app/document/document-preview/document-preview.component.html
@@ -5,14 +5,12 @@
                 <th [iaBalloon]="field.description" iaBalloonPosition="left" iaBalloonLength="medium">
                     {{field.displayName}}:
                 </th>
-                <ng-container *ngIf="document.highlight && document.highlight[field.name]; else unhighlightedRow">
-                    <td>
-                        <ng-container *ngFor="let highlight of document.highlight[field.name]">
-                            <div ngPreserveWhitespaces style="word-break:break-word" [innerHtml]="highlight"></div>
-                            <hr *ngIf="highlight !== document.highlight[field.name][document.highlight[field.name].length-1]">
-                        </ng-container>
-                    </td>
-                </ng-container>
+                <td *ngIf="document.highlight && document.highlight[field.name]; else unhighlightedRow">
+                    <ng-container *ngFor="let highlight of document.highlight[field.name]">
+                        <div ngPreserveWhitespaces style="word-break:break-word" [innerHtml]="highlight"></div>
+                        <hr *ngIf="highlight !== document.highlight[field.name][document.highlight[field.name].length-1]">
+                    </ng-container>
+                </td>
                 <ng-template #unhighlightedRow>
                     <td style="word-break:break-word" [innerHtml]="document.fieldValue(field) | highlight:query:true"></td>
                 </ng-template>
@@ -22,12 +20,8 @@
 
 
     <div class="columns is-vcentered">
-        <div class="column is-narrow">
-            <ng-container *ngIf="document.relevance">
-                <div class="relevance-score heading">
-                    <span>Relevance: {{document.relevance * 100 | number:'1.0-0' }}%</span>
-                </div>
-            </ng-container>
+        <div class="column is-narrow heading" *ngIf="document.relevance">
+            Relevance: {{document.relevance * 100 | number:'1.0-0' }}%
         </div>
         <div class="column" role="presentation"></div>
         <div class="column field is-grouped is-narrow">

--- a/frontend/src/app/document/document-preview/document-preview.component.scss
+++ b/frontend/src/app/document/document-preview/document-preview.component.scss
@@ -1,37 +1,5 @@
-@import "../../../_utilities";
-
 .table {
     td, th {
         border: none;
     }
-}
-
-.relevance-score {
-    text-align: center;
-
-    strong, span {
-        vertical-align: baseline;
-    }
-
-    strong {
-        @extend .title;
-    }
-}
-
-.scan-button {
-    display: block;
-    margin-top: 2rem;
-    margin-left: 3rem;
-}
-
-.title {
-    font-size: 1.5rem;
-}
-
-.src-thumbnail {
-    border-radius: 5px;
-    box-shadow: 0 2px 3px rgba(10, 10, 10, 0.1),
-                0 0 0 1px rgba(10, 10, 10, 0.1);
-    margin-top: 5px;
-
 }

--- a/frontend/src/app/document/document-preview/document-preview.component.ts
+++ b/frontend/src/app/document/document-preview/document-preview.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { FoundDocument } from '../../models';
 import { DocumentPage } from '../../models/document-page';
-import { documentIcons } from '../../shared/icons';
+import { actionIcons, documentIcons } from '../../shared/icons';
 
 @Component({
     selector: 'ia-document-preview',
@@ -12,7 +12,14 @@ export class DocumentPreviewComponent {
     @Input() document: FoundDocument;
     @Input() page: DocumentPage;
 
+    actionIcons = actionIcons;
     documentIcons = documentIcons;
+
+    get documentUrl(): string[] {
+        if (this.document) {
+            return ['/document', this.document.corpus.name, this.document.id];
+        }
+    }
 
     goToScan(page: DocumentPage, document: FoundDocument, event: Event) {
         page.focus(document, 'scan');

--- a/frontend/src/app/search/search-relevance.component.html
+++ b/frontend/src/app/search/search-relevance.component.html
@@ -1,9 +1,1 @@
-<progress role="meter"
-    class="progress is-primary"
-    [value]="value" max="1"
-    title="Relevance score = {{value}}"
-    [attr.aria-label]="'Relevance score = {{value}}'"
-    [attr.aria-valuenow]="value"
-    aria-valuemin="0" aria-valuemax="1"
-    >{{value}}
-</progress>
+{{value * 100 | number:'1.0-0' }}%

--- a/frontend/src/app/shared/icons.ts
+++ b/frontend/src/app/shared/icons.ts
@@ -2,7 +2,7 @@ import {
     IconDefinition as SolidIconDefinition,
     faAngleDown, faArrowLeft, faArrowRight, faAt, faBook, faBookOpen, faChartColumn,
     faCheck, faChevronLeft, faChevronRight, faCog, faCogs, faDatabase, faDiagramProject,
-    faDownload, faEnvelope, faFilter, faHistory, faImage, faInfo, faInfoCircle, faLink, faList, faLock,
+    faDownload, faEnvelope, faEye, faFilter, faHistory, faImage, faInfo, faInfoCircle, faLink, faList, faLock,
     faMinus, faPalette, faPlus, faQuestionCircle, faSearch, faSearchMinus, faSearchPlus, faSignOut,
     faSortAlphaAsc, faSortAlphaDesc, faSortNumericAsc, faSortNumericDesc, faSquare,
     faTable, faTimes, faTrashCan, faUndo, faUser
@@ -45,6 +45,7 @@ export const actionIcons: Icons = {
     add: faPlus,
     remove: faTimes,
     delete: faTrashCan,
+    view: faEye,
 };
 
 export const formIcons: Icons = {


### PR DESCRIPTION
Changes the layout of document previews.

- content can use the full width of the preview
- preview includes a direct link to the document page
- no dead space for documents without an attached scan

close #1383

Screenshot:

![screenshot of i-analyzer document preview](https://github.com/UUDigitalHumanitieslab/I-analyzer/assets/43678097/8ed37519-2863-4927-a671-a63dfbe45690)

Document with scan image:

![screenshot of i-analyzer document preview, showing "scan image" button](https://github.com/UUDigitalHumanitieslab/I-analyzer/assets/43678097/88716257-6217-4603-9a2a-b3b8584b5bf2)

This also changes the relevance score to just show the percentage (rather than a meter), which I think is clearer.

![screenshot of i-analyzer document page](https://github.com/UUDigitalHumanitieslab/I-analyzer/assets/43678097/f6bb5806-4c21-4b4c-bef7-c78e79de6f35)