### PR TITLE
Add `word_model_path` to parliament corpora

### DIFF
--- a/backend/corpora/parliament/canada.py
+++ b/backend/corpora/parliament/canada.py
@@ -18,6 +18,7 @@ class ParliamentCanada(Parliament, CSVCorpusDefinition):
     min_date = datetime(year=1901, month=1, day=1)
     data_directory = settings.PP_CANADA_DATA
     es_index = getattr(settings, 'PP_CANADA_INDEX', 'parliament-canada')
+    word_model_path = getattr(settings, 'PP_CANADA_WM', None)
     image = 'canada.jpeg'
     languages = ['en']
     description_page = 'canada.md'

--- a/backend/corpora/parliament/denmark-new.py
+++ b/backend/corpora/parliament/denmark-new.py
@@ -39,6 +39,7 @@ class ParliamentDenmarkNew(Parliament, CSVCorpusDefinition):
     max_date = datetime(year=2016, month=12, day=31)
     data_directory = settings.PP_DENMARK_NEW_DATA
     es_index = getattr(settings, 'PP_DENMARK_NEW_INDEX', 'parliament-denmark-new')
+    word_model_path = getattr(settings, 'PP_DENMARK_WM', None)
     image = 'denmark.jpg'
     description_page = 'denmark-new.md'
     languages = ['da']

--- a/backend/corpora/parliament/ireland.py
+++ b/backend/corpora/parliament/ireland.py
@@ -447,6 +447,7 @@ class ParliamentIreland(Parliament, CorpusDefinition):
     max_date = datetime(year=2020, month=12, day=31)
     data_directory = settings.PP_IRELAND_DATA
     es_index = getattr(settings, 'PP_IRELAND_INDEX', 'parliament-ireland')
+    word_model_path = getattr(settings, 'PP_IRELAND_WM', None)
     image = 'ireland.png'
     description_page = 'ireland.md'
     es_settings = {'index': {'number_of_replicas': 0}} # do not include analyzers in es_settings

--- a/backend/corpora/parliament/norway-new.py
+++ b/backend/corpora/parliament/norway-new.py
@@ -52,6 +52,7 @@ class ParliamentNorwayNew(Parliament, CSVCorpusDefinition):
     max_date = datetime(year=2016, month=12, day=31)
     data_directory = settings.PP_NORWAY_NEW_DATA
     es_index = getattr(settings, 'PP_NORWAY_NEW_INDEX', 'parliament-norway-new')
+    word_model_path = getattr(settings, 'PP_NORWAY_WM', None)
     image = 'norway.JPG'
     languages = ['no']
     description_page = 'norway-new.md'


### PR DESCRIPTION
In the first instance, this PR is intended to activate the Irish word models, but it also prepares addition of word models for Canada, Denmark and Norway.