### PR TITLE
increment version number on CITATION.cff

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+  jobs:
+    citation-update:
+    uses: actions/checkout@v3
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Update CITATION.cff
+    - run: |
+      version=`grep -o '\d\+\.\d\+\.\d\+' package.json`
+      sed "s/^version: [[:digit:]]\{1,\}\.[[:digit:]]\{1,\}\.[[:digit:]]\{1,\}/version: $version/" CITATION.cff > CITATION.cff.temp
+      rm -f CITATION.cff
+      mv CITATION.cff.temp CITATION.cff
+      git commit -a -m "update version number in CITATION.cff"
+


### PR DESCRIPTION
To keep version numbers up to date in `CITATION.cff`, I thought to update upon every merge to `master`. This may only a partial solution for keeping `CITATION.cff` up to date, as the doi from zenodo will still point to the old version. *BUT* we may use the overarching DOI for I-Analyzer, [10.5281/zenodo.10261620](https://zenodo.org/account/settings/github/repository/UUDigitalHumanitieslab/I-analyzer), which seems to point to the latest version always.