### PR TITLE
display paragraph breaks in document content

### DIFF
--- a/frontend/src/app/document-view/document-view.component.html
+++ b/frontend/src/app/document-view/document-view.component.html
@@ -33,7 +33,7 @@
         <div class="box">
             <ia-tabs [activeTab]="activeTab">
                 <ng-template iaTabPanel *ngFor="let field of contentFields" [id]="field.name" [title]="field.displayName" [icon]="documentIcons.text">
-                    <div class="content" [innerHtml]="highlightedInnerHtml(field)"></div>
+                    <div class="content" [innerHtml]="formatInnerHtml(field)"></div>
                 </ng-template>
                 <ng-template iaTabPanel id="scan" *ngIf="showScanTab" title="Image" [icon]="documentIcons.scan">
                     <ia-image-view [corpus]="corpus" [document]="document"></ia-image-view>

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -90,6 +90,18 @@ export class DocumentViewComponent implements OnChanges {
         return parseHTML.body.textContent || '';
       }
 
+    formatInnerHtml(field: CorpusField) {
+        const fieldValue = this.document.fieldValues[field.name];
+
+        if (_.isEmpty(fieldValue)) {
+            return;
+        }
+
+        const highlighted = this.highlightedInnerHtml(field);
+        return this.addParagraphTags(highlighted);
+    }
+
+
     highlightedInnerHtml(field: CorpusField) {
         let highlighted = this.document.fieldValues[field.name];
         if (this.document.highlight && this.document.highlight.hasOwnProperty(field.name) &&
@@ -103,4 +115,9 @@ export class DocumentViewComponent implements OnChanges {
                 return this.document.fieldValues[field.name];
             }
         }
+
+    addParagraphTags(content: string) {
+        const paragraphs = content.split('\n');
+        return paragraphs.map(p => `<p>${p}</p>`).join(' ');
+    }
 }


### PR DESCRIPTION
I noticed the document view in the frontend was not displaying paragraph breaks:

![screenshot of I-analyzer](https://github.com/UUDigitalHumanitieslab/I-analyzer/assets/43678097/ee5965fd-aee8-4f5a-bdaf-690ef2ea3392)

This adds `<p>` tags based on `\n`.

![image](https://github.com/UUDigitalHumanitieslab/I-analyzer/assets/43678097/97570687-5e01-4319-9ba3-862a5cd052fb)
