### PR TITLE
update ianalyzer readers

### DIFF
--- a/backend/addcorpus/tests/mock_csv_corpus.py
+++ b/backend/addcorpus/tests/mock_csv_corpus.py
@@ -32,13 +32,13 @@ class MockCSVCorpus(CSVCorpusDefinition):
     fields = [
         FieldDefinition(
             name = 'character',
-            extractor = CSV(field = 'character')
+            extractor = CSV('character')
         ),
         FieldDefinition(
             name = 'lines',
             display_type = 'text_content',
             extractor = CSV(
-                field = 'line',
+                'line',
                 multiple = True,
             )
         )

--- a/backend/corpora/goodreads/goodreads.py
+++ b/backend/corpora/goodreads/goodreads.py
@@ -68,7 +68,7 @@ class GoodReads(CSVCorpusDefinition):
             display_name='Year',
             description='Year the review was written.',
             extractor=CSV(
-                field='date',
+                'date',
                 transform=lambda x: datetime.strptime(
                     x, '%b %d, %Y').strftime('%Y')
             ),
@@ -86,9 +86,7 @@ class GoodReads(CSVCorpusDefinition):
             name='id',
             display_name='ID',
             description='ID of the review.',
-            extractor=CSV(
-                field='id',
-            ),
+            extractor=CSV('id'),
             es_mapping={'type': 'keyword'},
             csv_core=True,
         ),
@@ -120,18 +118,14 @@ class GoodReads(CSVCorpusDefinition):
             name='edition_id',
             display_name='Edition ID',
             description='ID of the edition the review was made for.',
-            extractor=CSV(
-                field='edition_id',
-            ),
+            extractor=CSV('edition_id'),
             es_mapping={'type': 'keyword'},
         ),
         FieldDefinition(
             name='edition_language',
             display_name='Edition language',
             description='The language that the edition that the review is for was written in',
-            extractor=CSV(
-                field='edition_language',
-            ),
+            extractor=CSV('edition_language'),
             es_mapping={'type': 'keyword'},
             search_filter=MultipleChoiceFilter(
                 description='Accept only editions written in these languages.',
@@ -169,18 +163,14 @@ class GoodReads(CSVCorpusDefinition):
             name='url',
             display_name='Source URL',
             description='Link to the the review on Goodreads',
-            extractor=CSV(
-                field='url',
-            ),
+            extractor=CSV('url'),
             es_mapping={'type': 'keyword'},
         ),
         FieldDefinition(
             name='text',
             display_name='Text',
             description='Fulltext of the review.',
-            extractor=CSV(
-                field='text',
-            ),
+            extractor=CSV('text'),
             es_mapping=main_content_mapping(),
             display_type='text_content',
             csv_core=True,
@@ -192,9 +182,7 @@ class GoodReads(CSVCorpusDefinition):
             name='language',
             display_name='Review language',
             description='The language of the review.',
-            extractor=CSV(
-                field='language',
-            ),
+            extractor=CSV('language'),
             es_mapping={'type': 'keyword'},
             search_filter=MultipleChoiceFilter(
                 description='Accept only reviews written in these languages.',
@@ -209,7 +197,7 @@ class GoodReads(CSVCorpusDefinition):
             display_name='Date',
             description='Date the review was written.',
             extractor=CSV(
-                field='date',
+                'date',
                 transform=lambda x: datetime.strptime(
                     x, '%b %d, %Y').strftime('%Y-%m-%d')
             ),
@@ -219,18 +207,14 @@ class GoodReads(CSVCorpusDefinition):
             name='rating_text',
             display_name='Goodreads rating',
             description='Rating in the Goodreads style, e.g. \'really liked it\'.',
-            extractor=CSV(
-                field='rating',
-            ),
+            extractor=CSV('rating'),
             es_mapping={'type': 'keyword'},
         ),
         FieldDefinition(
             name='rating_no',
             display_name='Rating',
             description='Rating as a number.',
-            extractor=CSV(
-                field='rating_no',
-            ),
+            extractor=CSV('rating_no'),
             es_mapping={'type': 'keyword'},
             search_filter=MultipleChoiceFilter(
                 description='Accept only reviews with these ratings.',
@@ -245,7 +229,7 @@ class GoodReads(CSVCorpusDefinition):
             display_name='Word count',
             description='Number of words (whitespace-delimited) in the review.',
             extractor=CSV(
-                field='text',
+                'text',
                 transform=lambda x: len(x.split(' '))
             ),
             es_mapping={'type': 'integer'},
@@ -261,7 +245,7 @@ class GoodReads(CSVCorpusDefinition):
             display_name='Edition publisher',
             description='Publisher of the edition the review was written for',
             extractor=CSV(
-                field='edition_publisher',
+                'edition_publisher',
             ),
             es_mapping={'type': 'keyword'},
         ),
@@ -270,7 +254,7 @@ class GoodReads(CSVCorpusDefinition):
             display_name='Edition publishing year',
             description='Year the edition the review was written for was published.',
             extractor=CSV(
-                field='edition_publishing_year',
+                'edition_publishing_year',
             ),
             es_mapping={'type': 'keyword'},
         ),

--- a/backend/corpora/parliament/canada.py
+++ b/backend/corpora/parliament/canada.py
@@ -35,7 +35,7 @@ class ParliamentCanada(Parliament, CSVCorpusDefinition):
 
     chamber = field_defaults.chamber()
     chamber.extractor = CSV(
-        field='house',
+        'house',
         transform=format_house
     )
     # remove search filter and visualisations since there is only value in the data
@@ -48,68 +48,48 @@ class ParliamentCanada(Parliament, CSVCorpusDefinition):
     )
 
     date = field_defaults.date()
-    date.extractor = CSV(
-        field='date_yyyy-mm-dd'
-    )
+    date.extractor = CSV('date_yyyy-mm-dd')
     date.search_filter.lower = min_date
 
     debate_id = field_defaults.debate_id()
     debate_id.extractor = CSV(
-        field='speech_id',
+        'speech_id',
         transform=lambda x: x[:re.search(r'\d{4}-\d{2}-\d{2}', x).span()[1]]
     )
 
     debate_title = field_defaults.debate_title()
-    debate_title.extractor = CSV(
-        field='heading1'
-    )
+    debate_title.extractor = CSV('heading1')
 
     party = field_defaults.party()
-    party.extractor = CSV(
-        field='speaker_party'
-    )
+    party.extractor = CSV('speaker_party')
 
     role = field_defaults.parliamentary_role()
-    role.extractor = CSV(
-        field='speech_type'
-    )
+    role.extractor = CSV('speech_type')
 
     speaker = field_defaults.speaker()
-    speaker.extractor = CSV(
-        field='speaker_name'
-    )
+    speaker.extractor = CSV('speaker_name')
 
     speaker_id = field_defaults.speaker_id()
-    speaker_id.extractor = CSV(
-        field='speaker_id'
-    )
+    speaker_id.extractor = CSV('speaker_id')
 
     speaker_constituency = field_defaults.speaker_constituency()
-    speaker_constituency.extractor = CSV(
-        field='speaker_constituency'
-    )
+    speaker_constituency.extractor = CSV('speaker_constituency')
 
     speech = field_defaults.speech()
     speech.extractor = CSV(
-        field='content',
+        'content',
         multiple=True,
         transform=lambda x : ' '.join(x)
     )
 
     speech_id = field_defaults.speech_id()
-    speech_id.extractor = CSV(
-        field='speech_id'
-    )
+    speech_id.extractor = CSV('speech_id')
 
     topic = field_defaults.topic()
-    topic.extractor = CSV(
-        field='heading2'
-    )
+    topic.extractor = CSV('heading2')
 
     subtopic = field_defaults.subtopic()
-    subtopic.extractor = CSV(
-        field='heading3'
-    )
+    subtopic.extractor = CSV('heading3')
 
     def __init__(self):
         self.fields = [

--- a/backend/corpora/parliament/denmark-new.py
+++ b/backend/corpora/parliament/denmark-new.py
@@ -59,14 +59,14 @@ class ParliamentDenmarkNew(Parliament, CSVCorpusDefinition):
     country.extractor = Constant('Denmark')
 
     date = field_defaults.date()
-    date.extractor = CSV(field = 'Date')
+    date.extractor = CSV('Date')
     date.search_filter.lower = min_date
     date.search_filter.upper = max_date
 
     party = field_defaults.party()
     party.extractor = Combined(
         CSV(
-            field = 'Party',
+            'Party',
             transform = format_party,
         ),
         Metadata('parties'),
@@ -75,38 +75,38 @@ class ParliamentDenmarkNew(Parliament, CSVCorpusDefinition):
     party.language = 'da'
 
     role = field_defaults.parliamentary_role()
-    role.extractor = CSV(field = 'Role')
+    role.extractor = CSV('Role')
     role.language = 'da'
 
     speaker = field_defaults.speaker()
-    speaker.extractor = CSV(field = 'Name')
+    speaker.extractor = CSV('Name')
 
     speaker_gender = field_defaults.speaker_gender()
-    speaker_gender.extractor = CSV(field = 'Gender')
+    speaker_gender.extractor = CSV('Gender')
 
     speaker_birth_year = field_defaults.speaker_birth_year()
     speaker_birth_year.extractor = CSV(
-        field = 'Birth',
+        'Birth',
         transform = formatting.extract_year,
     )
 
     speech = field_defaults.speech()
-    speech.extractor = CSV(field = 'Text')
+    speech.extractor = CSV('Text')
     speech.language = 'da'
 
     speech_id = field_defaults.speech_id()
-    speech_id.extractor = CSV(field = 'ID')
+    speech_id.extractor = CSV('ID')
 
     subject = field_defaults.subject()
-    subject.extractor = CSV(field = 'Subject 1')
+    subject.extractor = CSV('Subject 1')
     subject.language = 'en'
 
     topic = field_defaults.topic()
-    topic.extractor = CSV(field = 'Agenda title')
+    topic.extractor = CSV('Agenda title')
 
     sequence = field_defaults.sequence()
     sequence.extractor = CSV(
-        field='ID',
+        'ID',
         transform = get_timestamp_from_id
     )
 

--- a/backend/corpora/parliament/denmark.py
+++ b/backend/corpora/parliament/denmark.py
@@ -55,11 +55,11 @@ class ParliamentDenmark(Parliament, CSVCorpusDefinition):
 
 
     book_label = field_defaults.book_label()
-    book_label.extractor = CSV(field='title')
+    book_label.extractor = CSV('title')
 
     book_id = field_defaults.book_id()
     book_id.extractor = CSV(
-        field='id',
+        'id',
         transform = get_book_id
     )
 
@@ -68,13 +68,13 @@ class ParliamentDenmark(Parliament, CSVCorpusDefinition):
 
     chamber = field_defaults.chamber()
     chamber.extractor = CSV(
-        field='chamber',
+        'chamber',
         transform = format_chamber,
     )
 
     date_earliest = field_defaults.date_earliest()
     date_earliest.extractor = CSV(
-        field='year',
+        'year',
         transform= lambda value: formatting.get_date_from_year(value, 'earliest')
     )
     date_earliest.search_filter.lower = min_date
@@ -82,24 +82,24 @@ class ParliamentDenmark(Parliament, CSVCorpusDefinition):
 
     date_latest = field_defaults.date_latest()
     date_latest.extractor = CSV(
-        field='year',
+        'year',
         transform= lambda value: formatting.get_date_from_year(value, 'latest')
     )
     date_latest.search_filter.lower = min_date
     date_latest.search_filter.upper = max_date
 
     page = field_defaults.page()
-    page.extractor = CSV(field='page')
+    page.extractor = CSV('page')
 
     speech = field_defaults.speech()
-    speech.extractor = CSV(field='text')
+    speech.extractor = CSV('text')
 
     speech_id = field_defaults.speech_id()
-    speech_id.extractor = CSV(field='id')
+    speech_id.extractor = CSV('id')
 
     sequence = field_defaults.sequence()
     sequence.extractor = CSV(
-        field='page',
+        'page',
         transform = formatting.extract_integer_value,
     )
 

--- a/backend/corpora/parliament/finland-old.py
+++ b/backend/corpora/parliament/finland-old.py
@@ -33,7 +33,7 @@ class ParliamentFinlandOld(Parliament, CSVCorpusDefinition):
 
 
     chamber = field_defaults.chamber()
-    chamber.extractor = CSV(field='estate')
+    chamber.extractor = CSV('estate')
     chamber.search_filter = MultipleChoiceFilter(
         description='Search only in debates from the selected chamber(s)',
         option_count=4
@@ -44,7 +44,7 @@ class ParliamentFinlandOld(Parliament, CSVCorpusDefinition):
 
     date_earliest = field_defaults.date_earliest()
     date_earliest.extractor = CSV(
-        field='year_start',
+        'year_start',
         transform=lambda value: formatting.get_date_from_year(value, 'earliest')
     )
     date_earliest.search_filter.lower = min_date
@@ -52,33 +52,33 @@ class ParliamentFinlandOld(Parliament, CSVCorpusDefinition):
 
     date_latest = field_defaults.date_latest()
     date_latest.extractor = CSV(
-        field='year_end',
+        'year_end',
         transform=lambda value: formatting.get_date_from_year(value, 'latest')
     )
     date_latest.search_filter.lower = min_date
     date_latest.search_filter.upper = max_date
 
     language = field_defaults.language()
-    language.extractor = CSV(field='language')
+    language.extractor = CSV('language')
 
     page = field_defaults.page()
-    page.extractor = CSV(field='page')
+    page.extractor = CSV('page')
 
     source_archive = field_defaults.source_archive()
-    source_archive.extractor = CSV(field='file')
+    source_archive.extractor = CSV('file')
 
     speech = field_defaults.speech()
-    speech.extractor = CSV(field='text')
+    speech.extractor = CSV('text')
 
     speech_id = field_defaults.speech_id()
     speech_id.extractor = Combined(
-        CSV(field='file'),
-        CSV(field='page'),
+        CSV('file'),
+        CSV('page'),
         transform=lambda x: '_'.join(x)
     )
 
     speech_type = field_defaults.speech_type()
-    speech_type.extractor = CSV(field='type')
+    speech_type.extractor = CSV('type')
 
     def __init__(self):
         self.fields = [

--- a/backend/corpora/parliament/france.py
+++ b/backend/corpora/parliament/france.py
@@ -34,15 +34,15 @@ class ParliamentFrance(Parliament, CSVCorpusDefinition):
 
     book_id = field_defaults.book_id()
     book_id.extractor = Combined(
-        CSV(field='book_id'),
-        CSV(field='book_part_id'),
-        CSV(field='page_id'),
+        CSV('book_id'),
+        CSV('book_part_id'),
+        CSV('page_id'),
         transform=lambda x: ' '.join(filter(None, x))
     )
 
     chamber = field_defaults.chamber()
     chamber.extractor = CSV(
-        field='chamber',
+        'chamber',
         transform=underscore_to_space
     )
     chamber.language = 'fr'
@@ -53,20 +53,18 @@ class ParliamentFrance(Parliament, CSVCorpusDefinition):
     )
 
     date = field_defaults.date()
-    date.extractor = CSV(
-        field='date'
-    )
+    date.extractor = CSV('date')
 
     date_is_estimate = field_defaults.date_is_estimate()
     date_is_estimate.extractor = CSV(
-        field='date_is_estimate',
+        'date_is_estimate',
         transform=lambda x: x=='True'
     )
 
     debate_id = field_defaults.debate_id()
     debate_id.extractor = Combined(
-        CSV(field='date'),
-        CSV(field='seance_order'),
+        CSV('date'),
+        CSV('seance_order'),
         transform=lambda x: '_'.join(filter(None, x))
     )
 
@@ -74,64 +72,46 @@ class ParliamentFrance(Parliament, CSVCorpusDefinition):
     # the values of 'seance' field seem very limited (Première séance, Deuxième séance, etc.,)
     # so we don't want this to be treated as a text field
     debate_title = field_defaults.debate_title()
-    debate_title.extractor = CSV(
-        field='seance'
-    )
+    debate_title.extractor = CSV('seance')
 
     debate_type = field_defaults.debate_type()
     debate_type.extractor = CSV(
-        field='session_type',
+        'session_type',
         transform=lambda x: x.title() if x else None,
     )
 
     era = field_defaults.era(include_aggregations=False)
     era.extractor = CSV(
-        field='era',
+        'era',
         transform=underscore_to_space
     )
 
     legislature = field_defaults.legislature()
-    legislature.extractor = CSV(
-        field='legislature'
-    )
+    legislature.extractor = CSV('legislature')
 
     page = field_defaults.page()
-    page.extractor = CSV(
-        field='page_order'
-    )
+    page.extractor = CSV('page_order')
 
     page_source = field_defaults.page_source()
-    page_source.extractor = CSV(
-        field='page_source'
-    )
+    page_source.extractor = CSV('page_source')
 
     sequence = field_defaults.sequence()
-    sequence.extractor = CSV(
-        field='sequence'
-    )
+    sequence.extractor = CSV('sequence')
 
     speech = field_defaults.speech()
-    speech.extractor = CSV(
-        field='page_text'
-    )
+    speech.extractor = CSV('page_text')
     speech.language = 'fr'
 
     speech_id = field_defaults.speech_id()
-    speech_id.extractor = CSV(
-        field='speech_id'
-    )
+    speech_id.extractor = CSV('speech_id')
 
     url_pdf = field_defaults.url()
-    url_pdf.extractor = CSV(
-        field='pdf_url'
-    )
+    url_pdf.extractor = CSV('pdf_url')
     url_pdf.display_name = 'Source url (PDF)'
     url_pdf.description = 'URL to PDF source file of this speech'
 
     url_html = field_defaults.url()
-    url_html.extractor = CSV(
-        field='html_url'
-    )
+    url_html.extractor = CSV('html_url')
     url_html.name = 'url_html'
     url_html.display_name = 'Source url (HTML)'
     url_html.description = 'URL to HTML source file of this speech'

--- a/backend/corpora/parliament/germany-new.py
+++ b/backend/corpora/parliament/germany-new.py
@@ -38,9 +38,7 @@ class ParliamentGermanyNew(Parliament, CSVCorpusDefinition):
     )
 
     date = field_defaults.date()
-    date.extractor = CSV(
-        field='date'
-    )
+    date.extractor = CSV('date')
     date.search_filter.lower = min_date
 
     chamber = field_defaults.chamber()
@@ -52,121 +50,89 @@ class ParliamentGermanyNew(Parliament, CSVCorpusDefinition):
     chamber.language = 'de'
 
     debate_id = field_defaults.debate_id()
-    debate_id.extractor = CSV(
-        field='session'
-    )
+    debate_id.extractor = CSV('session')
 
     # in Germany, abbreviations are the most common way to refer to parties
     party = field_defaults.party()
-    party.extractor = CSV(
-        field='party_abbreviation'
-    )
+    party.extractor = CSV('party_abbreviation')
     party.language = 'de'
 
     party_full = field_defaults.party_full()
-    party_full.extractor = CSV(
-        field='party_full_name'
-    )
+    party_full.extractor = CSV('party_full_name')
     party_full.language = 'de'
 
     party_id = field_defaults.party_id()
-    party_id.extractor = CSV(
-        field='party_id'
-    )
+    party_id.extractor = CSV('party_id')
 
     role = field_defaults.parliamentary_role()
-    role.extractor = CSV(
-        field='position_short'
-    )
+    role.extractor = CSV('position_short')
     role.language = 'en'
 
     role_long = field_defaults.role_long()
-    role_long.extractor = CSV(
-        field='position-long'
-    )
+    role_long.extractor = CSV('position-long')
 
     speaker = field_defaults.speaker()
     speaker.extractor = Combined(
-        CSV(field='speaker_first_name', convert_to_none=False),
-        CSV(field='speaker_last_name', convert_to_none=False),
+        CSV('speaker_first_name', convert_to_none=False),
+        CSV('speaker_last_name', convert_to_none=False),
         transform=lambda x: ' '.join(x)
     )
 
     speaker_id = field_defaults.speaker_id()
-    speaker_id.extractor = CSV(
-        field='speaker_id'
-    )
+    speaker_id.extractor = CSV('speaker_id')
 
     speaker_aristocracy = field_defaults.speaker_aristocracy()
-    speaker_aristocracy.extractor = CSV(
-        field='speaker_aristocracy'
-    )
+    speaker_aristocracy.extractor = CSV('speaker_aristocracy')
 
     speaker_academic_title = field_defaults.speaker_academic_title()
-    speaker_academic_title.extractor = CSV(
-        field='speaker_academic_title'
-    )
+    speaker_academic_title.extractor = CSV('speaker_academic_title')
 
     speaker_birth_country = field_defaults.speaker_birth_country()
-    speaker_birth_country.extractor = CSV(
-        field='speaker_birth_country'
-    )
+    speaker_birth_country.extractor = CSV('speaker_birth_country')
     speaker_birth_country.language = 'de'
 
     speaker_birthplace = field_defaults.speaker_birthplace()
-    speaker_birthplace.extractor = CSV(
-        field='speaker_birth_place'
-    )
+    speaker_birthplace.extractor = CSV('speaker_birth_place')
     speaker_birthplace.language = 'de'
 
     speaker_birth_year = field_defaults.speaker_birth_year()
     speaker_birth_year.extractor = CSV(
-        field='speaker_birth_date',
+        'speaker_birth_date',
         transform=formatting.extract_year
     )
 
     speaker_death_year = field_defaults.speaker_death_year()
     speaker_death_year.extractor = CSV(
-        field='speaker_death_date',
+        'speaker_death_date',
         transform=formatting.extract_year
     )
 
     speaker_gender = field_defaults.speaker_gender()
-    speaker_gender.extractor = CSV(
-        field='speaker_gender'
-    )
+    speaker_gender.extractor = CSV('speaker_gender')
     speaker_gender.language = 'en'
 
     speaker_profession = field_defaults.speaker_profession()
-    speaker_profession.extractor = CSV(
-        field='speaker_profession'
-    )
+    speaker_profession.extractor = CSV('speaker_profession')
     speaker_profession.language = 'de'
 
     speech = field_defaults.speech()
     speech.extractor = CSV(
-        field='speech_content',
+        'speech_content',
         multiple=True,
         transform=lambda x : ' '.join(x)
     )
     speech.language = 'de'
 
     speech_id = field_defaults.speech_id()
-    speech_id.extractor = CSV(
-        field='id'
-    )
+    speech_id.extractor = CSV('id')
 
     url = field_defaults.url()
-    url.extractor = CSV(
-        field='document_url'
-    )
+    url.extractor = CSV('document_url')
 
     # order of speeches: value is identical to speech_id
     # but saved as integer for sorting
     sequence = field_defaults.sequence()
-    sequence.extractor = CSV(
-        field = 'id'
-    )
+    sequence.extractor = CSV('id')
 
     def __init__(self):
         self.fields = [

--- a/backend/corpora/parliament/germany-old.py
+++ b/backend/corpora/parliament/germany-old.py
@@ -34,54 +34,40 @@ class ParliamentGermanyOld(Parliament, CSVCorpusDefinition):
     )
 
     book_id = field_defaults.book_id()
-    book_id.extractor = CSV(
-        field='book_id'
-    )
+    book_id.extractor = CSV('book_id')
 
     book_label = field_defaults.book_label()
-    book_label.extractor = CSV(
-        field='book_label'
-    )
+    book_label.extractor = CSV('book_label')
 
     era = field_defaults.era(include_aggregations= False)
-    era.extractor = CSV(
-        field='parliament'
-    )
+    era.extractor = CSV('parliament')
 
     date = field_defaults.date()
-    date.extractor = CSV(
-        field='date'
-    )
+    date.extractor = CSV('date')
     date.search_filter.lower = min_date
     date.search_filter.upper = max_date
 
     date_is_estimate = field_defaults.date_is_estimate()
     date_is_estimate.extractor = CSV(
-        field='date_is_estimate',
+        'date_is_estimate',
         transform=standardize_bool
     )
 
     page = field_defaults.page()
-    page.extractor = CSV(
-        field='page_number'
-    )
+    page.extractor = CSV('page_number')
 
     speech = field_defaults.speech()
     speech.extractor = CSV(
-        field='text',
+        'text',
         multiple=True,
         transform=lambda x : ' '.join(x)
     )
 
     url = field_defaults.url()
-    url.extractor = CSV(
-        field='img_url'
-    )
+    url.extractor = CSV('img_url')
 
     speech_id = field_defaults.speech_id()
-    speech_id.extractor = CSV(
-        field='item_order'
-    )
+    speech_id.extractor = CSV('item_order')
 
     def __init__(self):
         self.fields = [

--- a/backend/corpora/parliament/norway-new.py
+++ b/backend/corpora/parliament/norway-new.py
@@ -73,128 +73,128 @@ class ParliamentNorwayNew(Parliament, CSVCorpusDefinition):
     chamber.searchable = False
 
     date = field_defaults.date()
-    date.extractor = CSV(field='date')
+    date.extractor = CSV('date')
     date.search_filter.lower = min_date
     date.search_filter.upper = max_date
 
     debate_title = field_defaults.debate_title()
     debate_title.extractor = CSV(
-        field = 'debate_title',
+        'debate_title',
         convert_to_none = EMPTY_VALUES
     )
 
     debate_id = field_defaults.debate_id()
-    debate_id.extractor = CSV(field = 'debate_reference')
+    debate_id.extractor = CSV('debate_reference')
 
     debate_type = field_defaults.debate_type()
     debate_type.extractor = CSV(
-        field = 'debate_type',
+        'debate_type',
         convert_to_none = EMPTY_VALUES
     )
 
     legislature = field_defaults.legislature()
     legislature.extractor = CSV(
-        field = 'cabinet_short',
+        'cabinet_short',
         convert_to_none = EMPTY_VALUES,
     )
 
     party = field_defaults.party()
     party.extractor = CSV(
-        field = 'party_name',
+        'party_name',
         convert_to_none = EMPTY_VALUES,
     )
 
     party_id = field_defaults.party_id()
     party_id.extractor = CSV(
-        field='party_id',
+        'party_id',
         convert_to_none = EMPTY_VALUES,
     )
 
     party_role = field_defaults.party_role()
     party_role.extractor = CSV(
-        field = 'party_role',
+        'party_role',
         convert_to_none = EMPTY_VALUES,
     )
 
     role = field_defaults.parliamentary_role()
     role.extractor = CSV(
-        field='speaker_role',
+        'speaker_role',
         convert_to_none = EMPTY_VALUES,
     )
 
     ministerial_role = field_defaults.ministerial_role()
     ministerial_role.extractor = Combined(
-        CSV(field='rep_name', convert_to_none=EMPTY_VALUES),
-        CSV(field='question_answered_by_minister_title', convert_to_none=EMPTY_VALUES),
+        CSV('rep_name', convert_to_none=EMPTY_VALUES),
+        CSV('question_answered_by_minister_title', convert_to_none=EMPTY_VALUES),
         transform = lambda values: extract_ministerial_role(*values)
     )
 
     speaker = field_defaults.speaker()
     speaker.extractor = CSV(
-        field='rep_name',
+        'rep_name',
         convert_to_none = EMPTY_VALUES,
     )
 
     speaker_id = field_defaults.speaker_id()
     speaker_id.extractor = Combined(
-        CSV(field='rep_id', convert_to_none = EMPTY_VALUES),
-        CSV(field='rep_name', convert_to_none = EMPTY_VALUES),
-        CSV(field='question_answered_by_id', convert_to_none = EMPTY_VALUES),
+        CSV('rep_id', convert_to_none = EMPTY_VALUES),
+        CSV('rep_name', convert_to_none = EMPTY_VALUES),
+        CSV('question_answered_by_id', convert_to_none = EMPTY_VALUES),
         transform = lambda values: extract_speaker_id(*values)
     )
 
     speaker_constituency = field_defaults.speaker_constituency()
     speaker_constituency.extractor = CSV(
-        field='county',
+        'county',
         convert_to_none = EMPTY_VALUES
     )
 
     speaker_gender = field_defaults.speaker_gender()
     speaker_gender.extractor = CSV(
-        field='rep_gender',
+        'rep_gender',
         convert_to_none = EMPTY_VALUES
     )
 
     speaker_birth_year = field_defaults.speaker_birth_year()
     speaker_birth_year.extractor = CSV(
-        field = 'rep_birth',
+        'rep_birth',
         transform = lambda date: formatting.extract_year(date, pattern = r'\d{2}\.\d{2}\.(\d{4})')
     )
 
     speaker_death_year = field_defaults.speaker_death_year()
     speaker_death_year.extractor = CSV(
-        field = 'rep_death',
+        'rep_death',
         transform = lambda date: formatting.extract_year(date, pattern = r'\d{2}\.\d{2}\.(\d{4})')
     )
 
     speech = field_defaults.speech()
-    speech.extractor = CSV(field='text')
+    speech.extractor = CSV('text')
 
     speech_id = field_defaults.speech_id()
-    speech_id.extractor = CSV(field='id')
+    speech_id.extractor = CSV('id')
 
     subject = field_defaults.subject()
     subject.extractor = CSV(
-        field = 'keyword',
+        'keyword',
         convert_to_none = EMPTY_VALUES
     )
 
     topic = field_defaults.topic()
     topic.extractor = CSV(
-        field='debate_subject',
+        'debate_subject',
         convert_to_none = EMPTY_VALUES
     )
 
     sequence = field_defaults.sequence()
     sequence.extractor = CSV(
-        field = 'order',
+        'order',
         transform = format_sequence,
         convert_to_none = EMPTY_VALUES,
     )
 
     language = field_defaults.language()
     language.extractor = CSV(
-        field = 'language',
+        'language',
         transform = format_language
     )
 

--- a/backend/corpora/parliament/norway.py
+++ b/backend/corpora/parliament/norway.py
@@ -49,14 +49,14 @@ class ParliamentNorway(Parliament, CSVCorpusDefinition):
 
     book_id = field_defaults.book_id()
     book_id.extractor = CSV(
-        field = 'source_file',
+        'source_file',
         transform = remove_file_extension,
     )
 
     book_label = field_defaults.book_label()
     book_label.extractor = Combined(
-        CSV(field = 'title'),
-        CSV(field = 'subtitle'),
+        CSV('title'),
+        CSV('subtitle'),
         transform = lambda parts: '; '.join(parts)
     )
 
@@ -73,7 +73,7 @@ class ParliamentNorway(Parliament, CSVCorpusDefinition):
 
     date_earliest = field_defaults.date_earliest()
     date_earliest.extractor = CSV(
-        field = 'year',
+        'year',
         transform = lambda value : formatting.get_date_from_year(value, 'earliest')
     )
     date_earliest.search_filter.lower = min_date
@@ -81,7 +81,7 @@ class ParliamentNorway(Parliament, CSVCorpusDefinition):
 
     date_latest = field_defaults.date_latest()
     date_latest.extractor = CSV(
-        field = 'year',
+        'year',
         transform = lambda value : formatting.get_date_from_year(value, 'latest')
     )
     date_latest.search_filter.lower = min_date
@@ -89,14 +89,14 @@ class ParliamentNorway(Parliament, CSVCorpusDefinition):
 
 
     page = field_defaults.page()
-    page.extractor = CSV(field = 'page')
+    page.extractor = CSV('page')
 
     speech = field_defaults.speech()
-    speech.extractor = CSV(field = 'text')
+    speech.extractor = CSV('text')
     speech.language = 'no'
 
     sequence = field_defaults.sequence()
-    sequence.extractor = CSV(field = 'page')
+    sequence.extractor = CSV('page')
 
     def __init__(self):
         self.fields = [

--- a/backend/corpora/parliament/sweden-old.py
+++ b/backend/corpora/parliament/sweden-old.py
@@ -57,63 +57,59 @@ class ParliamentSwedenOld(Parliament, CSVCorpusDefinition):
     image =  'sweden-old.jpg'
 
     book_id = field_defaults.book_id()
-    book_id.extractor = CSV(field = 'book_id')
+    book_id.extractor = CSV('book_id')
 
     book_label = field_defaults.book_label()
-    book_label.extractor = CSV(field = 'book_label')
+    book_label.extractor = CSV('book_label')
 
     country = field_defaults.country()
     country.extractor = Constant('Sweden')
 
     era = field_defaults.era()
     era.extractor = CSV(
-        field = 'era',
+        'era',
         transform = format_era
     )
 
     chamber = field_defaults.chamber()
     chamber.extractor = CSV(
-        field = 'chamber',
+        'chamber',
         transform = format_chamber
     )
     chamber.search_filter.option_count = 6
     chamber.description = 'Chamber (in Tvåkammarriksdagen era) or estate (in Ståndsriksdagen era) where the debate took place'
 
     date_earliest = field_defaults.date_earliest()
-    date_earliest.extractor = CSV(field='date_from')
+    date_earliest.extractor = CSV('date_from')
     date_earliest.search_filter.lower = min_date
     date_earliest.search_filter.upper = max_date
 
     date_latest = field_defaults.date_latest()
-    date_latest.extractor = CSV(field='date_to')
+    date_latest.extractor = CSV('date_to')
     date_latest.search_filter.lower = min_date
     date_latest.search_filter.upper = max_date
 
     speech = field_defaults.speech()
-    speech.extractor = CSV(field='text')
+    speech.extractor = CSV('text')
     speech.language = 'sv'
 
     page = field_defaults.page()
-    page.extractor = CSV(field='page_number')
+    page.extractor = CSV('page_number')
 
     sequence = field_defaults.sequence()
     sequence.extractor = CSV(
-        field = 'date_order',
+        'date_order',
         transform = formatting.extract_integer_value,
     )
     sequence.description = 'Order of documents within the same date range and chamber'
 
     url_pdf = field_defaults.url()
-    url_pdf.extractor = CSV(
-        field='pdf_url'
-    )
+    url_pdf.extractor = CSV('pdf_url')
     url_pdf.display_name = 'Source url (PDF)'
     url_pdf.description = 'URL to PDF source file of this speech'
 
     url_xml = field_defaults.url()
-    url_xml.extractor = CSV(
-        field='xml_url'
-    )
+    url_xml.extractor = CSV('xml_url')
     url_xml.name = 'url_xml'
     url_xml.display_name = 'Source url (XML)'
     url_xml.description = 'URL to XML source file of this speech'

--- a/backend/corpora/parliament/sweden.py
+++ b/backend/corpora/parliament/sweden.py
@@ -62,7 +62,7 @@ class ParliamentSweden(Parliament, CSVCorpusDefinition):
 
     date = field_defaults.date()
     date.extractor = CSV(
-        field = 'date',
+        'date',
         transform = complete_partial_dates
     )
     date.search_filter.lower = min_date
@@ -70,59 +70,59 @@ class ParliamentSweden(Parliament, CSVCorpusDefinition):
     date_is_estimate = field_defaults.date_is_estimate()
     date_is_estimate.description = 'Indicates if the recorded month and day are estimates'
     date_is_estimate.extractor = CSV(
-        field = 'date',
+        'date',
         transform = date_is_partial
     )
 
     chamber = field_defaults.chamber()
     chamber.extractor = CSV(
-        field = 'chamber',
+        'chamber',
         transform = format_chamber
     )
     chamber.search_filter.option_count = 3
 
     speech = field_defaults.speech()
-    speech.extractor = CSV(field = 'speech_text')
+    speech.extractor = CSV('speech_text')
     speech.language = 'sv'
 
     speech_id = field_defaults.speech_id()
-    speech_id.extractor = CSV(field = 'speech_id')
+    speech_id.extractor = CSV('speech_id')
 
     speaker = field_defaults.speaker()
-    speaker.extractor = CSV(field = 'person_name')
+    speaker.extractor = CSV('person_name')
 
     speaker_id = field_defaults.speaker_id()
-    speaker_id.extractor = CSV(field = 'person_id')
+    speaker_id.extractor = CSV('person_id')
 
     speaker_birth_year = field_defaults.speaker_birth_year()
     speaker_birth_year.extractor = CSV(
-        field = 'person_born',
+        'person_born',
         transform = formatting.extract_year
     )
 
     speaker_death_year = field_defaults.speaker_death_year()
     speaker_death_year.extractor = CSV(
-        field = 'person_dead',
+        'person_dead',
         transform = formatting.extract_year
     )
 
     speaker_constituency = field_defaults.speaker_constituency()
-    speaker_constituency.extractor = CSV(field = 'mp_district')
+    speaker_constituency.extractor = CSV('mp_district')
 
     speaker_gender = field_defaults.speaker_gender()
-    speaker_gender.extractor = CSV(field = 'person_gender')
+    speaker_gender.extractor = CSV('person_gender')
 
     party = field_defaults.party()
-    party.extractor = CSV(field = 'mp_party')
+    party.extractor = CSV('mp_party')
 
     parliamentary_role = field_defaults.parliamentary_role()
-    parliamentary_role.extractor = CSV(field = 'speaker_role')
+    parliamentary_role.extractor = CSV('speaker_role')
 
     ministerial_role = field_defaults.ministerial_role()
-    ministerial_role.extractor = CSV(field = 'minister_role')
+    ministerial_role.extractor = CSV('minister_role')
 
     sequence = field_defaults.sequence()
-    sequence.extractor = CSV(field = 'speech_order')
+    sequence.extractor = CSV('speech_order')
 
     def __init__(self):
         self.fields = [

--- a/backend/corpora/parliament/uk.py
+++ b/backend/corpora/parliament/uk.py
@@ -52,7 +52,7 @@ class ParliamentUK(Parliament, CSVCorpusDefinition):
 
     chamber =  field_defaults.chamber()
     chamber.extractor = CSV(
-        field='house',
+        'house',
         transform=format_house
     )
     chamber.search_filter.option_count = 3
@@ -63,67 +63,51 @@ class ParliamentUK(Parliament, CSVCorpusDefinition):
     )
 
     date = field_defaults.date()
-    date.extractor = CSV(
-        field='date',
-    )
+    date.extractor = CSV('date')
 
     debate_title = field_defaults.debate_title()
     debate_title.extractor = CSV(
-        field='debate',
+        'debate',
         transform=format_debate_title
     )
     debate_title.language = 'en'
 
     debate_id = field_defaults.debate_id()
-    debate_id.extractor = CSV(
-        field='debate_id'
-    )
+    debate_id.extractor = CSV('debate_id')
 
     speech = field_defaults.speech()
     speech.extractor = CSV(
-        field='content',
+        'content',
         multiple=True,
         transform=lambda x : ' '.join(x)
     )
     speech.language = 'en'
 
     speech_id = field_defaults.speech_id()
-    speech_id.extractor = CSV(
-        field='speech_id'
-    )
+    speech_id.extractor = CSV('speech_id')
 
     speech_type = field_defaults.speech_type()
-    speech_type.extractor = CSV(
-        field='speech_type'
-    )
+    speech_type.extractor = CSV('speech_type')
 
     speaker = field_defaults.speaker()
     speaker.extractor = CSV(
-        field='speaker_name',
+        'speaker_name',
         transform=format_speaker
     )
 
     speaker_id = field_defaults.speaker_id()
-    speaker_id.extractor = CSV(
-        field='speaker_id',
-    )
+    speaker_id.extractor = CSV('speaker_id')
 
     topic = field_defaults.topic()
-    topic.extractor = CSV(
-        field='heading_major',
-    )
+    topic.extractor = CSV('heading_major',)
     topic.language = 'en'
 
     subtopic = field_defaults.subtopic()
-    subtopic.extractor = CSV(
-        field='heading_minor',
-    )
+    subtopic.extractor = CSV('heading_minor')
     subtopic.language = 'en'
 
     sequence = field_defaults.sequence()
-    sequence.extractor = CSV(
-        field='sequence',
-    )
+    sequence.extractor = CSV('sequence')
 
     def __init__(self):
         self.fields = [

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -132,7 +132,7 @@ h11==0.14.0
     #   wsproto
 humanize==4.9.0
     # via flower
-ianalyzer-readers==0.0.0
+ianalyzer-readers==0.1.0
     # via -r requirements.in
 idna==3.4
     # via

--- a/documentation/Defining-corpus-fields.md
+++ b/documentation/Defining-corpus-fields.md
@@ -4,15 +4,9 @@ Each corpus has a number of fields, which are extracted from source data. Each f
 
 ## Extracting values
 
-Various classes are defined in `ianalyzer_readers.extract`
+The `extractor` attribute of a field should define how it extracts its data from source files. This value should be an instance of `Extractor`, which is defined in the `ianalyzer_readers` package. See [the API documentation of ianalyzer_readers](https://ianalyzer-readers.readthedocs.io/en/latest/api/#extractors) for a list of available extractors and their parameters.
 
-- The extractors `XML`, `HTML`, `CSV` and `JSON` are intended to extract values from the document type of your corpus. Naturally, `XML` is only available for `XMLCorpusDefinition`, et cetera. All other extractors are available for all corpora.
-- The `Metadata` extractor is used to collect any information that you passed on during file discovery, such as information based on the file path.
-- The `Constant` extractor can be used to define a constant value.
-- The `Order` extractor gives you the index of that document within the file.
-- The `Choice` and `Combined`, `Backup`, and `Pass` extractors can be used to combine multiple extractors.
-
-A field can have the property `required = True`, which means the document will not be added to the index if the extracted value for this field is falsy.
+These extractors are typically sufficient for new corpora; if they are not, you can create a custom `Extractor` subclass for your corpus, or expand the `ianalyzer_readers` package.
 
 ## Elasticsearch mapping
 

--- a/documentation/How-to-add-a-new-corpus-to-Ianalyzer.md
+++ b/documentation/How-to-add-a-new-corpus-to-Ianalyzer.md
@@ -52,38 +52,13 @@ The following properties are optional:
 
 The corpus class should also define a function `sources(self, start, end)` which iterates source files (presumably within on `data_directory`). The `start` and `end` properties define a date range: if possible, only yield files within the range. Each source file should be tuple of a filename and a dict with metadata.
 
-### XML / HTML corpora
+### Different types of readers
 
-If your source files are XML or HTML files, your corpus definition should respectively subclass `XMLCorpusDefinition` or `HTMLCorpusDefinition`.
+The `CorpusDefinition` class is a subclass of the `Reader` in `ianalyzer_readers`. `Reader` is a base class that does not provide much for data extraction.
 
-In addition to the properties above, the corpus class must define:
-- `tag_toplevel`: The highest-level tag in the source file.
-- `tag_entry`: The tag that corresponds to a single document entry.
+Most corpus definitions also inherit from a more specific `Reader` that provides functionality for the type of source data, e.g. `XMLReader`, `CSVReader`, etc. For convenience, you can use the classes `XMLCorpusDefinition`, `CSVCorpusDefinition`, etc., defined in [corpus.py](/backend/addcorpus/python_corpora/corpus.py).
 
-These tags can be strings or functions that map a metadata dict to a string. Your corpus will have one document for each `tag_entry`.
-
-### CSV corpora
-
-If your source files are CSV files, your corpus definition should subclass `CSVCorpusDefinition`.
-
-The CSV files will be read row by row. You can write the definition so each document is based on a single row, or so that each document is based on a group of adjacent rows.
-
-In addition to the properties above, CSV corpora have the following optional properties:
-- `field_entry`: specifies a field in de CSV that corresponds to a single document entry. A new document is begins whenever the value in this field changes. If left undefined, each row of the CSV will be indexed as a separate document.
-- `delimiter`: the delimiter for the CSV reader (`,` by default)
-
-### Spreadsheet corpora
-
-If your source files are XLSX files, your corpus definition should subclass `XLSXCorpusDefinition`.
-
-This reader is quite rudimentary. It will read data with a "CSV-like" structure on the first sheet.
-
-The reader works like the CSV reader and also uses the `CSV` extractor. However, it does not have a `delimiter` parameter.
-
-### JSON corpora
-If your source files are in JSON format, your corpus definition should subclass `JSONCorpusDefinition`.
-
-The JSON ingested via `source2dicts` is expected to contain a list of dictionaries, for which field data can be extracted with a given key.
+See [the documentation of ianalyzer_readers](https://ianalyzer-readers.readthedocs.io/en/latest/) for the available `Reader` classes and the API for each of them.
 
 ## Settings file
 


### PR DESCRIPTION
- Update `ianalyzer_readers` to the latest version.
- Replaced some documentation with references to the (more comprehensive) documentation of `ianalyzer_readers`.
- For the `CSV` extractor, the positional argument `field` was renamed to `column`, but I forgot that you can call positional arguments as named arguments in python and so this actually broke some code. Most of the changes here change `CSV(field='bla')` to `CSV('bla')`.