### PR TITLE
Feature/update elasticsearch

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -69,14 +69,6 @@ services:
       - ianalyzer-es:/usr/share/elasticsearch/data
     ports:
       - 127.0.0.1:9200:9200
-  kibana:
-    image: docker.elastic.co/kibana/kibana:8.10.2
-    depends_on:
-      - elasticsearch
-    environment:
-        - "ELASTICSEARCH_URL=http://elasticsearch:9200"
-    ports:
-      - 127.0.0.1:5601:5601
   redis:
     image: redis:latest
     restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
         target: /frontend/src
     command: sh -c "yarn start-docker"
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
     environment:
       - node.name=ianalyzer-node
       - discovery.type=single-node
@@ -70,7 +70,7 @@ services:
     ports:
       - 127.0.0.1:9200:9200
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.5.0
+    image: docker.elastic.co/kibana/kibana:8.10.2
     depends_on:
       - elasticsearch
     environment:


### PR DESCRIPTION
This branch updates the Elasticsearch version in Docker compose to match the version we use in production. Also removes Kibana - somehow this stopped working for me locally, and as it's mainly used in order to inspect indices and test queries, which arguably can also be done with other software (I now installed ThunderClient in VSCode to this purpose), we might as well slim down the number of services.