### PR TITLE
Feature/json corpus api

### DIFF
--- a/backend/addcorpus/json_corpora/export_json.py
+++ b/backend/addcorpus/json_corpora/export_json.py
@@ -6,7 +6,7 @@ from addcorpus.es_mappings import primary_mapping_type
 
 def export_json_corpus(corpus: Corpus) -> Dict:
     config = corpus.configuration
-    data = {'name': corpus.name}
+    data = {'name': corpus.name, 'id': corpus.pk }
     data['meta'] = export_corpus_meta(config)
     data['source_data'] = export_corpus_source_data(config)
     options = export_corpus_options(config)

--- a/backend/addcorpus/json_corpora/import_json.py
+++ b/backend/addcorpus/json_corpora/import_json.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, Optional
+from typing import List, Dict, Iterable, Optional
 from datetime import datetime
 
 
@@ -10,22 +10,13 @@ from addcorpus.validation.publishing import _any_date_fields
 from django.conf import settings
 from addcorpus.json_corpora.constants import DEFAULT_CSV_DELIMITER, DATE_FORMAT
 
-def import_json_corpus(data: Dict) -> Corpus:
+def import_json_corpus(data: Dict) -> Dict:
     name = get_path(data, 'name')
 
-    corpus, _created = Corpus.objects.get_or_create(name=name)
-
-    # create a clean CorpusConfiguration object, but use the existing PK if possible
-    pk = corpus.configuration_obj.pk if corpus.configuration_obj else None
-    configuration = CorpusConfiguration(pk=pk, corpus=corpus)
-    configuration = _parse_configuration(data, configuration)
-    configuration.save()
-    configuration.full_clean()
-
-    _import_fields(data, configuration)
-
-    return corpus
-
+    return {
+        'name': name,
+        'configuration': _parse_configuration(data)
+    }
 
 def create_index_name(corpus_name: str) -> str:
     prefix = settings.SERVERS['default'].get('index_prefix', None)
@@ -34,71 +25,57 @@ def create_index_name(corpus_name: str) -> str:
     return corpus_name
 
 
-def _parse_configuration(data: Dict, configuration: CorpusConfiguration) -> CorpusConfiguration:
-    configuration.title = get_path(data, 'meta', 'title')
-    configuration.description = get_path(data, 'meta', 'description')
-    configuration.category = get_path(data, 'meta', 'category')
-    configuration.es_index = create_index_name(get_path(data, 'name'))
-    configuration.languages = get_path(data, 'meta', 'languages')
-    configuration.min_date = _parse_date(
-        get_path(data, 'meta', 'date_range', 'min'))
-    configuration.max_date = _parse_date(
-        get_path(data, 'meta', 'date_range', 'max'))
-    configuration.default_sort = get_path(
-        data, 'options', 'default_sort') or {}
-    configuration.language_field = get_path(
-        data, 'options', 'language_field') or ''
-    configuration.document_context = get_path(
-        data, 'options', 'document_context') or {}
-    configuration.source_data_delimiter = get_path(
-        data, 'source_data', 'options', 'delimiter') or DEFAULT_CSV_DELIMITER
-    return configuration
+def _parse_configuration(data: Dict) -> Dict:
+    return {
+        'title': get_path(data, 'meta', 'title'),
+        'description': get_path(data, 'meta', 'description'),
+        'category': get_path(data, 'meta', 'category'),
+        'es_index': create_index_name(get_path(data, 'name')),
+        'languages': get_path(data, 'meta', 'languages'),
+        'min_date': _parse_date(
+            get_path(data, 'meta', 'date_range', 'min')),
+        'max_date': _parse_date(
+            get_path(data, 'meta', 'date_range', 'max')),
+        'default_sort': get_path(
+            data, 'options', 'default_sort') or {},
+        'language_field': get_path(
+            data, 'options', 'language_field') or '',
+        'document_context': get_path(
+            data, 'options', 'document_context') or {},
+        'source_data_delimiter': get_path(
+            data, 'source_data', 'options', 'delimiter') or DEFAULT_CSV_DELIMITER,
+        'fields': _import_fields(data),
+    }
 
 
 def _parse_date(date: str):
     return datetime.strptime(date, DATE_FORMAT).date()
 
 
-def _import_fields(data: Dict, configuration: CorpusConfiguration) -> None:
+def _import_fields(data: Dict) -> List[Dict]:
     fields_data = get_path(data, 'fields')
 
-    for field_data in fields_data:
-        field = _parse_field(field_data, configuration)
-        field.save()
-        field.full_clean()
+    parsed = [_parse_field(field) for field in fields_data]
 
-    for field in configuration.fields.exclude(name__in=(f['name'] for f in fields_data)):
-        field.delete()
+    # TODO: replace this!!!!
+    # for field in configuration.fields.exclude(name__in=(f['name'] for f in fields_data)):
+    #     field.delete()
 
-    _include_ngram_visualisation(configuration.fields.all())
-
-
-def _field_pk(name: str, configuration: CorpusConfiguration):
-    try:
-        return Field.objects.get(corpus_configuration=configuration, name=name).pk
-    except Field.DoesNotExist:
-        return None
+    _include_ngram_visualisation(parsed)
+    return parsed
 
 
-def _parse_field(field_data: Dict, configuration: Optional[CorpusConfiguration] = None) -> Field:
-    name = get_path(field_data, 'name')
-    display_name = get_path(field_data, 'display_name')
-    description = get_path(field_data, 'description')
+def _parse_field(field_data: Dict) -> Dict:
     results_overview = get_path(field_data, 'options', 'preview')
-    hidden = get_path(field_data, 'options', 'hidden')
-    extract_column = get_path(field_data, 'extract', 'column')
-
-    field = Field(
-        pk=_field_pk(name, configuration) if configuration else None,
-        corpus_configuration=configuration,
-        name=name,
-        display_name=display_name,
-        description=description,
-        results_overview=results_overview,
-        hidden=hidden,
-        csv_core=results_overview,
-        extract_column=extract_column,
-    )
+    parsed = {
+        'name': get_path(field_data, 'name'),
+        'display_name': get_path(field_data, 'display_name'),
+        'description': get_path(field_data, 'description'),
+        'results_overview': results_overview,
+        'hidden': get_path(field_data, 'options', 'hidden'),
+        'extract_column': get_path(field_data, 'extract', 'column'),
+        'csv_core': results_overview,
+    }
 
     field_type = get_path(field_data, 'type')
     parsers = {
@@ -111,171 +88,185 @@ def _parse_field(field_data: Dict, configuration: Optional[CorpusConfiguration] 
         'boolean': _parse_boolean_field,
         'geo_point': _parse_geo_field,
     }
-    field = parsers[field_type](field, field_data)
+    type_specific_data = parsers[field_type](field_data)
+    parsed.update(type_specific_data)
+    return parsed
 
-    return field
 
-
-
-def _parse_text_content_field(field: Field, field_data: Dict) -> Field:
+def _parse_text_content_field(field_data: Dict) -> Field:
     language = _parse_language(field_data)
     has_single_language = language and language != 'dynamic'
 
-    field.es_mapping = es_mappings.main_content_mapping(
-        token_counts=True,
-        stopword_analysis=has_single_language,
-        stemming_analysis=has_single_language,
-        language=language if has_single_language else None,
-    )
-    field.language = language
-    field.display_type = 'text_content'
-    field.search_filter = {}
-    field.searchable = True
-    field.search_field_core = True
+    parsed = {
+        'es_mapping': es_mappings.main_content_mapping(
+            token_counts=True,
+            stopword_analysis=has_single_language,
+            stemming_analysis=has_single_language,
+            language=language if has_single_language else None,
+        ),
+        'language': language,
+        'display_type': 'text_content',
+        'search_filter': {},
+        'searchable': True,
+        'search_field_core': True,
+    }
 
     visualize = get_path(field_data, 'options', 'visualize')
     if visualize:
-        field.visualizations = [
+        parsed['visualizations'] = [
             VisualizationType.WORDCLOUD.value
         ]
 
-    return field
+    return parsed
 
 
-def _parse_text_metadata_field(field: Field, field_data: Dict) -> Field:
+def _parse_text_metadata_field(field_data: Dict) -> Dict:
     searchable = get_path(field_data, 'options', 'search')
     filter_setting = get_path(field_data, 'options', 'filter')
     filterable = filter_setting != 'none'
     sortable = get_path(field_data, 'options', 'sort')
     visualize = get_path(field_data, 'options', 'visualize')
 
-    field.language = _parse_language(field_data)
+    parsed = {
+        'language': _parse_language(field_data)
+    }
 
     if searchable and not (sortable or filterable):
-        field.es_mapping = es_mappings.text_mapping()
-        field.display_type = 'text'
-        field.search_filter = {}
-        field.searchable = True
+        parsed['es_mapping'] = es_mappings.text_mapping()
+        parsed['display_type'] = 'text'
+        parsed['search_filter'] = {}
+        parsed['searchable'] = True
         if visualize:
-            field.visualizations = [
+            parsed['visualizations'] = [
                 VisualizationType.WORDCLOUD.value
             ]
     else:
-        field.es_mapping = es_mappings.keyword_mapping(
+        parsed['es_mapping'] = es_mappings.keyword_mapping(
             enable_full_text_search=searchable
         )
-        field.display_type = 'keyword'
+        parsed['display_type'] = 'keyword'
         if filter_setting == 'show':
-            field.search_filter = {
+            parsed['search_filter'] = {
                 'name': 'MultipleChoiceFilter',
-                'description': f'Select results based on {field.display_name}',
+                'description': f'Select results based on {field_data["display_name"]}',
             }
         else:
-            field.search_filter = {}
-        field.searchable = searchable
-        field.sortable = sortable
+            parsed['search_filter'] = {}
+        parsed['searchable'] = searchable
+        parsed['sortable'] = sortable
         if visualize:
-            field.visualizations = [
+            parsed['visualizations'] = [
                 VisualizationType.RESULTS_COUNT.value,
                 VisualizationType.TERM_FREQUENCY.value,
             ]
 
-    return field
+    return parsed
 
 
 def _parse_language(field_data: Dict) -> str:
     return get_path(field_data, 'language') or ''
 
 
-def _parse_url_field(field: Field, field_data: Dict) -> Field:
-    field.es_mapping = es_mappings.keyword_mapping()
-    field.display_type = 'url'
-    field.search_filter = {}
-    return field
+def _parse_url_field(_field_data: Dict) -> Dict:
+    parsed = {
+        'es_mapping': es_mappings.keyword_mapping(),
+        'display_type': 'url',
+        'search_filter': {},
+    }
+    return parsed
 
+def _parse_numeric_field(field_data: Dict) -> Dict:
+    parsed = {
+        'display_type': get_path(field_data, 'type')
+    }
 
-def _parse_numeric_field(field: Field, field_data: Dict) -> Field:
-    field.display_type = get_path(field_data, 'type')
-
-    if field.display_type == 'integer':
-        field.es_mapping = es_mappings.int_mapping()
+    if parsed['display_type'] == 'integer':
+        parsed['es_mapping'] = es_mappings.int_mapping()
     else:
-        field.es_mapping = es_mappings.float_mapping()
+        parsed['es_mapping'] = es_mappings.float_mapping()
 
-    field.sortable = get_path(field_data, 'options', 'sort')
+    parsed['sortable'] = get_path(field_data, 'options', 'sort')
 
     filter_setting = get_path(field_data, 'options', 'filter')
     if filter_setting == 'show':
-        field.search_filter = {
+        parsed['search_filter'] = {
             'name': 'RangeFilter',
-            'description': f'Select results based on {field.display_name}',
+            'description': f'Select results based on {field_data["display_name"]}',
         }
     else:
-        field.search_filter = {}
+        parsed['search_filter'] = {}
 
     visualize = get_path(field_data, 'options', 'visualize')
     if visualize:
-        field.visualizations = [
+        parsed['visualizations'] = [
             VisualizationType.RESULTS_COUNT.value,
             VisualizationType.TERM_FREQUENCY.value
         ]
-        field.visualization_sort = 'key'
-    return field
+        parsed['visualization_sort'] = 'key'
+    return parsed
 
 
-def _parse_date_field(field: Field, field_data: Dict) -> Field:
-    field.display_type = 'date'
-    field.es_mapping = es_mappings.date_mapping()
-    field.sortable = get_path(field_data, 'options', 'sort')
+def _parse_date_field(field_data: Dict) -> Dict:
     filter_setting = get_path(field_data, 'options', 'filter')
 
+    parsed = {
+        'display_type': 'date',
+        'es_mapping': es_mappings.date_mapping(),
+        'sortable': get_path(field_data, 'options', 'sort'),
+
+    }
+
     if filter_setting == 'show':
-        field.search_filter = {
+        parsed['search_filter'] = {
             'name': 'DateFilter',
-            'description': f'Select results based on {field.display_name}',
+            'description': f'Select results based on {field_data["display_name"]}',
         }
     else:
-        field.search_filter = {}
+        parsed['search_filter'] = {}
 
     visualize = get_path(field_data, 'options', 'visualize')
     if visualize:
-        field.visualizations = [
+        parsed['visualizations'] = [
             VisualizationType.RESULTS_COUNT.value,
             VisualizationType.TERM_FREQUENCY.value
         ]
-    return field
+    return parsed
 
 
-def _parse_boolean_field(field: Field, field_data: Dict) -> Field:
-    field.display_type = 'boolean'
-    field.es_mapping = es_mappings.bool_mapping()
+def _parse_boolean_field(field_data: Dict) -> Dict:
+    parsed = {
+        'display_type': 'boolean',
+        'es_mapping': es_mappings.bool_mapping(),
+    }
+
     filter_setting = get_path(field_data, 'options', 'filter')
 
     if filter_setting == 'show':
-        field.search_filter = {
+        parsed['search_filter'] = {
             'name': 'BooleanFilter',
-            'description': f'Select results based on {field.display_name}',
+            'description': f'Select results based on {field_data["display_name"]}',
         }
     else:
-        field.search_filter = {}
+        parsed['search_filter'] = {}
 
     visualize = get_path(field_data, 'options', 'visualize')
     if visualize:
-        field.visualizations = [
+        parsed['visualizations'] = [
             VisualizationType.RESULTS_COUNT.value,
             VisualizationType.TERM_FREQUENCY.value
         ]
-    return field
+    return parsed
 
 
-def _parse_geo_field(field: Field, field_data: Dict) -> Field:
-    field.display_type = 'geo_point'
-    field.es_mapping = es_mappings.geo_mapping()
-    field.search_filter = {}
-    return field
+def _parse_geo_field(field_data: Dict) -> Dict:
+    return {
+        'display_type': 'geo_point',
+        'es_mapping': es_mappings.geo_mapping(),
+        'search_filter': {},
+    }
 
 
-def _include_ngram_visualisation(fields: Iterable[Field]):
+def _include_ngram_visualisation(fields: Iterable[Dict]) -> None:
     '''
     Check if the ngram visualisation can be included and add it if possible.
 
@@ -283,8 +274,7 @@ def _include_ngram_visualisation(fields: Iterable[Field]):
     field is present.
     '''
 
-    if _any_date_fields(fields):
+    if any(get_path(field, 'es_mapping', 'type') == 'date' for field in fields):
         for field in fields:
-            if field.display_type == 'text_content':
-                field.visualizations.append(VisualizationType.NGRAM.value)
-                field.save()
+            if field['display_type'] == 'text_content':
+                field['visualizations'].append(VisualizationType.NGRAM.value)

--- a/backend/addcorpus/json_corpora/tests/test_export.py
+++ b/backend/addcorpus/json_corpora/tests/test_export.py
@@ -4,6 +4,7 @@ from addcorpus.json_corpora.import_json import _parse_field
 
 def test_corpus_export(json_mock_corpus: Corpus, json_corpus_data):
     result = export_json_corpus(json_mock_corpus)
+    result.pop('id')
     assert result == json_corpus_data
 
 def test_field_export(any_field_json):

--- a/backend/addcorpus/json_corpora/tests/test_export.py
+++ b/backend/addcorpus/json_corpora/tests/test_export.py
@@ -1,5 +1,5 @@
 from addcorpus.json_corpora.export_json import export_json_corpus, export_json_field
-from addcorpus.models import Corpus
+from addcorpus.models import Corpus, Field
 from addcorpus.json_corpora.import_json import _parse_field
 
 def test_corpus_export(json_mock_corpus: Corpus, json_corpus_data):
@@ -8,5 +8,6 @@ def test_corpus_export(json_mock_corpus: Corpus, json_corpus_data):
 
 def test_field_export(any_field_json):
     imported = _parse_field(any_field_json)
-    exported = export_json_field(imported)
+    field = Field(**imported)
+    exported = export_json_field(field)
     assert any_field_json == exported

--- a/backend/addcorpus/json_corpora/tests/test_import.py
+++ b/backend/addcorpus/json_corpora/tests/test_import.py
@@ -1,9 +1,12 @@
 from datetime import date
 from addcorpus.json_corpora.import_json import import_json_corpus, _parse_field
-
+from addcorpus.models import Corpus, Field
 
 def test_import(db, json_corpus_data):
-    corpus = import_json_corpus(json_corpus_data)
+    data = import_json_corpus(json_corpus_data)
+    corpus = Corpus(**data)
+    corpus.save()
+    corpus.full_clean()
 
     assert corpus.name == 'example'
     assert corpus.ready_to_index()
@@ -31,7 +34,8 @@ def test_import(db, json_corpus_data):
 
 
 def test_parse_content_field(content_field_json):
-    field = _parse_field(content_field_json)
+    data = _parse_field(content_field_json)
+    field = Field(**data)
     assert field.name == 'content'
     assert field.display_name == 'Content'
     assert field.display_type == 'text_content'
@@ -52,7 +56,8 @@ def test_parse_content_field(content_field_json):
 
 
 def test_parse_keyword_field(keyword_field_json):
-    field = _parse_field(keyword_field_json)
+    data = _parse_field(keyword_field_json)
+    field = Field(**data)
     assert field.name == 'author'
     assert field.display_type == 'keyword'
     assert field.search_filter['name'] == 'MultipleChoiceFilter'
@@ -67,7 +72,8 @@ def test_parse_keyword_field(keyword_field_json):
 
 
 def test_parse_int_field(int_field_json):
-    field = _parse_field(int_field_json)
+    data =  _parse_field(int_field_json)
+    field = Field(**data)
     assert field.name == 'year'
     assert field.display_type == 'integer'
     assert field.search_filter['name'] == 'RangeFilter'
@@ -83,7 +89,8 @@ def test_parse_int_field(int_field_json):
 
 
 def test_parse_float_field(float_field_json):
-    field = _parse_field(float_field_json)
+    data = _parse_field(float_field_json)
+    field = Field(**data)
     assert field.name == 'ocr_confidence'
     assert field.display_type == 'float'
     assert field.search_filter == {}
@@ -99,7 +106,8 @@ def test_parse_float_field(float_field_json):
 
 
 def test_parse_date_field(date_field_json):
-    field = _parse_field(date_field_json)
+    data = _parse_field(date_field_json)
+    field = Field(**data)
     assert field.name == 'date'
     assert field.display_type == 'date'
     assert field.search_filter['name'] == 'DateFilter'
@@ -114,7 +122,8 @@ def test_parse_date_field(date_field_json):
 
 
 def test_parse_boolean_field(boolean_field_json):
-    field = _parse_field(boolean_field_json)
+    data = _parse_field(boolean_field_json)
+    field = Field(**data)
     assert field.name == 'author_known'
     assert field.display_type == 'boolean'
     assert field.search_filter['name'] == 'BooleanFilter'
@@ -129,7 +138,8 @@ def test_parse_boolean_field(boolean_field_json):
 
 
 def test_parse_geo_field(geo_field_json):
-    field = _parse_field(geo_field_json)
+    data = _parse_field(geo_field_json)
+    field = Field(**data)
     assert field.name == 'location'
     assert field.display_type == 'geo_point'
     assert field.search_filter == {}

--- a/backend/addcorpus/json_corpora/tests/test_import.py
+++ b/backend/addcorpus/json_corpora/tests/test_import.py
@@ -2,7 +2,7 @@ from datetime import date
 from addcorpus.json_corpora.import_json import _parse_field
 from addcorpus.models import Field, Corpus
 from addcorpus.serializers import CorpusEditSerializer
-
+from addcorpus.models import Corpus, CorpusConfiguration
 
 def test_json_corpus_import(db, json_corpus_data):
     Corpus.objects.all().delete()
@@ -44,8 +44,18 @@ def test_serializer_representation(db, json_corpus_data):
     corpus = serializer.create(serializer.validated_data)
 
     serialized = serializer.to_representation(corpus)
-
+    serialized.pop('id')
     assert json_corpus_data == serialized
+
+def test_serializer_update(db, json_corpus_data, json_mock_corpus: Corpus):
+    json_corpus_data['meta']['description'] = 'A different description'
+    serializer = CorpusEditSerializer(data=json_corpus_data)
+    assert serializer.is_valid()
+    serializer.update(json_mock_corpus, serializer.validated_data)
+
+    corpus_config = CorpusConfiguration.objects.get(corpus=json_mock_corpus)
+    assert corpus_config.description == 'A different description'
+
 
 
 def test_parse_content_field(content_field_json):

--- a/backend/addcorpus/json_corpora/tests/test_import.py
+++ b/backend/addcorpus/json_corpora/tests/test_import.py
@@ -1,10 +1,12 @@
 from datetime import date
 from addcorpus.json_corpora.import_json import _parse_field
-from addcorpus.models import Field
+from addcorpus.models import Field, Corpus
 from addcorpus.serializers import CorpusEditSerializer
 
 
-def test_import(db, json_corpus_data):
+def test_json_corpus_import(db, json_corpus_data):
+    Corpus.objects.all().delete()
+
     serializer = CorpusEditSerializer(data=json_corpus_data)
     assert serializer.is_valid()
     corpus = serializer.create(serializer.validated_data)
@@ -35,6 +37,8 @@ def test_import(db, json_corpus_data):
 
 
 def test_serializer_representation(db, json_corpus_data):
+    Corpus.objects.all().delete()
+
     serializer = CorpusEditSerializer(data=json_corpus_data)
     assert serializer.is_valid()
     corpus = serializer.create(serializer.validated_data)

--- a/backend/addcorpus/json_corpora/tests/test_import.py
+++ b/backend/addcorpus/json_corpora/tests/test_import.py
@@ -1,12 +1,13 @@
 from datetime import date
-from addcorpus.json_corpora.import_json import import_json_corpus, _parse_field
-from addcorpus.models import Corpus, Field
+from addcorpus.json_corpora.import_json import _parse_field
+from addcorpus.models import Field
+from addcorpus.serializers import CorpusEditSerializer
+
 
 def test_import(db, json_corpus_data):
-    data = import_json_corpus(json_corpus_data)
-    corpus = Corpus(**data)
-    corpus.save()
-    corpus.full_clean()
+    serializer = CorpusEditSerializer(data=json_corpus_data)
+    assert serializer.is_valid()
+    corpus = serializer.create(serializer.validated_data)
 
     assert corpus.name == 'example'
     assert corpus.ready_to_index()
@@ -31,6 +32,16 @@ def test_import(db, json_corpus_data):
     line_field = config.fields.get(name='line')
     assert line_field.display_name == 'Line'
     assert line_field.display_type == 'text_content'
+
+
+def test_serializer_representation(db, json_corpus_data):
+    serializer = CorpusEditSerializer(data=json_corpus_data)
+    assert serializer.is_valid()
+    corpus = serializer.create(serializer.validated_data)
+
+    serialized = serializer.to_representation(corpus)
+
+    assert json_corpus_data == serialized
 
 
 def test_parse_content_field(content_field_json):

--- a/backend/addcorpus/json_corpora/tests/test_import.py
+++ b/backend/addcorpus/json_corpora/tests/test_import.py
@@ -48,14 +48,21 @@ def test_serializer_representation(db, json_corpus_data):
     assert json_corpus_data == serialized
 
 def test_serializer_update(db, json_corpus_data, json_mock_corpus: Corpus):
+    # edit description
     json_corpus_data['meta']['description'] = 'A different description'
     serializer = CorpusEditSerializer(data=json_corpus_data)
     assert serializer.is_valid()
     serializer.update(json_mock_corpus, serializer.validated_data)
-
     corpus_config = CorpusConfiguration.objects.get(corpus=json_mock_corpus)
     assert corpus_config.description == 'A different description'
 
+    # remove a field
+    assert Field.objects.filter(corpus_configuration__corpus=json_mock_corpus).count() == 2
+    json_corpus_data['fields'] = json_corpus_data['fields'][:-1]
+    serializer = CorpusEditSerializer(data=json_corpus_data)
+    assert serializer.is_valid()
+    serializer.update(json_mock_corpus, serializer.validated_data)
+    assert Field.objects.filter(corpus_configuration__corpus=json_mock_corpus).count() == 1
 
 
 def test_parse_content_field(content_field_json):

--- a/backend/addcorpus/json_corpora/tests/test_import.py
+++ b/backend/addcorpus/json_corpora/tests/test_import.py
@@ -1,13 +1,13 @@
 from datetime import date
 from addcorpus.json_corpora.import_json import _parse_field
 from addcorpus.models import Field, Corpus
-from addcorpus.serializers import CorpusEditSerializer
+from addcorpus.serializers import CorpusJSONDefinitionSerializer
 from addcorpus.models import Corpus, CorpusConfiguration
 
 def test_json_corpus_import(db, json_corpus_data):
     Corpus.objects.all().delete()
 
-    serializer = CorpusEditSerializer(data=json_corpus_data)
+    serializer = CorpusJSONDefinitionSerializer(data=json_corpus_data)
     assert serializer.is_valid()
     corpus = serializer.create(serializer.validated_data)
 
@@ -39,7 +39,7 @@ def test_json_corpus_import(db, json_corpus_data):
 def test_serializer_representation(db, json_corpus_data):
     Corpus.objects.all().delete()
 
-    serializer = CorpusEditSerializer(data=json_corpus_data)
+    serializer = CorpusJSONDefinitionSerializer(data=json_corpus_data)
     assert serializer.is_valid()
     corpus = serializer.create(serializer.validated_data)
 
@@ -50,7 +50,7 @@ def test_serializer_representation(db, json_corpus_data):
 def test_serializer_update(db, json_corpus_data, json_mock_corpus: Corpus):
     # edit description
     json_corpus_data['meta']['description'] = 'A different description'
-    serializer = CorpusEditSerializer(data=json_corpus_data)
+    serializer = CorpusJSONDefinitionSerializer(data=json_corpus_data)
     assert serializer.is_valid()
     serializer.update(json_mock_corpus, serializer.validated_data)
     corpus_config = CorpusConfiguration.objects.get(corpus=json_mock_corpus)
@@ -59,7 +59,7 @@ def test_serializer_update(db, json_corpus_data, json_mock_corpus: Corpus):
     # remove a field
     assert Field.objects.filter(corpus_configuration__corpus=json_mock_corpus).count() == 2
     json_corpus_data['fields'] = json_corpus_data['fields'][:-1]
-    serializer = CorpusEditSerializer(data=json_corpus_data)
+    serializer = CorpusJSONDefinitionSerializer(data=json_corpus_data)
     assert serializer.is_valid()
     serializer.update(json_mock_corpus, serializer.validated_data)
     assert Field.objects.filter(corpus_configuration__corpus=json_mock_corpus).count() == 1

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -1,8 +1,13 @@
 from rest_framework import serializers
+from typing import Dict
+
 from addcorpus.models import Corpus, CorpusConfiguration, Field, CorpusDocumentationPage
 from addcorpus.constants import CATEGORIES
 from langcodes import Language, standardize_tag
 from addcorpus.documentation import render_documentation_context
+from addcorpus.json_corpora.export_json import export_json_corpus
+from addcorpus.json_corpora.import_json import import_json_corpus
+
 
 class NonEmptyJSONField(serializers.JSONField):
     '''
@@ -121,3 +126,14 @@ class CorpusDocumentationPageSerializer(serializers.ModelSerializer):
     class Meta:
         model = CorpusDocumentationPage
         fields = ['corpus_configuration', 'type', 'content']
+
+
+class CorpusEditSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Corpus
+
+    def to_representation(self, instance) -> Dict:
+        return export_json_corpus(instance)
+
+    def to_internal_value(self, data):
+        return import_json_corpus(data)

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -158,8 +158,8 @@ class CorpusEditSerializer(serializers.ModelSerializer):
         corpus.save()
 
         configuration, _ = CorpusConfiguration.objects.get_or_create(corpus=corpus)
-        for attr in validated_data:
-            setattr(configuration, attr, validated_data[attr])
+        for attr in configuration_data:
+            setattr(configuration, attr, configuration_data[attr])
         configuration.save()
 
         for field_data in fields_data:

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -131,9 +131,45 @@ class CorpusDocumentationPageSerializer(serializers.ModelSerializer):
 class CorpusEditSerializer(serializers.ModelSerializer):
     class Meta:
         model = Corpus
+        fields = '__all__'
 
     def to_representation(self, instance) -> Dict:
         return export_json_corpus(instance)
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data) -> Dict:
         return import_json_corpus(data)
+
+    def create(self, validated_data: Dict):
+        configuration_data = validated_data.pop('configuration')
+        fields_data = configuration_data.pop('fields')
+
+        corpus = Corpus.objects.create(**validated_data)
+        configuration = CorpusConfiguration.objects.create(corpus=corpus, **configuration_data)
+        for field_data in fields_data:
+            Field.objects.create(corpus_configuration=configuration, **field_data)
+
+        return corpus
+
+    def update(self, instance: Corpus, validated_data: Dict):
+        configuration_data = validated_data.pop('configuration')
+        fields_data = configuration_data.pop('fields')
+
+        corpus = Corpus(pk=instance.pk, **validated_data)
+        corpus.save()
+
+        configuration, _ = CorpusConfiguration.objects.get_or_create(corpus=corpus)
+        for attr in validated_data:
+            setattr(configuration, attr, validated_data[attr])
+        configuration.save()
+
+        for field_data in fields_data:
+            field, _ = Field.objects.get_or_create(
+                corpus_configuration=configuration, name=field_data['name']
+            )
+            for attr in field_data:
+                setattr(field, attr, field_data[attr])
+            field.save()
+
+        configuration.fields.exclude(name__in=(f['name'] for f in fields_data)).delete()
+
+        return corpus

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -128,7 +128,7 @@ class CorpusDocumentationPageSerializer(serializers.ModelSerializer):
         fields = ['corpus_configuration', 'type', 'content']
 
 
-class CorpusEditSerializer(serializers.ModelSerializer):
+class CorpusJSONDefinitionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Corpus
         fields = '__all__'

--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -87,17 +87,17 @@ def test_corpus_not_publication_ready(admin_client, basic_mock_corpus):
 def test_corpus_edit_views(admin_client: Client, json_corpus_data: Dict, json_mock_corpus: Corpus):
     json_mock_corpus.delete()
 
-    response = admin_client.get('/api/corpus/edit/')
+    response = admin_client.get('/api/corpus/definitions/')
     assert status.is_success(response.status_code)
     assert len(response.data) == 0
 
     response = admin_client.post(
-        '/api/corpus/edit/',
+        '/api/corpus/definitions/',
         json_corpus_data,
         content_type='application/json',
     )
     assert status.is_success(response.status_code)
 
-    response = admin_client.get('/api/corpus/edit/')
+    response = admin_client.get('/api/corpus/definitions/')
     assert status.is_success(response.status_code)
     assert len(response.data) == 1

--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -1,4 +1,7 @@
 from rest_framework import status
+from django.test.client import Client
+from typing import Dict
+
 from users.models import CustomUser
 from addcorpus.models import Corpus
 from addcorpus.python_corpora.save_corpus import load_and_save_all_corpora
@@ -80,3 +83,21 @@ def test_corpus_not_publication_ready(admin_client, basic_mock_corpus):
 
     response = admin_client.get('/api/corpus/')
     corpus = not any(c['name'] == basic_mock_corpus for c in response.data)
+
+def test_corpus_edit_views(admin_client: Client, json_corpus_data: Dict, json_mock_corpus: Corpus):
+    json_mock_corpus.delete()
+
+    response = admin_client.get('/api/corpus/edit/')
+    assert status.is_success(response.status_code)
+    assert len(response.data) == 0
+
+    response = admin_client.post(
+        '/api/corpus/edit/',
+        json_corpus_data,
+        content_type='application/json',
+    )
+    assert status.is_success(response.status_code)
+
+    response = admin_client.get('/api/corpus/edit/')
+    assert status.is_success(response.status_code)
+    assert len(response.data) == 1

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -1,10 +1,10 @@
 from rest_framework.views import APIView
-from addcorpus.serializers import CorpusSerializer, CorpusDocumentationPageSerializer
+from addcorpus.serializers import CorpusSerializer, CorpusDocumentationPageSerializer, CorpusEditSerializer
 from rest_framework.response import Response
 from addcorpus.python_corpora.load_corpus import corpus_dir, load_corpus_definition
 import os
 from django.http.response import FileResponse
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAdminUser
 from addcorpus.permissions import CorpusAccessPermission, filter_user_corpora
 from rest_framework.exceptions import NotFound
 from rest_framework import viewsets
@@ -86,3 +86,11 @@ class CorpusDocumentView(APIView):
 
     def get(self, request, *args, **kwargs):
         return send_corpus_file(subdir='documents', **kwargs)
+
+
+class CorpusEditViewset(viewsets.ModelViewSet):
+    permission_classes = [IsAdminUser]
+    serializer_class = CorpusEditSerializer
+
+    def get_queryset(self):
+        return Corpus.objects.filter(has_python_definition=False)

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -1,5 +1,5 @@
 from rest_framework.views import APIView
-from addcorpus.serializers import CorpusSerializer, CorpusDocumentationPageSerializer, CorpusEditSerializer
+from addcorpus.serializers import CorpusSerializer, CorpusDocumentationPageSerializer, CorpusJSONDefinitionSerializer
 from rest_framework.response import Response
 from addcorpus.python_corpora.load_corpus import corpus_dir, load_corpus_definition
 import os
@@ -88,9 +88,9 @@ class CorpusDocumentView(APIView):
         return send_corpus_file(subdir='documents', **kwargs)
 
 
-class CorpusEditViewset(viewsets.ModelViewSet):
+class CorpusDefinitionViewset(viewsets.ModelViewSet):
     permission_classes = [IsAdminUser]
-    serializer_class = CorpusEditSerializer
+    serializer_class = CorpusJSONDefinitionSerializer
 
     def get_queryset(self):
         return Corpus.objects.filter(has_python_definition=False)

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -14,7 +14,7 @@ from es import es_index as index
 from django.conf import settings
 from django.contrib.auth.models import Group
 from addcorpus.models import Corpus
-from addcorpus.serializers import CorpusEditSerializer
+from addcorpus.serializers import CorpusJSONDefinitionSerializer
 
 @pytest.fixture(autouse=True)
 def media_dir(tmpdir, settings):
@@ -203,7 +203,7 @@ def json_corpus_data():
 @pytest.fixture(autouse=True)
 def json_mock_corpus(db,  json_corpus_data) -> Corpus:
     # add json mock corpora to the database at the start of each test
-    serializer = CorpusEditSerializer(data=json_corpus_data)
+    serializer = CorpusJSONDefinitionSerializer(data=json_corpus_data)
     assert serializer.is_valid()
     corpus = serializer.create(serializer.validated_data)
     return corpus

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -14,7 +14,7 @@ from es import es_index as index
 from django.conf import settings
 from django.contrib.auth.models import Group
 from addcorpus.models import Corpus
-
+from addcorpus.serializers import CorpusEditSerializer
 
 @pytest.fixture(autouse=True)
 def media_dir(tmpdir, settings):
@@ -201,6 +201,9 @@ def json_corpus_data():
 
 
 @pytest.fixture(autouse=True)
-def json_mock_corpus(db,  json_corpus_data):
+def json_mock_corpus(db,  json_corpus_data) -> Corpus:
     # add json mock corpora to the database at the start of each test
-    return import_json_corpus(json_corpus_data)
+    serializer = CorpusEditSerializer(data=json_corpus_data)
+    assert serializer.is_valid()
+    corpus = serializer.create(serializer.validated_data)
+    return corpus

--- a/backend/ianalyzer/urls.py
+++ b/backend/ianalyzer/urls.py
@@ -33,10 +33,12 @@ from api import urls as api_urls
 from media import urls as media_urls
 from tag import urls as tag_urls
 from tag.views import TagViewSet
+from addcorpus.views import CorpusEditViewset
 
 api_router = routers.DefaultRouter()  # register viewsets with this router
 api_router.register('search_history', QueryViewset, basename='query')
 api_router.register('tag/tags', TagViewSet)
+api_router.register('corpus/edit', CorpusEditViewset, basename='corpus')
 
 if settings.PROXY_FRONTEND:
     spa_url = re_path(r'^(?P<path>.*)$', proxy_frontend)

--- a/backend/ianalyzer/urls.py
+++ b/backend/ianalyzer/urls.py
@@ -33,12 +33,12 @@ from api import urls as api_urls
 from media import urls as media_urls
 from tag import urls as tag_urls
 from tag.views import TagViewSet
-from addcorpus.views import CorpusEditViewset
+from addcorpus.views import CorpusDefinitionViewset
 
 api_router = routers.DefaultRouter()  # register viewsets with this router
 api_router.register('search_history', QueryViewset, basename='query')
 api_router.register('tag/tags', TagViewSet)
-api_router.register('corpus/edit', CorpusEditViewset, basename='corpus')
+api_router.register('corpus/definitions', CorpusDefinitionViewset, basename='corpus')
 
 if settings.PROXY_FRONTEND:
     spa_url = re_path(r'^(?P<path>.*)$', proxy_frontend)


### PR DESCRIPTION
Builds on #1547 : implements the backend API for managing corpus definitions. Preparation for #982 

- Adapts the `import_json` / `export_json` modules to work with a DRF `ModelSerializer `
- Adds a viewset for listing / creating / updating JSON corpus definitions to the API.

You can now view and import JSON corpus definitions using the API.