### PR TITLE
Feature/corpus doc order

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,6 +59,26 @@
                 "/*": "*",
                 "/./~/*": "${webRoot}/node_modules/*"
             }
+        },
+        {
+            "name": "celery",
+            "type": "debugpy",
+            "request": "launch",
+            "cwd": "${workspaceFolder}/backend",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/backend"
+            },
+            "module": "celery",
+            "console": "integratedTerminal",
+            "args": [
+                "-A",
+                "ianalyzer.celery",
+                "worker",
+                "--pool=solo",
+                "--concurrency=1",
+                "--events",
+                "--loglevel=info"
+            ]
         }
     ],
     "inputs": [

--- a/backend/addcorpus/models.py
+++ b/backend/addcorpus/models.py
@@ -431,11 +431,12 @@ class Field(models.Model):
                     e
                 ])
 
+
 class CorpusDocumentationPage(models.Model):
     class PageType(models.TextChoices):
         GENERAL = ('general', 'General information')
         CITATION = ('citation', 'Citation')
-        LICENSE = ('license', 'Licence')
+        LICENSE = ('license', 'License')
         TERMS_OF_SERVICE = ('terms_of_service', 'Terms of service')
         WORDMODELS = ('wordmodels', 'Word models')
 
@@ -454,6 +455,9 @@ class CorpusDocumentationPage(models.Model):
     content = models.TextField(
         help_text='markdown contents of the documentation'
     )
+
+    def __str__(self):
+        return f'{self.corpus_configuration.corpus.name} - {self.type}'
 
     class Meta:
         constraints = [

--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -19,9 +19,14 @@ def test_no_corpora(db, settings, admin_client):
 def test_corpus_documentation_view(admin_client, basic_mock_corpus, settings):
     response = admin_client.get(f'/api/corpus/documentation/{basic_mock_corpus}/')
     assert response.status_code == 200
+    pages = response.data
+
+    # check that the pages are sorted in canonical order
+    page_types = [page['type'] for page in pages]
+    assert page_types == ['General information', 'Citation', 'License']
 
     # should contain citation guidelines
-    citation_page = next(page for page in response.data if page['type'] == 'Citation')
+    citation_page = next(page for page in pages if page['type'] == 'Citation')
 
     # check that the page template is rendered with context
     content = citation_page['content']

--- a/backend/corpora_test/basic/license/license.md
+++ b/backend/corpora_test/basic/license/license.md
@@ -1,0 +1,1 @@
+Do whatever you please.

--- a/backend/corpora_test/basic/mock_csv_corpus.py
+++ b/backend/corpora_test/basic/mock_csv_corpus.py
@@ -25,6 +25,8 @@ class MockCSVCorpus(CSVCorpusDefinition):
     max_date = datetime.datetime(year=2022, month=12, day=31)
     data_directory = os.path.join(here, 'source_data')
     citation_page = 'citation.md'
+    license_page = 'license.md'
+    description_page = 'mock-csv-corpus.md'
 
     languages = ['en']
     category = 'book'

--- a/frontend/src/app/corpus-definitions/create-definition/create-definition.component.ts
+++ b/frontend/src/app/corpus-definitions/create-definition/create-definition.component.ts
@@ -5,11 +5,12 @@ import { APIEditableCorpus, CorpusDefinition } from '../../models/corpus-definit
 import * as _ from 'lodash';
 import { Router } from '@angular/router';
 import { HttpErrorResponse } from '@angular/common/http';
+import { Subject } from 'rxjs';
 
 @Component({
     selector: 'ia-create-definition',
     templateUrl: './create-definition.component.html',
-    styleUrls: ['./create-definition.component.scss']
+    styleUrls: ['./create-definition.component.scss'],
 })
 export class CreateDefinitionComponent {
     actionIcons = actionIcons;
@@ -18,6 +19,8 @@ export class CreateDefinitionComponent {
     corpus: CorpusDefinition;
 
     error: Error;
+
+    reset$ = new Subject<void>();
 
     constructor(private apiService: ApiService, private router: Router) {
         this.corpus = new CorpusDefinition(apiService);
@@ -31,12 +34,15 @@ export class CreateDefinitionComponent {
         this.error = undefined;
         this.corpus.save().subscribe(
             (result: APIEditableCorpus) => {
-                this.router.navigate(['/corpus-definitions', 'edit', result.id]);
+                this.router.navigate([
+                    '/corpus-definitions',
+                    'edit',
+                    result.id,
+                ]);
             },
             (err: HttpErrorResponse) => {
                 this.error = err;
             }
         );
     }
-
 }


### PR DESCRIPTION
Resolves #1607

Takes the choices of the `type` field in the backend as canonical order, to make it easy to extend the types at a later stages.
I realize using `.index()` as key is not the most efficient way to sort, but it's a small amount of pages.
