### PR TITLE
Bugfix/compare queries

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -53,17 +53,18 @@ import { SharedModule } from './shared/shared.module';
 import { TagOverviewComponent } from './tag/tag-overview/tag-overview.component';
 import { WordModelsComponent } from './word-models/word-models.component';
 import { WordModelsModule } from './word-models/word-models.module';
+import { forwardLegacyParamsGuard } from './forward-legacy-params.guard';
 
 export const appRoutes: Routes = [
     {
         path: 'search/:corpus',
         component: SearchComponent,
-        canActivate: [CorpusGuard],
+        canActivate: [CorpusGuard, forwardLegacyParamsGuard],
     },
     {
         path: 'word-models/:corpus',
         component: WordModelsComponent,
-        canActivate: [CorpusGuard],
+        canActivate: [CorpusGuard, forwardLegacyParamsGuard],
     },
     {
         path: 'info/:corpus',

--- a/frontend/src/app/forward-legacy-params.guard.spec.ts
+++ b/frontend/src/app/forward-legacy-params.guard.spec.ts
@@ -1,17 +1,42 @@
 import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
+import { Router, RouterModule} from '@angular/router';
 
 import { forwardLegacyParamsGuard } from './forward-legacy-params.guard';
+import { Component } from '@angular/core';
+
+@Component({
+    template: '<p>Hello world!</p>',
+})
+class TestComponent {}
 
 describe('forwardLegacyParamsGuard', () => {
-    const executeGuard: CanActivateFn = (...guardParameters) =>
-        TestBed.runInInjectionContext(() => forwardLegacyParamsGuard(...guardParameters));
+    let router: Router;
+    const legacyUrl = '/search/my-corpus?query=test&compareTerm=test&compareTerm=testing&compareTerm=tester';
+    const targetUrl = '/search/my-corpus?query=test&compareTerms=testing,tester';
 
     beforeEach(() => {
-        TestBed.configureTestingModule({});
+        TestBed.configureTestingModule({
+            imports: [
+                RouterModule.forRoot([
+                    {
+                        path: 'search/:corpus',
+                        component: TestComponent,
+                        canActivate: [forwardLegacyParamsGuard],
+                    }
+                ])
+            ],
+            declarations: [TestComponent],
+        });
+        router = TestBed.inject(Router);
     });
 
-    it('should be created', () => {
-        expect(executeGuard).toBeTruthy();
+    it('should activate valid routes', async () => {
+        await router.navigateByUrl(targetUrl);
+        expect(router.url).toBe(targetUrl)
+    });
+
+    it('should forward legacy parameters', async () => {
+        await router.navigateByUrl(legacyUrl);
+        expect(router.url).toBe(targetUrl);
     });
 });

--- a/frontend/src/app/forward-legacy-params.guard.spec.ts
+++ b/frontend/src/app/forward-legacy-params.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { forwardLegacyParamsGuard } from './forward-legacy-params.guard';
+
+describe('forwardLegacyParamsGuard', () => {
+    const executeGuard: CanActivateFn = (...guardParameters) =>
+        TestBed.runInInjectionContext(() => forwardLegacyParamsGuard(...guardParameters));
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+    });
+
+    it('should be created', () => {
+        expect(executeGuard).toBeTruthy();
+    });
+});

--- a/frontend/src/app/forward-legacy-params.guard.ts
+++ b/frontend/src/app/forward-legacy-params.guard.ts
@@ -1,0 +1,63 @@
+import {
+    ActivatedRouteSnapshot, CanActivateFn, createUrlTreeFromSnapshot, Params,
+    RouterStateSnapshot
+} from '@angular/router';
+import * as _ from 'lodash';
+import { COMPARE_TERMS_KEY, DELIMITER } from './models/compared-queries';
+
+const LEGACY_COMPARE_TERMS_PARAM = 'compareTerm';
+
+/**
+ * Forwards URLs that include outdated query parameters.
+ *
+ * This forwards URLs with the outdated `compareTerm` parameter. (May be expanded with
+ * other parameters in the future.) Allows old links/bookmarks to keep functioning.
+ *
+ * For example:
+ * `?query=a&compareTerm=a&compareTerm=b&compareTerm=c`
+ * will be redirected to
+ * `?query=a&compareTerms=b,c`
+ */
+export const forwardLegacyParamsGuard: CanActivateFn = (
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+) => {
+    if (hasLegacyParams(route)) {
+        const url = createUrlTreeFromSnapshot(route, ['.']);
+        // include updated query parameters
+        url.queryParams = updatedCompareTermsParams(route);
+        // preserve fragment
+        url.fragment = route.fragment;
+        return url;
+    }
+    return true;
+};
+
+const hasLegacyParams = (route: ActivatedRouteSnapshot): boolean => {
+    return route.queryParamMap.has(LEGACY_COMPARE_TERMS_PARAM);
+}
+
+/**
+ * Returns updated version of the query parameters in a URL.
+ *
+ * Replaces legacy `compareTerm` with `compareTerms` parameter. Returns the Params object
+ * with updated values.
+ */
+const updatedCompareTermsParams = (route: ActivatedRouteSnapshot): Params => {
+    const comparedTerms = legacyComparedTerms(route);
+    const params = _.omit(route.queryParams, [LEGACY_COMPARE_TERMS_PARAM]);
+    params[COMPARE_TERMS_KEY] = comparedTerms.join(DELIMITER);
+    return params;
+}
+
+/** The compared terms in a URL in legacy format
+ *
+ * Example of legacy parameters: `?query=a&compareTerm=a&compareTerm=b&compareTerm=c`
+ *
+ * This would return `['b', 'c']` as the compared terms.
+ */
+const legacyComparedTerms = (route: ActivatedRouteSnapshot): string[] => {
+    const query = route.queryParamMap.get('query');
+    const allTerms = route.queryParamMap.getAll(LEGACY_COMPARE_TERMS_PARAM);
+    return _.without(allTerms, query);
+}

--- a/frontend/src/app/models/compared-queries.spec.ts
+++ b/frontend/src/app/models/compared-queries.spec.ts
@@ -81,4 +81,14 @@ fdescribe('ComparedQueries', () => {
         expect(query.state$.value.queryText).toEqual('different test');
         expect(compared.state$.value).toEqual({primary: 'different test', compare: ['test', 'test2']});
     });
+
+    it('should not reset the query when destroyed', () => {
+        store.paramUpdates$.next({
+            query: 'test',
+            compareTerms: 'test2,test3,test4'
+        });
+
+        compared.complete();
+        expect(store.currentParams()).toEqual({ query: 'test' });
+    });
 });

--- a/frontend/src/app/models/compared-queries.spec.ts
+++ b/frontend/src/app/models/compared-queries.spec.ts
@@ -1,0 +1,11 @@
+import { SimpleStore } from '../store/simple-store';
+import { ComparedQueries } from './compared-queries';
+
+describe('ComparedQueries', () => {
+    it('should create', () => {
+        const store = new SimpleStore();
+        const model = new ComparedQueries(store);
+        expect(model).toBeTruthy();
+        expect(model.state$.value).toEqual({ queries: [] });
+    });
+});

--- a/frontend/src/app/models/compared-queries.spec.ts
+++ b/frontend/src/app/models/compared-queries.spec.ts
@@ -27,14 +27,16 @@ fdescribe('ComparedQueries', () => {
         expect(compared.state$.value).toEqual({ primary: undefined, compare: [] });
     });
 
-    it('should ignore overlap with the query text', () => {
+    it('should clean overlapping queries', () => {
         compared.setParams({ primary: undefined, compare: [ 'test', 'test2'] });
-
-        query.setParams({ searchFields: [mockField2] });
-        expect(compared.state$.value).toEqual({ primary: undefined, compare: ['test', 'test2'] });
 
         query.setQueryText('test');
         expect(compared.state$.value).toEqual({ primary: 'test', compare: ['test2'] });
+        expect(store.currentParams()['compareTerms']).toBe('test2');
+
+        compared.setParams({ compare: ['test2', 'test3', 'test2']});
+        expect(compared.state$.value).toEqual({ primary: 'test', compare: ['test2', 'test3'] });
+        expect(store.currentParams()['compareTerms']).toBe('test2,test3');
     });
 
     it('should have all queries as an observable', () => {
@@ -78,14 +80,5 @@ fdescribe('ComparedQueries', () => {
         // compared queries are reset when query text changes
         expect(query.state$.value.queryText).toEqual('different test');
         expect(compared.state$.value).toEqual({primary: 'different test', compare: ['test', 'test2']});
-    });
-
-    it('should encode stored values', () => {
-        compared.setParams({
-            compare: ['test testing','test']
-        });
-        expect(store.currentParams()).toEqual({
-            compareTerms: 'test%20testing,test'
-        });
     });
 });

--- a/frontend/src/app/models/compared-queries.spec.ts
+++ b/frontend/src/app/models/compared-queries.spec.ts
@@ -1,11 +1,55 @@
+import { mockCorpus, mockField2 } from '../../mock-data/corpus';
 import { SimpleStore } from '../store/simple-store';
 import { ComparedQueries } from './compared-queries';
+import { QueryModel } from './query';
 
 describe('ComparedQueries', () => {
+    let store: SimpleStore;
+    let query: QueryModel;
+    let compared: ComparedQueries;
+
+    beforeEach(() => {
+        store = new SimpleStore();
+        query = new QueryModel(mockCorpus, store);
+        compared = new ComparedQueries(store, query);
+    });
+
     it('should create', () => {
-        const store = new SimpleStore();
-        const model = new ComparedQueries(store);
-        expect(model).toBeTruthy();
-        expect(model.state$.value).toEqual({ queries: [] });
+        expect(compared).toBeTruthy();
+        expect(compared.state$.value).toEqual({ queries: [] });
+    });
+
+    it('should update', () => {
+        compared.setParams({ queries: ['test', 'test2'] });
+        expect(compared.state$.value).toEqual({ queries: ['test', 'test2'] });
+
+        compared.reset();
+        expect(compared.state$.value).toEqual({ queries: [] });
+    });
+
+    it('should reset when the query text changes', () => {
+        compared.setParams({ queries: [ 'test', 'test2'] });
+
+        query.setParams({ searchFields: [mockField2] });
+        expect(compared.state$.value).toEqual({ queries: ['test', 'test2'] });
+
+        query.setQueryText('test');
+        expect(compared.state$.value).toEqual({ queries: [] });
+    });
+
+    fit('should have all queries as an observable', () => {
+        let latestValue: string[];
+        compared.allQueries$.subscribe(value => latestValue = value);
+
+        expect(latestValue).toEqual([undefined]);
+
+        compared.setParams({queries: ['test2']});
+        expect(latestValue).toEqual([undefined, 'test2']);
+
+        query.setQueryText('test');
+        expect(latestValue).toEqual(['test']);
+
+        compared.setParams({queries: ['test2']});
+        expect(latestValue).toEqual(['test', 'test2']);
     });
 });

--- a/frontend/src/app/models/compared-queries.spec.ts
+++ b/frontend/src/app/models/compared-queries.spec.ts
@@ -37,7 +37,7 @@ describe('ComparedQueries', () => {
         expect(compared.state$.value).toEqual({ queries: [] });
     });
 
-    fit('should have all queries as an observable', () => {
+    it('should have all queries as an observable', () => {
         let latestValue: string[];
         compared.allQueries$.subscribe(value => latestValue = value);
 
@@ -51,5 +51,35 @@ describe('ComparedQueries', () => {
 
         compared.setParams({queries: ['test2']});
         expect(latestValue).toEqual(['test', 'test2']);
+    });
+
+    it('it should initialise from parameters', () => {
+        store = new SimpleStore();
+        store.paramUpdates$.next({
+            query: 'test',
+            compareTerms: 'test2,test3,test4'
+        });
+
+        query = new QueryModel(mockCorpus, store);
+        compared = new ComparedQueries(store, query);
+
+        expect(query.state$.value.queryText).toEqual('test');
+        expect(compared.state$.value).toEqual({queries: ['test2', 'test3', 'test4']});
+
+    });
+
+    it('should set from parameters', () => {
+        store.paramUpdates$.next({
+            compareTerms: 'test,test2'
+        });
+        expect(compared.state$.value).toEqual({queries: ['test', 'test2']});
+
+
+        store.paramUpdates$.next({
+            query: 'different test',
+        });
+        // compared queries are reset when query text changes
+        expect(query.state$.value.queryText).toEqual('different test');
+        expect(compared.state$.value).toEqual({queries: []});
     });
 });

--- a/frontend/src/app/models/compared-queries.spec.ts
+++ b/frontend/src/app/models/compared-queries.spec.ts
@@ -1,9 +1,9 @@
-import { mockCorpus, mockField2 } from '../../mock-data/corpus';
+import { mockCorpus } from '../../mock-data/corpus';
 import { SimpleStore } from '../store/simple-store';
 import { ComparedQueries } from './compared-queries';
 import { QueryModel } from './query';
 
-fdescribe('ComparedQueries', () => {
+describe('ComparedQueries', () => {
     let store: SimpleStore;
     let query: QueryModel;
     let compared: ComparedQueries;

--- a/frontend/src/app/models/compared-queries.ts
+++ b/frontend/src/app/models/compared-queries.ts
@@ -1,0 +1,41 @@
+import { Params } from '@angular/router';
+import { StoreSync } from '../store/store-sync';
+import * as _ from 'lodash';
+
+interface CompareQueryState {
+    queries: string[];
+}
+
+const COMPARE_TERMS_KEY = 'compareTerms';
+const DELIMITER = ',';
+
+export class ComparedQueries extends StoreSync<CompareQueryState> {
+    protected keysInStore = [COMPARE_TERMS_KEY];
+
+    constructor(store) {
+        super(store);
+        this.connectToStore();
+    }
+
+    reset() {
+        this.setParams({ queries: [] });
+    }
+
+    protected storeToState(params: Params): CompareQueryState {
+        const value = _.get(params, COMPARE_TERMS_KEY, '');
+        if (value.length) {
+            return { queries: value.split(DELIMITER) };
+        } else {
+            return { queries: [] };
+        }
+    }
+
+    protected stateToStore(state: CompareQueryState): Params {
+        if (!state.queries.length) {
+            const value = state.queries.join(DELIMITER);
+            return { [COMPARE_TERMS_KEY]: value };
+        } else {
+            return { [COMPARE_TERMS_KEY]: null };
+        }
+    }
+}

--- a/frontend/src/app/models/compared-queries.ts
+++ b/frontend/src/app/models/compared-queries.ts
@@ -11,8 +11,8 @@ interface CompareQueryState {
     compare: string[];
 }
 
-const COMPARE_TERMS_KEY = 'compareTerms';
-const DELIMITER = ',';
+export const COMPARE_TERMS_KEY = 'compareTerms';
+export const DELIMITER = ',';
 
 export class ComparedQueries extends StoreSync<CompareQueryState> {
     /** all queries, including the primary query text */

--- a/frontend/src/app/models/compared-queries.ts
+++ b/frontend/src/app/models/compared-queries.ts
@@ -61,6 +61,10 @@ export class ComparedQueries extends StoreSync<CompareQueryState> {
         return {...query, [COMPARE_TERMS_KEY]: compareTerms};
     }
 
+    protected storeOnComplete(): Params {
+        return { [COMPARE_TERMS_KEY]: null };
+    }
+
     private cleanStoredState() {
         this.store.params$.pipe(
             takeUntil(this.complete$),

--- a/frontend/src/app/models/query.ts
+++ b/frontend/src/app/models/query.ts
@@ -6,7 +6,7 @@ import { EsQuery } from '../models';
 import { combineSearchClauseAndFilters,  } from '../utils/es-query';
 import {
     omitNullParameters, queryFiltersToParams,
-    queryFromParams, searchFieldsFromParams
+    queryFromParams, queryToParams, searchFieldsFromParams
 } from '../utils/params';
 import { isFieldFilter, SearchFilter } from './field-filter';
 import { isTagFilter, TagFilter } from './tag-filter';
@@ -187,7 +187,7 @@ export class QueryModel extends StoreSync<QueryState> {
     }
 
     protected stateToStore(state: QueryState): Params {
-        const queryTextParams =  { query: state.queryText || null };
+        const queryTextParams =  queryToParams(state.queryText);
         const searchFieldsParams = { fields: state.searchFields?.map(f => f.name).join(',') || null};
 
         return {

--- a/frontend/src/app/store/simple-store.ts
+++ b/frontend/src/app/store/simple-store.ts
@@ -18,7 +18,7 @@ export class SimpleStore implements Store {
         this.paramUpdates$.pipe(
             scan(mergeParams),
             map(omitNullParameters),
-            map(obj => _.mapValues(obj, _.toString))
+            map(obj => _.mapValues(obj, _.toString)),
         ).subscribe(params =>
             this.params$.next(params)
         );

--- a/frontend/src/app/utils/params.ts
+++ b/frontend/src/app/utils/params.ts
@@ -25,6 +25,10 @@ export const mergeAllParams = (values: Params[]): Params =>
 export const queryFromParams = (params: Params): string =>
     params['query'];
 
+export const queryToParams = (queryText: string): Params => ({
+     query: queryText || null
+});
+
 export const searchFieldsFromParams = (params: Params, corpus: Corpus): CorpusField[] => {
     if (params['fields']) {
         const fieldNames = params['fields'].split(',');

--- a/frontend/src/app/visualization/barchart/barchart-options.component.html
+++ b/frontend/src/app/visualization/barchart/barchart-options.component.html
@@ -59,7 +59,6 @@
     </div>
 
     <div class="control" *ngIf="showEdit">
-        <ia-term-comparison-editor [initialValue]="queries"
-            (queriesChanged)="updateQueries($event)" (clearQueries)="signalClearQueries()"></ia-term-comparison-editor>
+        <ia-term-comparison-editor (queriesChanged)="updateQueries($event)" (clearQueries)="signalClearQueries()"></ia-term-comparison-editor>
     </div>
 </form>

--- a/frontend/src/app/visualization/barchart/barchart-options.component.html
+++ b/frontend/src/app/visualization/barchart/barchart-options.component.html
@@ -59,6 +59,6 @@
     </div>
 
     <div class="control" *ngIf="showEdit">
-        <ia-term-comparison-editor (queriesChanged)="updateQueries($event)" (clearQueries)="signalClearQueries()"></ia-term-comparison-editor>
+        <ia-term-comparison-editor (queriesChanged)="updateQueries($event)" />
     </div>
 </form>

--- a/frontend/src/app/visualization/barchart/barchart-options.component.html
+++ b/frontend/src/app/visualization/barchart/barchart-options.component.html
@@ -59,6 +59,6 @@
     </div>
 
     <div class="control" *ngIf="showEdit">
-        <ia-term-comparison-editor (queriesChanged)="updateQueries($event)" />
+        <ia-term-comparison-editor />
     </div>
 </form>

--- a/frontend/src/app/visualization/barchart/barchart-options.component.ts
+++ b/frontend/src/app/visualization/barchart/barchart-options.component.ts
@@ -38,7 +38,7 @@ export class BarchartOptionsComponent
     constructor(
         route: ActivatedRoute,
         router: Router,
-        paramService: ParamService
+        paramService: ParamService,
     ) {
         super(route, router, paramService);
     }
@@ -86,6 +86,9 @@ export class BarchartOptionsComponent
     teardown() {}
 
     setStateFromParams(params: ParamMap) {
+        // show term comparison editor if there are terms in the route ;
+        // don't hide the editor if already displayed
+        this.showEdit = this.showEdit || params.has('compareTerms');
         if (params.has('normalize')) {
             this.currentNormalizer = params.get('normalize') as Normalizer;
         } else {
@@ -102,7 +105,7 @@ export class BarchartOptionsComponent
 
     updateQueries(queries: string[]) {
         this.queries = queries;
-        if (this.queries.length === 1 && this.queries[0] === this.queryText) {
+        if (this.queries.length === 0) {
             this.showEdit = false;
         }
         this.queriesChanged.emit(this.queries);
@@ -111,7 +114,6 @@ export class BarchartOptionsComponent
     signalClearQueries() {
         this.queries = [this.queryText];
         this.showEdit = false;
-        this.setParams({ visualizeTerm: null });
         this.clearQueries.emit();
     }
 }

--- a/frontend/src/app/visualization/barchart/barchart-options.component.ts
+++ b/frontend/src/app/visualization/barchart/barchart-options.component.ts
@@ -43,10 +43,6 @@ export class BarchartOptionsComponent
         super(route, router, paramService);
     }
 
-    get showTermFrequency(): boolean {
-        return _.some(this.queries);
-    }
-
     ngOnChanges(changes: SimpleChanges): void {
         if (changes.queryText) {
             if (this.queryText) {

--- a/frontend/src/app/visualization/barchart/barchart-options.component.ts
+++ b/frontend/src/app/visualization/barchart/barchart-options.component.ts
@@ -101,7 +101,7 @@ export class BarchartOptionsComponent
 
     updateQueries(queries: string[]) {
         this.queries = queries;
-        if (this.queries.length === 0) {
+        if (_.isEqual(this.queries, [this.queryText])) {
             this.showEdit = false;
         }
         this.queriesChanged.emit(this.queries);
@@ -111,5 +111,6 @@ export class BarchartOptionsComponent
         this.queries = [this.queryText];
         this.showEdit = false;
         this.clearQueries.emit();
+        this.queriesChanged.emit(this.queries);
     }
 }

--- a/frontend/src/app/visualization/barchart/barchart-options.component.ts
+++ b/frontend/src/app/visualization/barchart/barchart-options.component.ts
@@ -23,7 +23,6 @@ export class BarchartOptionsComponent
 
     @Output() chartParameters = new EventEmitter<ChartParameters>();
     @Output() queriesChanged = new EventEmitter<string[]>();
-    @Output() clearQueries = new EventEmitter<void>();
 
     currentNormalizer: Normalizer;
 
@@ -107,10 +106,4 @@ export class BarchartOptionsComponent
         this.queriesChanged.emit(this.queries);
     }
 
-    signalClearQueries() {
-        this.queries = [this.queryText];
-        this.showEdit = false;
-        this.clearQueries.emit();
-        this.queriesChanged.emit(this.queries);
-    }
 }

--- a/frontend/src/app/visualization/barchart/barchart-options.component.ts
+++ b/frontend/src/app/visualization/barchart/barchart-options.component.ts
@@ -28,8 +28,6 @@ export class BarchartOptionsComponent
 
     currentChartType: ChartType = 'bar';
 
-    public queries: string[] = [];
-
     showEdit = false;
 
     nullableParameters = ['normalize'];
@@ -43,14 +41,6 @@ export class BarchartOptionsComponent
     }
 
     ngOnChanges(changes: SimpleChanges): void {
-        if (changes.queryText) {
-            if (this.queryText) {
-                this.queries = [this.queryText];
-            } else {
-                this.queries = [];
-            }
-        }
-
         if (
             changes.showTokenCountOption &&
             changes.showTokenCountOption.currentValue &&
@@ -99,11 +89,10 @@ export class BarchartOptionsComponent
     }
 
     updateQueries(queries: string[]) {
-        this.queries = queries;
-        if (_.isEqual(this.queries, [this.queryText])) {
+        if (_.isEqual(queries, [this.queryText])) {
             this.showEdit = false;
         }
-        this.queriesChanged.emit(this.queries);
+        this.queriesChanged.emit(queries);
     }
 
 }

--- a/frontend/src/app/visualization/barchart/barchart.directive.ts
+++ b/frontend/src/app/visualization/barchart/barchart.directive.ts
@@ -249,13 +249,6 @@ export abstract class BarchartDirective<
         };
     }
 
-    /** Remove any additional queries from the BarchartOptions component.
-     * Only keep the original query */
-    clearAddedQueries() {
-        this.rawData = this.rawData.slice(0, 1);
-        this.prepareChart();
-    }
-
     /** Show a loading spinner and load data for the graph.
      * This function should be called after (potential) changes to parameters.
      */

--- a/frontend/src/app/visualization/barchart/barchart.directive.ts
+++ b/frontend/src/app/visualization/barchart/barchart.directive.ts
@@ -61,8 +61,6 @@ export abstract class BarchartDirective<
     tableHeaders: FreqTableHeaders;
     tableData: any[];
 
-    /** list of query used by each series in te graph */
-    queries: string[] = [];
 
     /** Stores the key that can be used in a DataPoint object
      * to retrieve the y-axis value.
@@ -219,7 +217,6 @@ export abstract class BarchartDirective<
 
     initQueries(): void {
         this.rawData = [this.newSeries(this.queryText)];
-        this.queries = [this.queryText];
     }
 
     /** if a chart is active, clear canvas and reset chart object */
@@ -256,7 +253,6 @@ export abstract class BarchartDirective<
      * Only keep the original query */
     clearAddedQueries() {
         this.rawData = this.rawData.slice(0, 1);
-        this.queries = [this.queryText];
         this.prepareChart();
     }
 

--- a/frontend/src/app/visualization/barchart/histogram.component.html
+++ b/frontend/src/app/visualization/barchart/histogram.component.html
@@ -9,7 +9,7 @@
         [queryText]="queryText" [showTokenCountOption]="totalTokenCountAvailable" [isLoading]="isLoading"
         [frequencyMeasure]="frequencyMeasure"
         [freqTable]="asTable" [histogram]="true"
-        (chartParameters)="onOptionChange($event)" (queriesChanged)="updateQueries($event)"  (clearQueries)="clearAddedQueries()">
+        (chartParameters)="onOptionChange($event)" (queriesChanged)="updateQueries($event)">
     </ia-barchart-options>
 </div>
 

--- a/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.html
+++ b/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.html
@@ -6,7 +6,7 @@
                     <p-chips name="queries" [(ngModel)]="queries" separator="," addOnBlur="true"></p-chips>
                 </div>
                 <div class="control">
-                    <button class="button is-primary" (click)="confirmQueries()" [disabled]="disableConfirm">
+                    <button class="button is-primary" (click)="confirmQueries()" [disabled]="!valid(queries)">
                         <span class="icon">
                             <fa-icon [icon]="formIcons.confirm" aria-hidden="true"></fa-icon>
                         </span>
@@ -15,8 +15,8 @@
                 </div>
             </div>
         </div>
-        <div *ngIf="showReset" class="control">
-            <button class="button" (click)="signalClearQueries()">
+        <div *ngIf="showReset$ | async" class="control">
+            <button class="button" (click)="reset()">
                 <span class="icon">
                     <fa-icon [icon]="formIcons.reset" aria-hidden="true"></fa-icon>
                 </span>

--- a/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
+++ b/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
@@ -14,8 +14,6 @@ import { map } from 'rxjs/operators';
 export class TermComparisonEditorComponent implements OnDestroy {
     @Input() termLimit = 10;
 
-    @Output() queriesChanged = new EventEmitter<string[]>();
-
     comparedQueries: ComparedQueries;
 
     queries: string[] = [];
@@ -28,9 +26,8 @@ export class TermComparisonEditorComponent implements OnDestroy {
     ) {
         this.comparedQueries = new ComparedQueries(this.routerStoreService);
 
-        // note that state$ and allQueries$ are completed by this component's ngOnDestroy
+        // note that state$ is completed by this component's ngOnDestroy
         this.comparedQueries.state$.subscribe(state => this.queries = state.compare);
-        this.comparedQueries.allQueries$.subscribe(this.queriesChanged);
 
         this.showReset$ = this.comparedQueries.state$.pipe(
             map(state => !_.isEmpty(state.compare))

--- a/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
+++ b/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
@@ -15,7 +15,6 @@ export class TermComparisonEditorComponent implements OnDestroy {
     @Input() termLimit = 10;
 
     @Output() queriesChanged = new EventEmitter<string[]>();
-    @Output() clearQueries = new EventEmitter<void>();
 
     comparedQueries: ComparedQueries;
 
@@ -53,6 +52,5 @@ export class TermComparisonEditorComponent implements OnDestroy {
 
     reset() {
         this.comparedQueries.reset();
-        this.clearQueries.emit();
     }
 }

--- a/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
+++ b/frontend/src/app/visualization/barchart/term-comparison-editor/term-comparison-editor.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { Component, Input, OnDestroy } from '@angular/core';
 import { formIcons } from '../../../shared/icons';
 import { RouterStoreService } from '../../../store/router-store.service';
 import { ComparedQueries } from '../../../models/compared-queries';
@@ -16,7 +16,7 @@ export class TermComparisonEditorComponent implements OnDestroy {
 
     comparedQueries: ComparedQueries;
 
-    queries: string[] = [];
+    queries: string[] = []; // queries in user input (not necessarily submitted)
     showReset$: Observable<boolean>;
 
     formIcons = formIcons;

--- a/frontend/src/app/visualization/barchart/timeline.component.html
+++ b/frontend/src/app/visualization/barchart/timeline.component.html
@@ -13,7 +13,7 @@
         [queryText]="queryText" [showTokenCountOption]="totalTokenCountAvailable" [isLoading]="isLoading"
         [freqTable]="asTable" [histogram]="false"
         [frequencyMeasure]="frequencyMeasure"
-        (chartParameters)="onOptionChange($event)" (queriesChanged)="updateQueries($event)" (clearQueries)="clearAddedQueries()">
+        (chartParameters)="onOptionChange($event)" (queriesChanged)="updateQueries($event)">
     </ia-barchart-options>
 </div>
 

--- a/frontend/src/app/word-models/word-models.component.html
+++ b/frontend/src/app/word-models/word-models.component.html
@@ -55,7 +55,7 @@
                             </ia-related-words>
 
                             <ia-word-similarity *ngIf="tab === 'wordsimilarity'"
-                                [corpus]="corpus" [queryText]="activeQuery"
+                                [corpus]="corpus"
                                 [asTable]="asTable" [palette]="palette"
                                 (wordSimilarityError)="setErrorMessage($event)">
                             </ia-word-similarity>

--- a/frontend/src/app/word-models/word-similarity/word-similarity.component.html
+++ b/frontend/src/app/word-models/word-similarity/word-similarity.component.html
@@ -2,8 +2,7 @@
     <div class="control">
         <label class="label">Enter one or more terms to compare to "{{queryText}}":</label>
         <ia-term-comparison-editor
-            [termLimit]="comparisonTermLimit"
-            (queriesChanged)="updateComparisonTerms($event)">
+            [termLimit]="comparisonTermLimit">
         </ia-term-comparison-editor>
     </div>
 </div>

--- a/frontend/src/app/word-models/word-similarity/word-similarity.component.html
+++ b/frontend/src/app/word-models/word-similarity/word-similarity.component.html
@@ -3,7 +3,7 @@
         <label class="label">Enter one or more terms to compare to "{{queryText}}":</label>
         <ia-term-comparison-editor
             [termLimit]="comparisonTermLimit"
-            (queriesChanged)="updateComparisonTerms($event)" (clearQueries)="updateComparisonTerms()">
+            (queriesChanged)="updateComparisonTerms($event)">
         </ia-term-comparison-editor>
     </div>
 </div>

--- a/frontend/src/app/word-models/word-similarity/word-similarity.component.ts
+++ b/frontend/src/app/word-models/word-similarity/word-similarity.component.ts
@@ -56,7 +56,12 @@ export class WordSimilarityComponent implements OnChanges {
 
     updateComparisonTerms(terms: string[] = []) {
         this.comparisonTerms = terms;
-        this.getData();
+
+        if (terms.length > 1) {
+            this.getData();
+        } else {
+            this.clearData();
+        }
     }
 
     getData(): void {
@@ -74,6 +79,12 @@ export class WordSimilarityComponent implements OnChanges {
         )
             .then(this.onDataLoaded.bind(this))
             .catch(this.onError.bind(this));
+    }
+
+    clearData() {
+        this.results = undefined;
+        this.timeIntervals = undefined;
+        this.data = undefined;
     }
 
     getTimePoints(points: WordSimilarity[]) {

--- a/frontend/src/app/word-models/word-similarity/word-similarity.component.ts
+++ b/frontend/src/app/word-models/word-similarity/word-similarity.component.ts
@@ -1,19 +1,20 @@
-import { Component, EventEmitter, HostBinding, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, HostBinding, Input, OnChanges, OnDestroy, Output, SimpleChanges } from '@angular/core';
 import * as _ from 'lodash';
 import { BehaviorSubject } from 'rxjs';
 import { showLoading } from '../../utils/utils';
 import { Corpus, WordSimilarity } from '../../models';
 import { WordmodelsService } from '../../services';
+import { RouterStoreService } from '../../store/router-store.service';
+import { ComparedQueries } from '../../models/compared-queries';
 
 @Component({
     selector: 'ia-word-similarity',
     templateUrl: './word-similarity.component.html',
     styleUrls: ['./word-similarity.component.scss'],
 })
-export class WordSimilarityComponent implements OnChanges {
+export class WordSimilarityComponent implements OnChanges, OnDestroy {
     @HostBinding('style.display') display = 'block'; // needed for loading spinner positioning
 
-    @Input() queryText: string;
     @Input() corpus: Corpus;
     @Input() asTable: boolean;
     @Input() palette: string[];
@@ -23,18 +24,32 @@ export class WordSimilarityComponent implements OnChanges {
     isLoading$ = new BehaviorSubject<boolean>(false);
 
     comparisonTermLimit = Infinity;
-    comparisonTerms: string[] = [];
+
+    comparedQueries: ComparedQueries;
 
     results: WordSimilarity[][];
     timeIntervals: string[];
 
     data: WordSimilarity[];
 
-    constructor(private wordModelsService: WordmodelsService) {}
+    constructor(
+        private wordModelsService: WordmodelsService,
+        private routerStoreService: RouterStoreService) {
+            this.comparedQueries = new ComparedQueries(this.routerStoreService);
+            this.comparedQueries.allQueries$.subscribe(this.onTermsUpdate.bind(this))
+        }
 
     @HostBinding('class.is-loading')
     get isLoading() {
         return this.isLoading$.value;
+    }
+
+    get queryText(): string {
+        return this.comparedQueries.state$.value.primary;
+    }
+
+    get comparisonTerms(): string[] {
+        return this.comparedQueries.state$.value.compare;
     }
 
     get tableFileName(): string {
@@ -43,7 +58,7 @@ export class WordSimilarityComponent implements OnChanges {
 
     ngOnChanges(changes: SimpleChanges): void {
         if (
-            (changes.queryText || changes.corpus) &&
+            (changes.corpus) &&
             this.comparisonTerms.length
         ) {
             this.getData();
@@ -54,10 +69,12 @@ export class WordSimilarityComponent implements OnChanges {
         }
     }
 
-    updateComparisonTerms(terms: string[] = []) {
-        this.comparisonTerms = terms;
+    ngOnDestroy(): void {
+        this.comparedQueries.complete();
+    }
 
-        if (terms.length > 1) {
+    onTermsUpdate() {
+        if (this.corpus && this.comparisonTerms.length >= 1) {
             this.getData();
         } else {
             this.clearData();


### PR DESCRIPTION
This is a refactor of the term comparison editor to fix several issues:

resolves https://github.com/UUDigitalHumanitieslab/I-analyzer/issues/1564
resolves https://github.com/UUDigitalHumanitieslab/I-analyzer/issues/1563 
resolves https://github.com/UUDigitalHumanitieslab/I-analyzer/issues/1562
resolves https://github.com/UUDigitalHumanitieslab/I-analyzer/issues/1561

For barcharts, the comparison editor now only shows the additional queries, not the main one.

I've changed the format for query parameters in the route. For example, https://ianalyzer.hum.uu.nl/search/parliament-netherlands?query=minister&tab=visualizations&visualize=resultscount&visualizedField=date&compareTerm=minister&compareTerm=premier&compareTerm=staatssecretaris would now be https://ianalyzer.hum.uu.nl/search/parliament-netherlands?query=minister&tab=visualizations&visualize=resultscount&visualizedField=date&compareTerms=premier,staatssecretaris . This update includes a `forwardLegacyParamsGuard` which will redirect old routes, so this isn't a breaking change for users.

Internally, it switches the term comparison from the `ParamSync` to the `StoreSync` class.