### PR TITLE
conditional download of nltk stopwords

### DIFF
--- a/backend/addcorpus/es_settings.py
+++ b/backend/addcorpus/es_settings.py
@@ -23,9 +23,12 @@ def get_language_key(language_code):
 
     return Language.make(language_code).display_name().lower()
 
+
 def get_nltk_stopwords(language_code):
-    nltk.download('stopwords', settings.NLTK_DATA_PATH)
     stopwords_dir = os.path.join(settings.NLTK_DATA_PATH, 'corpora', 'stopwords')
+    if not os.path.exists(stopwords_dir):
+        nltk.download('stopwords', settings.NLTK_DATA_PATH)
+
     languages = os.listdir(stopwords_dir)
     language = get_language_key(language_code)
 


### PR DESCRIPTION
This branch is meant to close #1377. @lukavdplas , can you check whether this fixes the issue for you? I've seen the nltk check pop up multiple times during testing, that seems to not be happening anymore now. I think it's basically caused by a call to `load_corpus_definition`, so I'd expect the check to be run for every corpus that has stopword removal or stemming assigned, not infinitely, so there might still be a leakage issue elsewhere. In that case, this is just a cosmetic fix.