### PR TITLE
New pair of GH actions for testing on pull requests

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - 'develop'
       - 'master'
-      - 'feature/**'
       - 'bugfix/**'
       - 'hotfix/**'
       - 'release/**'

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - 'develop'
       - 'master'
-      - 'feature/**'
       - 'bugfix/**'
       - 'hotfix/**'
       - 'release/**'

--- a/.github/workflows/pr-backend.yml
+++ b/.github/workflows/pr-backend.yml
@@ -1,0 +1,32 @@
+# This workflow will run backend tests on the Python version defined in the Dockerfiles
+
+name: Backend unit tests (pull request)
+
+on: [pull_request]
+jobs:
+  backend-test:
+    name: Test Backend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if files have been changed in the backend
+        uses: actions/github-script@0.9.0
+        id: backend-changed
+        with:
+          result-encoding: string
+          script: |
+            const result = await github.pulls.listFiles({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: context.payload.number,
+              per_page: 100
+            })
+            const backendChanged = result.data.filter(f => f.filename.startsWith("backend/") || f.filename.startsWith(".github") || f.filename.startsWith("docker-compose") || f.filename.startsWith(".env-ci")).length > 0
+            console.log("backend changed: ", backendChanged)
+            return backendChanged
+
+      - name: Checkout repository
+        if: ${{ steps.backend-changed.outputs.result == 'true' }}
+        uses: actions/checkout@v3
+
+      - name: Run backend tests
+        run: sudo mkdir -p /ci-data && sudo docker-compose --env-file .env-ci run backend pytest

--- a/.github/workflows/pr-frontend.yml
+++ b/.github/workflows/pr-frontend.yml
@@ -1,0 +1,33 @@
+# This workflow will run frontend tests on the Node version defined in the Dockerfiles
+
+name: Frontend unit tests (pull request)
+
+on: [pull_request]
+
+jobs:
+  frontend-test:
+    name: Test Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if files have been changed in the frontend
+        uses: actions/github-script@0.9.0
+        id: frontend-changed
+        with:
+          result-encoding: string
+          script: |
+            const result = await github.pulls.listFiles({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: context.payload.number,
+              per_page: 100
+            })
+            const frontendChanged = result.data.filter(f => f.filename.startsWith("frontend/") || f.filename.startsWith(".github") || f.filename.startsWith("docker-compose")  || f.filename.startsWith(".env-ci")).length > 0
+            console.log("Frontend changed: ", frontendChanged)
+            return frontendChanged
+
+      - name: Checkout repository
+        if: ${{ steps.frontend-changed.outputs.result == 'true' }}
+        uses: actions/checkout@v3
+
+      - name: Run frontend tests
+        run: sudo docker-compose --env-file .env-ci run frontend yarn test

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -188,3 +188,5 @@ export const providers: any[] = [
     bootstrap: [AppComponent],
 })
 export class AppModule {}
+
+// don't merge me!


### PR DESCRIPTION
Instead of not running test actions at all when relevant files are unchanged, run the actions but skip the actual tests. This allows required checks to succees if no relevant changes were detected.