### PR TITLE
fix: only split document view content if it is a string

### DIFF
--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -130,8 +130,8 @@ export class DocumentViewComponent implements OnChanges {
             }
         }
 
-    addParagraphTags(content: string) {
-        const paragraphs = content.split('\n');
+    addParagraphTags(content: string | string[]) {
+        const paragraphs = typeof content === 'string' ? content.split('\n') : content;
         return paragraphs.map(p => `<p>${p}</p>`).join(' ');
     }
 }


### PR DESCRIPTION
The content of some fields can be an array of strings. Elasticsearch is pretty agnostic to this, which means on the frontend we need to do a type check.