### PR TITLE
enable sorting by date in guardianobserver

### DIFF
--- a/backend/corpora/guardianobserver/guardianobserver.py
+++ b/backend/corpora/guardianobserver/guardianobserver.py
@@ -86,7 +86,8 @@ class GuardianObserver(XMLCorpusDefinition):
             extractor=extract.XML(
                 tag='NumericPubDate', toplevel=True,
                 transform=lambda x: '{y}-{m}-{d}'.format(y=x[:4],m=x[4:6],d=x[6:])
-                )
+            ),
+            sortable=True,
         ),
         FieldDefinition(
             name='date-pub',


### PR DESCRIPTION
Request from a participant at our last workshop: enables sorting by date in the guardian-observer corpus.