### PR TITLE
feat: introduce authService as dependency on tagService

### DIFF
--- a/frontend/src/app/document-view/document-view.component.html
+++ b/frontend/src/app/document-view/document-view.component.html
@@ -9,10 +9,10 @@
                             <ia-search-relevance [value]="document.relevance"></ia-search-relevance>
                         </td>
                     </tr>
-                    <tr>
+                    <tr *ngIf="(document?.tags$ | async) as tags">
                         <th>Your tags</th>
                         <td>
-                            <ia-document-tags [document]="document"></ia-document-tags>
+                            <ia-document-tags [document]="document" [tags]="tags"></ia-document-tags>
                         </td>
                     </tr>
                     <ng-container *ngFor="let field of propertyFields">

--- a/frontend/src/app/document-view/document-view.component.ts
+++ b/frontend/src/app/document-view/document-view.component.ts
@@ -4,7 +4,6 @@ import { CorpusField, FoundDocument, Corpus, QueryModel } from '../models/index'
 import { DocumentView } from '../models/document-page';
 import * as _ from 'lodash';
 import { documentIcons } from '../shared/icons';
-import { findByName } from '../utils/utils';
 
 @Component({
     selector: 'ia-document-view',

--- a/frontend/src/app/filter/filter-manager.component.spec.ts
+++ b/frontend/src/app/filter/filter-manager.component.spec.ts
@@ -71,8 +71,7 @@ describe('FilterManagerComponent', () => {
             fixture.detectChanges();
         });
 
-        xit('does not show tag filter', async () => {
-            // TO DO
+        it('does not show tag filter', async () => {
             await fixture.whenStable();
             const compiled = fixture.debugElement;
             const tagFilter = compiled.query(By.css('ia-tag-filter'));

--- a/frontend/src/app/filter/filter-manager.component.ts
+++ b/frontend/src/app/filter/filter-manager.component.ts
@@ -7,6 +7,8 @@ import { map } from 'rxjs/operators';
 
 import { FilterInterface, QueryModel } from '../models/index';
 import { filterIcons } from '../shared/icons';
+import { AuthService } from '../services/auth.service';
+import { isTagFilter } from '../models/tag-filter';
 
 @Component({
     selector: 'ia-filter-manager',
@@ -17,8 +19,10 @@ export class FilterManagerComponent {
     @Input() queryModel: QueryModel;
 
     filterIcons = filterIcons;
+    authorized: boolean;
 
-    constructor() {
+    constructor(private authService: AuthService) {
+        this.authorized = this.authService.getCurrentUser() !== null;
     }
 
     get activeFilters(): FilterInterface[] {
@@ -26,7 +30,12 @@ export class FilterManagerComponent {
     }
 
     get filters(): FilterInterface[] {
-        return this.queryModel?.filters;
+        const filters = this.queryModel?.filters;
+        if (this.authorized) {
+            return filters;
+        } else {
+            return filters.filter(filter => !isTagFilter(filter));
+        }
     }
 
     get anyActiveFilters$(): Observable<boolean> {

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -31,7 +31,7 @@ export class AuthService implements OnDestroy {
     private currentUserSubject = new BehaviorSubject<User>(null);
     public currentUser$ = this.currentUserSubject
         .asObservable()
-        .pipe(distinctUntilChanged());
+        .pipe(distinctUntilChanged(), takeUntil(this.destroy$));
     // Provide the currentUser as a Promise to adapt to existing functionality
     public currentUserPromise = this.currentUser$.toPromise();
 

--- a/frontend/src/app/services/tag.service.spec.ts
+++ b/frontend/src/app/services/tag.service.spec.ts
@@ -4,6 +4,8 @@ import { TagService } from './tag.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ApiService } from './api.service';
 import { ApiServiceMock } from '../../mock-data/api';
+import { AuthService } from './auth.service';
+import { AuthServiceMock } from '../../mock-data/auth';
 
 describe('TagService', () => {
     let service: TagService;
@@ -12,6 +14,7 @@ describe('TagService', () => {
         TestBed.configureTestingModule({
             providers: [
                 { provide: ApiService, useValue: new ApiServiceMock() },
+                { provide: AuthService, useValue: new AuthServiceMock() }
             ],
             imports: [
                 HttpClientTestingModule,

--- a/frontend/src/app/tag/document-tags/document-tags.component.html
+++ b/frontend/src/app/tag/document-tags/document-tags.component.html
@@ -1,4 +1,4 @@
-<div class="field is-grouped is-grouped-multiline" *ngIf="(document?.tags$ | async) as tags">
+<div class="field is-grouped is-grouped-multiline">
     <div class="control tags has-addons" *ngFor="let tag of tags">
         <span class="tag is-primary tag-name">
             <span class="name">

--- a/frontend/src/app/tag/document-tags/document-tags.component.ts
+++ b/frontend/src/app/tag/document-tags/document-tags.component.ts
@@ -10,6 +10,7 @@ import { formIcons, actionIcons } from '../../shared/icons';
 })
 export class DocumentTagsComponent implements OnChanges {
     @Input() document: FoundDocument;
+    @Input() tags: Tag[];
 
     formIcons = formIcons;
     actionIcons = actionIcons;

--- a/frontend/src/mock-data/auth.ts
+++ b/frontend/src/mock-data/auth.ts
@@ -5,10 +5,12 @@ export class AuthServiceMock {
     currentUser$ = of(mockUser);
     isAuthenticated$ = of(1);
     getCurrentUserPromise = () => Promise.resolve(mockUser);
+    getCurrentUser = () => mockUser;
 }
 
 export class UnauthenticatedMock {
     currentUser$ = of(null);
     isAuthenticated$ = of(0);
     getCurrentUserPromise = () => Promise.resolve(null);
+    getCurrentUser = () => null;
 }


### PR DESCRIPTION
Close #1483. After 4+ hours of trying to write a decent unit test for `document-view-component` which tests that tags are shown for authenticated users / not shown for unauthenticated users, I give up, and commit with a test only for the behaviour of the tag filter. 😞 Hope to figure out what the problem is soon. I think it's something to do with the `TagServiceMock` not mocking convincingly enough. But in the interest of a speedy release, perhaps better to just rely on my manual tests for now.

### Authorized:
<img width="1141" alt="Screenshot 2024-04-11 at 15 56 34" src="https://github.com/UUDigitalHumanitieslab/I-analyzer/assets/11174072/e66216f7-7dc8-4596-a8db-232ff1c17cc1">
<img width="1268" alt="Screenshot 2024-04-11 at 15 56 39" src="https://github.com/UUDigitalHumanitieslab/I-analyzer/assets/11174072/87ed5435-5317-4017-baec-bdbdb5e82d9e">

### Unauthorized:

<img width="386" alt="Screenshot 2024-04-11 at 15 56 50" src="https://github.com/UUDigitalHumanitieslab/I-analyzer/assets/11174072/5c7cc45f-3dfa-4ec5-98fb-aceb5fc5e37c">
<img width="1160" alt="Screenshot 2024-04-11 at 15 56 54" src="https://github.com/UUDigitalHumanitieslab/I-analyzer/assets/11174072/000692d2-86ca-49e8-af32-7bc68a40445a">

### Requests for unauthenticated user:
The only request to the backend is now one to the `user` endpoint:

<img width="513" alt="Screenshot 2024-04-11 at 15 57 30" src="https://github.com/UUDigitalHumanitieslab/I-analyzer/assets/11174072/4538ef98-df66-4b26-9dc6-b9ca9781165b">
