### PR TITLE
clarify fields named "URL"

### DIFF
--- a/backend/corpora/dbnl/dbnl.py
+++ b/backend/corpora/dbnl/dbnl.py
@@ -229,7 +229,7 @@ class DBNL(XMLCorpusDefinition):
 
     url = FieldDefinition(
         name='url',
-        display_name='URL (DBNL)',
+        display_name='Source URL',
         description='Link to the book\'s page in DBNL',
         extractor=Metadata('url'),
         es_mapping=keyword_mapping(),

--- a/backend/corpora/dbnl/dbnl.py
+++ b/backend/corpora/dbnl/dbnl.py
@@ -229,7 +229,7 @@ class DBNL(XMLCorpusDefinition):
 
     url = FieldDefinition(
         name='url',
-        display_name='View on DBNL',
+        display_name='URL (DBNL)',
         description='Link to the book\'s page in DBNL',
         extractor=Metadata('url'),
         es_mapping=keyword_mapping(),

--- a/backend/corpora/goodreads/goodreads.py
+++ b/backend/corpora/goodreads/goodreads.py
@@ -167,8 +167,8 @@ class GoodReads(CSVCorpusDefinition):
         ),
         FieldDefinition(
             name='url',
-            display_name='URL',
-            description='URL of the review.',
+            display_name='URL (Goodreads)',
+            description='Link to the the review on Goodreads',
             extractor=CSV(
                 field='url',
             ),

--- a/backend/corpora/goodreads/goodreads.py
+++ b/backend/corpora/goodreads/goodreads.py
@@ -167,7 +167,7 @@ class GoodReads(CSVCorpusDefinition):
         ),
         FieldDefinition(
             name='url',
-            display_name='URL (Goodreads)',
+            display_name='Source URL',
             description='Link to the the review on Goodreads',
             extractor=CSV(
                 field='url',

--- a/backend/corpora/parliament/utils/field_defaults.py
+++ b/backend/corpora/parliament/utils/field_defaults.py
@@ -539,7 +539,7 @@ def url():
     """url of the source file"""
     return FieldDefinition(
         name='url',
-        display_name='Source url',
+        display_name='Source URL',
         description='URL to source file of this speech',
         es_mapping=keyword_mapping(),
         searchable=False,

--- a/backend/corpora/peaceportal/utils/field_defaults.py
+++ b/backend/corpora/peaceportal/utils/field_defaults.py
@@ -29,7 +29,7 @@ def source_database():
 def url():
     return FieldDefinition(
         name='url',
-        display_name='URL',
+        display_name='Source URL',
         description='URL of the inscription entry.',
         es_mapping=keyword_mapping(),
         search_field_core=True

--- a/backend/corpora/peaceportal/utils/field_defaults.py
+++ b/backend/corpora/peaceportal/utils/field_defaults.py
@@ -30,7 +30,7 @@ def url():
     return FieldDefinition(
         name='url',
         display_name='Source URL',
-        description='URL of the inscription entry.',
+        description='URL of the inscription entry in the source database.',
         es_mapping=keyword_mapping(),
         search_field_core=True
     )

--- a/backend/corpora/rechtspraak/rechtspraak.py
+++ b/backend/corpora/rechtspraak/rechtspraak.py
@@ -298,7 +298,7 @@ class Rechtspraak(XMLCorpusDefinition):
         ),
         FieldDefinition(
             name='url',
-            display_name='URL',
+            display_name='URL (rechtspraak.nl)',
             es_mapping=keyword_mapping(),
             extractor=rdf_description_extractor(
                 'dcterms:identifier', section='html')

--- a/backend/corpora/rechtspraak/rechtspraak.py
+++ b/backend/corpora/rechtspraak/rechtspraak.py
@@ -298,7 +298,8 @@ class Rechtspraak(XMLCorpusDefinition):
         ),
         FieldDefinition(
             name='url',
-            display_name='URL (rechtspraak.nl)',
+            display_name='Source URL',
+            description='URL of the case on rechtspraak.nl',
             es_mapping=keyword_mapping(),
             extractor=rdf_description_extractor(
                 'dcterms:identifier', section='html')


### PR DESCRIPTION
See #1117  : naming a field "URL" in the interface is unclear because I-analyzer also creates a unique URL for the document. This update clarifies the display names for most of those fields, by making it clear it's the URL _on Goodreads_ (or wherever).

The exception is this one:

https://github.com/UUDigitalHumanitieslab/I-analyzer/blob/7b84d6b93d1876e5834e933249ca8c04ab7d89ba/backend/corpora/peaceportal/utils/field_defaults.py#L29-L36

where I don't know what it's supposed to link to. @BeritJanssen , could you add this?