### PR TITLE
mark peace import test xfail

### DIFF
--- a/backend/corpora/peaceportal/tests/test_peace.py
+++ b/backend/corpora/peaceportal/tests/test_peace.py
@@ -240,6 +240,7 @@ def corpus_test_name(corpus_spec):
     return corpus_spec['name']
 
 
+@pytest.mark.xfail()
 @pytest.mark.parametrize("corpus_object", CORPUS_TEST_DATA, ids=corpus_test_name)
 def test_peace_imports(peace_test_settings, corpus_object):
     parent_corpus = load_corpus_definition('peaceportal')


### PR DESCRIPTION
The `test_peace_imports` regularly fails during CI ([example](https://github.com/UUDigitalHumanitieslab/I-analyzer/actions/runs/8832898059/job/24251085038)). Can we add an [xfail mark](https://docs.pytest.org/en/6.2.x/reference.html?highlight=xfail#pytest.mark.xfail) so it's less disruptive?