### PR TITLE
Hotfix/fix pagination

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -35,5 +35,5 @@ keywords:
   - elasticsearch
   - natural language processing
 license: MIT
-version: 5.5.0
-date-released: '2024-02-06'
+version: 5.5.1
+date-released: '2024-03-21'

--- a/backend/addcorpus/constants.py
+++ b/backend/addcorpus/constants.py
@@ -44,7 +44,8 @@ FORBIDDEN_FIELD_NAMES = [
     'visualize',
     'visualizedField',
     'normalize',
-    'ngramSettings'
+    'ngramSettings',
+    'p',
 ]
 '''
 Field names that cannot be used because they are also query parameters in frontend routes.

--- a/frontend/src/app/models/page-results.ts
+++ b/frontend/src/app/models/page-results.ts
@@ -38,9 +38,9 @@ export class PageResults extends Results<PageResultsParameters, DocumentPage> {
         private searchService: SearchService,
         query: QueryModel,
     ) {
-        super(store, query, ['sort', 'highlight', 'page']);
-        this.sort$ = this.state$.pipe(map(p => p.sort));
-        this.highlight$ = this.state$.pipe(map(p => p.highlight));
+        super(store, query, ['sort', 'highlight', 'p']);
+        this.sort$ = this.state$.pipe(map(params => params.sort));
+        this.highlight$ = this.state$.pipe(map(params => params.highlight));
         this.from$ = this.state$.pipe(
             map(parameters => parameters.from + 1)
         );

--- a/frontend/src/app/utils/params.spec.ts
+++ b/frontend/src/app/utils/params.spec.ts
@@ -68,7 +68,7 @@ describe('pageFromParams', () => {
             size: 20,
         };
 
-        expect(pageToParams(state)).toEqual({ page: null });
+        expect(pageToParams(state)).toEqual({ p: null });
         expect(pageFromParams({})).toEqual(state);
     });
 });

--- a/frontend/src/app/utils/params.ts
+++ b/frontend/src/app/utils/params.ts
@@ -77,16 +77,16 @@ export const pageToParams = (state: PageParameters): Params => {
 
     if (page === 1) {
         return {
-            page: null,
+            p: null,
         };
     }
 
-    return {page};
+    return {p: page};
 };
 
 export const pageFromParams = (params: Params|undefined): PageParameters => {
-    if (params && params['page']) {
-        const page = _.toInteger(params['page']);
+    if (params && params['p']) {
+        const page = _.toInteger(params['p']);
         const size = RESULTS_PER_PAGE;
         const from = (page - 1) * size;
         return {from, size};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i-analyzer",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "license": "MIT",
   "scripts": {
     "postinstall": "yarn install-back && yarn install-front",


### PR DESCRIPTION
This fixes an issue where page navigation in the Times and P&P Netherlands corpora did not work. (Probably others, too.)

The problem was that the new route query parameter for the page was named `page` which is also a field name for some corpora. This breaks things because the route is ambiguous for those corpora. Fixed it by renaming the page parameter to `p`.