### PR TITLE
scan controls fixes

### DIFF
--- a/frontend/src/app/image-view/image-view.component.html
+++ b/frontend/src/app/image-view/image-view.component.html
@@ -1,4 +1,4 @@
-<div style="text-align: center;">
+<div style="text-align: center;" *ngIf="!noImages">
     <div class="level">
     <div class="level-left">
         <button class="button is-primary is-inverted" (click)="zoomIn()"

--- a/frontend/src/app/shared/icons.ts
+++ b/frontend/src/app/shared/icons.ts
@@ -90,8 +90,8 @@ export const scanIcons: Icons = {
     zoomIn: faSearchPlus,
     zoomOut: faSearchMinus,
     zoomReset: faUndo,
-    prev: faChevronRight,
-    next: faChevronLeft,
+    prev: faChevronLeft,
+    next: faChevronRight,
 };
 
 export const documentIcons: Icons = {


### PR DESCRIPTION
- fixes the previous/next icons on the scan pagination controls (those were swapped)
- hides the controls of the scan view when no image is available (close #1353)