### PR TITLE
Instructions to run loadcorpora admin command

### DIFF
--- a/backend/addcorpus/python_corpora/load_corpus.py
+++ b/backend/addcorpus/python_corpora/load_corpus.py
@@ -41,7 +41,7 @@ def load_corpus_definition(corpus_name) -> CorpusDefinition:
     # assume the class name is the same as the corpus name,
     # allowing for differences in camel case vs. lower case
     regex = re.compile('[^a-zA-Z]')
-    corpus_name = regex.sub('', corpus_name)
+    corpus_name = regex.sub('', corpus_name).lower()
     endpoint = next((attr for attr in dir(corpus_mod)
                      if attr.lower() == corpus_name), None)
     corpus_class = getattr(corpus_mod, endpoint)

--- a/documentation/First-time-setup.md
+++ b/documentation/First-time-setup.md
@@ -77,7 +77,7 @@ _Note:_ these instructions are for indexing a corpus that already has a corpus d
 
 1. Add the corpus to the `CORPORA` dictionary in your local settings file. See [CORPORA settings documentation](/documentation/Django-project-settings.md#corpora).
 2. Set configurations for your corpus. Check the definition file to see which variables it expects to find in the configuration. Some of these may be optional, but you will at least need to define the (absolute) path to your source files.
-3. Activate your python virtual environment. Create an ElasticSearch index from the source files by running, e.g., `yarn django index dutchannualreports`, for indexing the Dutch Annual Reports corpus in a development environment. See [Indexing](documentation/Indexing-corpora.md) for more information.
+3. Activate your python virtual environment. Run the `loadcorpora` admin command (`yarn django loadcorpora`) to register the new corpus in the SQL database. Then create an ElasticSearch index from the source files by running, e.g., `yarn django index dutchannualreports`, for indexing the Dutch Annual Reports corpus in a development environment. See [Indexing](documentation/Indexing-corpora.md) for more information.
 
 ## Running a dev environment
 

--- a/documentation/Indexing-corpora.md
+++ b/documentation/Indexing-corpora.md
@@ -6,6 +6,7 @@ You can start indexing once you have
 - A python source file for the corpus
 - A directory with source data
 - Added the necessary properties to django settings
+- Run the admin command `loadcorpora` (`yarn django loadcorpora`)
 
 The basic indexing command is:
 


### PR DESCRIPTION
As discussed with @BeritJanssen the READMEs did not include instructions to run the `loadcorpora` admin command before indexing, so I added it to the readmes.

I have also done a small fix. The documentation states that the keys in the `CORPORA` dictionary are case insensitive. However, the function `load_corpus_definition` does not match using lower case on both sides, so that using lower case is obligatory. I think this small change fixes this, but please check it carefully.

I'm asking a review from @lukavdplas because they have been most involved with documentation.