### PR TITLE
add annotated-text-plugin to Docker

### DIFF
--- a/DockerfileElastic
+++ b/DockerfileElastic
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.10.2
+
+RUN bin/elasticsearch-plugin install mapper-annotated-text

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -52,7 +52,9 @@ services:
         target: /frontend/build
     command: sh -c "yarn prebuild && yarn start-docker"
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.2
+    build:
+      context: .
+      dockerfile: DockerfileElastic
     environment:
       - node.name=ianalyzer-node
       - discovery.type=single-node


### PR DESCRIPTION
This PR is mainly a convenience for developing with Docker: switching between an instance of Elasticsearch *with* the [Annotated Text Plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/8.6/mapper-annotated-text.html), needed for #956 , and one without, is rather annoying. This PR should not affect other development in Docker, but will make sure that working with a local volume that has an index with `annotated-text` mapping will be smooth.