### PR TITLE
Query in download CSV not rendered #1623 

### DIFF
--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -135,7 +135,9 @@ class JSONDefinitionField(serializers.Field):
         return instance
 
     def to_representation(self, value: Corpus) -> Dict:
-        return export_json_corpus(value)
+        representation = export_json_corpus(value)
+        representation["$schema"] = "http://example.com/schema/corpus.json"
+        return representation
 
     def to_internal_value(self, data: Dict) -> Dict:
         return import_json_corpus(data)
@@ -146,7 +148,7 @@ class CorpusJSONDefinitionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Corpus
-        fields = ['id', 'active', 'definition']
+        fields = ['id', 'active', 'definition', 'schema_url']
         read_only_fields = ['id']
 
     def create(self, validated_data: Dict):

--- a/backend/download/convert_csv.py
+++ b/backend/download/convert_csv.py
@@ -69,8 +69,10 @@ def format_wide_format_column_name(column):
         return '{} ({})'.format(quantity, query)
 
 def set_long_wide_format(df, format, query_term=None):
+
     # check if wide format conversion is needed
     # i.e. specified format is wide, and the results include multiple queries (i.e. there is a query column)
+
     if format == 'wide' and df.columns[0] == 'Query':
         query_column = df.columns[0]
         field_column = df.columns[1]  # the field values are being compared on

--- a/backend/download/convert_csv.py
+++ b/backend/download/convert_csv.py
@@ -69,10 +69,8 @@ def format_wide_format_column_name(column):
         return '{} ({})'.format(quantity, query)
 
 def set_long_wide_format(df, format, query_term=None):
-
     # check if wide format conversion is needed
     # i.e. specified format is wide, and the results include multiple queries (i.e. there is a query column)
-
     if format == 'wide' and df.columns[0] == 'Query':
         query_column = df.columns[0]
         field_column = df.columns[1]  # the field values are being compared on


### PR DESCRIPTION
Fix query text rendering in CSV downloads by updating write_output to include the query in headers and data, and modifying set_long_wide_format to handle queries in wide format, resolving issue #1623.