### PR TITLE
Edit corpus documention in API

### DIFF
--- a/backend/addcorpus/models.py
+++ b/backend/addcorpus/models.py
@@ -473,6 +473,13 @@ class CorpusDocumentationPage(models.Model):
         help_text='markdown contents of the documentation'
     )
 
+    @property
+    def page_index(self):
+        '''Numerical index to determine the order in which pages should be displayed.
+        Based on the order in which `PageType` choices are declared.'''
+        indexed_values = enumerate(__class__.PageType.values)
+        return next((i for (i, value) in indexed_values if value == self.type), None)
+
     def __str__(self):
         return f'{self.corpus_configuration.corpus.name} - {self.type}'
 

--- a/backend/addcorpus/permissions.py
+++ b/backend/addcorpus/permissions.py
@@ -1,5 +1,6 @@
 from rest_framework import permissions
 from rest_framework.exceptions import NotFound
+from rest_framework.request import Request
 from users.models import CustomUser
 from typing import List
 from addcorpus.models import Corpus
@@ -54,3 +55,27 @@ class CorpusAccessPermission(permissions.BasePermission):
 
         # check if the user has access
         return user.has_access(corpus)
+
+
+class IsCurator(permissions.BasePermission):
+    '''
+    The user is permitted to use the corpus definition API.
+    '''
+
+    message = 'You do not have permission to manage corpus definitions'
+
+    def has_permission(self, request: Request, view):
+        return request.user.is_staff
+
+class IsCuratorOrReadOnly(permissions.BasePermission):
+    '''
+    The user is permitted to edit the corpus, or it is a read-only request.
+    '''
+
+    message = 'You do not have permission to edit this corpus'
+
+    def has_permission(self, request: Request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        return request.user.is_staff

--- a/backend/addcorpus/permissions.py
+++ b/backend/addcorpus/permissions.py
@@ -1,8 +1,6 @@
 from rest_framework import permissions
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
-from users.models import CustomUser
-from typing import List
 from addcorpus.models import Corpus
 
 def corpus_name_from_request(request):
@@ -26,19 +24,6 @@ def corpus_name_from_request(request):
     return corpus
 
 
-def filter_user_corpora(corpora: List[Corpus], user: CustomUser) -> List[Corpus]:
-    '''
-    Filter all available corpora to only
-    include the ones the user has access to
-    '''
-
-    return [
-         corpus
-         for corpus in corpora
-         if user.has_access(corpus.name)
-    ]
-
-
 class CanSearchCorpus(permissions.BasePermission):
     message = 'You do not have permission to access this corpus'
 
@@ -49,12 +34,11 @@ class CanSearchCorpus(permissions.BasePermission):
         # check if the corpus exists
         try:
             corpus = Corpus.objects.get(name=corpus_name)
-            assert corpus.active
         except:
             raise NotFound('Corpus does not exist')
 
         # check if the user has access
-        return user.has_access(corpus)
+        return user.can_search(corpus)
 
 
 class IsCurator(permissions.BasePermission):

--- a/backend/addcorpus/permissions.py
+++ b/backend/addcorpus/permissions.py
@@ -39,7 +39,7 @@ def filter_user_corpora(corpora: List[Corpus], user: CustomUser) -> List[Corpus]
     ]
 
 
-class CorpusAccessPermission(permissions.BasePermission):
+class CanSearchCorpus(permissions.BasePermission):
     message = 'You do not have permission to access this corpus'
 
     def has_permission(self, request, view):

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -121,13 +121,29 @@ class DocumentationTemplateField(serializers.CharField):
         return render_documentation_context(content)
 
 
+class CorpusConfigurationField(serializers.SlugRelatedField):
+    '''
+    Serialise a related corpus configuration as the corpus name.
+    '''
+
+    def __init__(self, **kwargs):
+        super().__init__('corpus__name', **kwargs)
+
+    def get_queryset(self):
+        return CorpusConfiguration.objects.all()
+
+    def to_representation(self, value: CorpusConfiguration) -> str:
+        return value.corpus.name
+
+
 class CorpusDocumentationPageSerializer(serializers.ModelSerializer):
     type = PrettyChoiceField(choices = CorpusDocumentationPage.PageType.choices)
     content = DocumentationTemplateField()
+    corpus = CorpusConfigurationField(source='corpus_configuration')
 
     class Meta:
         model = CorpusDocumentationPage
-        fields = ['corpus_configuration', 'type', 'content']
+        fields = ['id', 'corpus', 'type', 'content']
 
 
 class JSONDefinitionField(serializers.Field):

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -65,6 +65,16 @@ class PrettyChoiceField(serializers.ChoiceField):
         key = super().to_representation(value)
         return self.choices[key]
 
+    def to_internal_value(self, data):
+        # If the data provides a display name, get the corresponding key.
+        # The browsable API sends keys instead of labels; use the original data if no
+        # matching label is found.
+        value = next(
+            (key for (key, label) in self.choices.items() if label == data),
+            data
+        )
+        return super().to_internal_value(value)
+
 class CorpusConfigurationSerializer(serializers.ModelSerializer):
     fields = FieldSerializer(many=True, read_only=True)
     languages = serializers.ListField(child=LanguageField())

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -136,14 +136,32 @@ class CorpusConfigurationField(serializers.SlugRelatedField):
         return value.corpus.name
 
 
+class ChoiceOrderSerializer(serializers.ReadOnlyField, serializers.ChoiceField):
+    def __init__(self, choices, **kwargs):
+        super().__init__(choices=choices, **kwargs)
+        self.index = {
+            value: i
+            for i, (value, label) in enumerate(choices)
+        }
+
+    def to_representation(self, value):
+        key = super().to_representation(value)
+        return self.index[key]
+
+
 class CorpusDocumentationPageSerializer(serializers.ModelSerializer):
     type = PrettyChoiceField(choices = CorpusDocumentationPage.PageType.choices)
+    index = ChoiceOrderSerializer(
+        read_only=True,
+        source='type',
+        choices=CorpusDocumentationPage.PageType.choices,
+    )
     content = DocumentationTemplateField()
     corpus = CorpusConfigurationField(source='corpus_configuration')
 
     class Meta:
         model = CorpusDocumentationPage
-        fields = ['id', 'corpus', 'type', 'content']
+        fields = ['id', 'corpus', 'type', 'content', 'index']
 
 
 class JSONDefinitionField(serializers.Field):

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -121,21 +121,6 @@ class DocumentationTemplateField(serializers.CharField):
         return render_documentation_context(content)
 
 
-class CorpusConfigurationField(serializers.SlugRelatedField):
-    '''
-    Serialise a related corpus configuration as the corpus name.
-    '''
-
-    def __init__(self, **kwargs):
-        super().__init__('corpus__name', **kwargs)
-
-    def get_queryset(self):
-        return CorpusConfiguration.objects.all()
-
-    def to_representation(self, value: CorpusConfiguration) -> str:
-        return value.corpus.name
-
-
 class ChoiceOrderSerializer(serializers.ChoiceField):
     '''
     Variant on the ChoiceField that serialises to the index in the choices array.
@@ -161,7 +146,11 @@ class CorpusDocumentationPageSerializer(serializers.ModelSerializer):
     )
     content = DocumentationTemplateField(read_only=True)
     content_template = serializers.CharField(source='content')
-    corpus = CorpusConfigurationField(source='corpus_configuration')
+    corpus = serializers.SlugRelatedField(
+        source='corpus_configuration',
+        queryset=CorpusConfiguration.objects.all(),
+        slug_field='corpus__name',
+    )
 
     class Meta:
         model = CorpusDocumentationPage

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -131,29 +131,9 @@ class DocumentationTemplateField(serializers.CharField):
         return render_documentation_context(content)
 
 
-class ChoiceOrderSerializer(serializers.ChoiceField):
-    '''
-    Variant on the ChoiceField that serialises to the index in the choices array.
-    '''
-    def __init__(self, choices, **kwargs):
-        super().__init__(choices=choices, **kwargs)
-        self.index = {value: i for i, (value, label) in enumerate(choices)}
-
-    def to_internal_value(self, data):
-        return self.choices[data]
-
-    def to_representation(self, value):
-        key = super().to_representation(value)
-        return self.index[key]
-
-
 class CorpusDocumentationPageSerializer(serializers.ModelSerializer):
     type = PrettyChoiceField(choices = CorpusDocumentationPage.PageType.choices)
-    index = ChoiceOrderSerializer(
-        read_only=True,
-        source='type',
-        choices=CorpusDocumentationPage.PageType.choices,
-    )
+    index = serializers.IntegerField(source='page_index', read_only=True)
     content = DocumentationTemplateField(read_only=True)
     content_template = serializers.CharField(source='content')
     corpus = serializers.SlugRelatedField(

--- a/backend/addcorpus/serializers.py
+++ b/backend/addcorpus/serializers.py
@@ -136,13 +136,16 @@ class CorpusConfigurationField(serializers.SlugRelatedField):
         return value.corpus.name
 
 
-class ChoiceOrderSerializer(serializers.ReadOnlyField, serializers.ChoiceField):
+class ChoiceOrderSerializer(serializers.ChoiceField):
+    '''
+    Variant on the ChoiceField that serialises to the index in the choices array.
+    '''
     def __init__(self, choices, **kwargs):
         super().__init__(choices=choices, **kwargs)
-        self.index = {
-            value: i
-            for i, (value, label) in enumerate(choices)
-        }
+        self.index = {value: i for i, (value, label) in enumerate(choices)}
+
+    def to_internal_value(self, data):
+        return self.choices[data]
 
     def to_representation(self, value):
         key = super().to_representation(value)
@@ -156,12 +159,13 @@ class CorpusDocumentationPageSerializer(serializers.ModelSerializer):
         source='type',
         choices=CorpusDocumentationPage.PageType.choices,
     )
-    content = DocumentationTemplateField()
+    content = DocumentationTemplateField(read_only=True)
+    content_template = serializers.CharField(source='content')
     corpus = CorpusConfigurationField(source='corpus_configuration')
 
     class Meta:
         model = CorpusDocumentationPage
-        fields = ['id', 'corpus', 'type', 'content', 'index']
+        fields = ['id', 'corpus', 'type', 'content', 'content_template', 'index']
 
 
 class JSONDefinitionField(serializers.Field):

--- a/backend/addcorpus/tests/test_corpus_access.py
+++ b/backend/addcorpus/tests/test_corpus_access.py
@@ -1,24 +1,33 @@
 from users.models import CustomUser, CustomAnonymousUser
+from addcorpus.models import Corpus
 
 def test_access_through_group(db, basic_mock_corpus, group_with_access):
     user = CustomUser.objects.create(username='nice-user', password='secret')
     user.groups.add(group_with_access)
     user.save()
-    assert user.has_access(basic_mock_corpus)
+    corpus = Corpus.objects.get(name=basic_mock_corpus)
+    assert user.can_search(corpus)
+    assert corpus in user.searchable_corpora()
 
 def test_superuser_access(basic_mock_corpus, admin_user):
-    assert admin_user.has_access(basic_mock_corpus)
+    corpus = Corpus.objects.get(name=basic_mock_corpus)
+    assert admin_user.can_search(corpus)
+    assert corpus in admin_user.searchable_corpora()
 
 def test_no_corpus_access(db, basic_mock_corpus):
     user = CustomUser.objects.create(username='bad-user', password='secret')
-    assert not user.has_access(basic_mock_corpus)
-
+    corpus = Corpus.objects.get(name=basic_mock_corpus)
+    assert not user.can_search(corpus)
+    assert corpus not in user.searchable_corpora()
 
 def test_public_corpus_access(db, basic_corpus_public):
     user = CustomUser.objects.create(username='new-user', password='secret')
-    assert user.has_access(basic_corpus_public)
+    corpus = Corpus.objects.get(name=basic_corpus_public)
+    assert user.can_search(corpus)
+    assert corpus in user.searchable_corpora()
     anon = CustomAnonymousUser()
-    assert anon.has_access(basic_corpus_public)
+    assert anon.can_search(corpus)
+    assert corpus in anon.searchable_corpora()
 
 def test_api_access(db, basic_mock_corpus, group_with_access, auth_client, auth_user):
     # default: no access

--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -30,9 +30,9 @@ def test_corpus_documentation_list_view(admin_client, basic_mock_corpus, setting
     assert page_types == ['General information', 'Citation', 'License']
 
     # should contain citation guidelines
+    match = { 'type': 'Citation', 'corpus': basic_mock_corpus }
     citation_page = next(
-        page for page in response.data if
-        page['type'] == 'Citation' and page['corpus'] == basic_mock_corpus
+        page for page in response.data if match.items() <= page.items()
     )
 
     # check that the page template is rendered with context

--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -21,8 +21,12 @@ def test_corpus_documentation_view(admin_client, basic_mock_corpus, settings):
     assert response.status_code == 200
     pages = response.data
 
-    # check that the pages are sorted in canonical order
-    page_types = [page['type'] for page in pages]
+    # check that the pages specify canonical order
+    sorted_and_filtered = sorted(
+        (page for page in pages if page['corpus'] == basic_mock_corpus),
+        key=lambda page: page['index']
+    )
+    page_types = [page['type'] for page in sorted_and_filtered]
     assert page_types == ['General information', 'Citation', 'License']
 
     # should contain citation guidelines

--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -3,7 +3,7 @@ from django.test.client import Client
 from typing import Dict
 
 from users.models import CustomUser
-from addcorpus.models import Corpus
+from addcorpus.models import Corpus, CorpusDocumentationPage
 from addcorpus.python_corpora.save_corpus import load_and_save_all_corpora
 
 def test_no_corpora(db, settings, admin_client):
@@ -16,7 +16,7 @@ def test_no_corpora(db, settings, admin_client):
     assert status.is_success(response.status_code)
     assert response.data == []
 
-def test_corpus_documentation_view(admin_client, basic_mock_corpus, settings):
+def test_corpus_documentation_list_view(admin_client, basic_mock_corpus, settings):
     response = admin_client.get(f'/api/corpus/documentation/')
     assert response.status_code == 200
     pages = response.data
@@ -39,6 +39,12 @@ def test_corpus_documentation_view(admin_client, basic_mock_corpus, settings):
     content = citation_page['content']
     assert '{{ frontend_url }}' not in content
     assert settings.BASE_URL in content
+
+def test_corpus_documentation_retrieve_view(admin_client: Client, basic_mock_corpus):
+    page = CorpusDocumentationPage.objects.first()
+    response = admin_client.get(f'/api/corpus/documentation/{page.pk}/')
+    assert status.is_success(response.status_code)
+
 
 def test_corpus_image_view(admin_client, basic_mock_corpus):
     corpus = Corpus.objects.get(name=basic_mock_corpus)
@@ -66,12 +72,12 @@ def test_no_corpus_access(db, client, basic_mock_corpus):
     assert response.status_code == 403
 
 
-def test_corpus_documentation_unauthenticated(db, client, basic_mock_corpus):
+def test_private_corpus_image_unauthenticated(db, client, basic_mock_corpus):
     response = client.get(
         f'/api/corpus/image/{basic_mock_corpus}')
     assert response.status_code == 401
 
-def test_public_corpus_documentation_unauthenticated(db, client, basic_corpus_public):
+def test_public_corpus_image_unauthenticated(db, client, basic_corpus_public):
     response = client.get(
         f'/api/corpus/image/{basic_corpus_public}')
     assert response.status_code == 200

--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -40,6 +40,13 @@ def test_corpus_documentation_list_view(admin_client, basic_mock_corpus, setting
     assert '{{ frontend_url }}' not in content
     assert settings.BASE_URL in content
 
+def test_corpus_documentation_filter_list_view(admin_client, basic_mock_corpus):
+    response = admin_client.get(f'/api/corpus/documentation/?corpus={basic_mock_corpus}')
+    assert response.status_code == 200
+    pages = response.data
+    for page in pages:
+        assert page['corpus'] == basic_mock_corpus
+
 def test_corpus_documentation_retrieve_view(admin_client: Client, basic_mock_corpus):
     page = CorpusDocumentationPage.objects.first()
     response = admin_client.get(f'/api/corpus/documentation/{page.pk}/')

--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -47,9 +47,24 @@ def test_corpus_documentation_filter_list_view(admin_client, basic_mock_corpus):
     for page in pages:
         assert page['corpus'] == basic_mock_corpus
 
+
 def test_corpus_documentation_retrieve_view(admin_client: Client, basic_mock_corpus):
     page = CorpusDocumentationPage.objects.first()
     response = admin_client.get(f'/api/corpus/documentation/{page.pk}/')
+    assert status.is_success(response.status_code)
+
+
+def test_corpus_documentation_create_view(admin_client, basic_mock_corpus):
+    request_data = {
+        'corpus': basic_mock_corpus,
+        'type': 'Terms of service',
+        'content_template': 'You can do whatever you want.'
+    }
+    response = admin_client.post(
+        '/api/corpus/documentation/',
+        request_data,
+        content_type='application/json'
+    )
     assert status.is_success(response.status_code)
 
 

--- a/backend/addcorpus/tests/test_corpus_views.py
+++ b/backend/addcorpus/tests/test_corpus_views.py
@@ -42,7 +42,7 @@ def test_corpus_documentation_list_view(admin_client, basic_mock_corpus, setting
 
 def test_corpus_documentation_filter_list_view(admin_client, basic_mock_corpus):
     response = admin_client.get(f'/api/corpus/documentation/?corpus={basic_mock_corpus}')
-    assert response.status_code == 200
+    assert status.is_success(response.status_code)
     pages = response.data
     for page in pages:
         assert page['corpus'] == basic_mock_corpus

--- a/backend/addcorpus/tests/test_models.py
+++ b/backend/addcorpus/tests/test_models.py
@@ -1,4 +1,4 @@
-from addcorpus.models import Corpus
+from addcorpus.models import Corpus, CorpusDocumentationPage
 
 def test_corpus_model(db):
     corpus = Corpus(name = 'test_corpus')
@@ -9,3 +9,12 @@ def test_corpus_model(db):
     corpus.delete()
 
     assert not Corpus.objects.filter(name = corpus)
+
+def test_corpus_documentation_page_model(db, basic_mock_corpus):
+    corpus = Corpus.objects.get(name=basic_mock_corpus)
+    page = CorpusDocumentationPage(
+        corpus_configuration=corpus.configuration,
+        type=CorpusDocumentationPage.PageType.LICENSE,
+        content='Do whatever you want.',
+    )
+    assert page.page_index == 2

--- a/backend/addcorpus/urls.py
+++ b/backend/addcorpus/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from addcorpus.views import CorpusImageView, CorpusView, CorpusDocumentationPageViewset, CorpusDocumentView
 
 urlpatterns = [
-    path('', CorpusView.as_view()),
+    path('', CorpusView.as_view({'get': 'list'})),
     path('image/<str:corpus>', CorpusImageView.as_view()),
     path('documentation/<str:corpus>/', CorpusDocumentationPageViewset.as_view({'get': 'list'})),
     path('document/<str:corpus>/<str:filename>', CorpusDocumentView.as_view()),

--- a/backend/addcorpus/urls.py
+++ b/backend/addcorpus/urls.py
@@ -4,6 +4,5 @@ from addcorpus.views import CorpusImageView, CorpusView, CorpusDocumentationPage
 urlpatterns = [
     path('', CorpusView.as_view({'get': 'list'})),
     path('image/<str:corpus>', CorpusImageView.as_view()),
-    path('documentation/<str:corpus>/', CorpusDocumentationPageViewset.as_view({'get': 'list'})),
     path('document/<str:corpus>/<str:filename>', CorpusDocumentView.as_view()),
 ]

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -25,8 +25,8 @@ class CorpusView(viewsets.ReadOnlyModelViewSet):
         return filtered_corpora
 
 
-class CorpusDocumentationPageViewset(viewsets.ReadOnlyModelViewSet):
-    permission_classes = [CanSearchCorpus, IsCuratorOrReadOnly]
+class CorpusDocumentationPageViewset(viewsets.ModelViewSet):
+    permission_classes = [IsCuratorOrReadOnly]
     serializer_class = CorpusDocumentationPageSerializer
 
     @staticmethod

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -28,12 +28,15 @@ class CorpusDocumentationPageViewset(viewsets.ModelViewSet):
     serializer_class = CorpusDocumentationPageSerializer
 
     def get_queryset(self):
-        corpora = self.request.user.searchable_corpora()
+        # curators are not limited to active corpora (to allow editing)
+        if self.request.user.is_staff:
+            corpora = Corpus.objects.all()
+        else:
+           corpora = self.request.user.searchable_corpora()
+
         pages = CorpusDocumentationPage.objects.filter(corpus_configuration__corpus__in=corpora)
         relevant_pages = filter(__class__._is_applicable_in_environment, pages)
-        canonical_order = [e.value for e in CorpusDocumentationPage.PageType]
-        return sorted(
-            relevant_pages, key=lambda p: canonical_order.index(p.type))
+        return relevant_pages
 
     @staticmethod
     def _is_applicable_in_environment(page: CorpusDocumentationPage):

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -54,7 +54,7 @@ class CorpusImageView(APIView):
     Return the image for a corpus.
     '''
 
-    permission_classes = [IsCuratorOrReadOnly]
+    permission_classes = [CanSearchCorpus, IsCuratorOrReadOnly]
 
     def get(self, request, *args, **kwargs):
         corpus_name = corpus_name_from_request(request)

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -24,6 +24,10 @@ class CorpusView(viewsets.ReadOnlyModelViewSet):
 
 
 class CorpusDocumentationPageViewset(viewsets.ModelViewSet):
+    '''
+    Markdown documentation pages for corpora.
+    '''
+
     permission_classes = [IsCuratorOrReadOnly]
     serializer_class = CorpusDocumentationPageSerializer
 
@@ -34,26 +38,9 @@ class CorpusDocumentationPageViewset(viewsets.ModelViewSet):
         else:
            corpora = self.request.user.searchable_corpora()
 
-        pages = CorpusDocumentationPage.objects.filter(corpus_configuration__corpus__in=corpora)
-        relevant_pages = filter(__class__._is_applicable_in_environment, pages)
-        return relevant_pages
-
-    @staticmethod
-    def _is_applicable_in_environment(page: CorpusDocumentationPage):
-        '''
-        Whether a documentation page is applicable with the current settings.
-
-        Returns False if the page documents word models that are not present in the
-        environment.
-        '''
-
-        if page.type == CorpusDocumentationPage.PageType.WORDMODELS:
-            corpus = page.corpus_configuration.corpus
-            if corpus.has_python_definition:
-                definition = load_corpus_definition(corpus.name)
-                return definition.word_models_present
-            return False
-        return True
+        return CorpusDocumentationPage.objects.filter(
+            corpus_configuration__corpus__in=corpora
+        )
 
 
 class CorpusImageView(APIView):

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -38,6 +38,10 @@ class CorpusDocumentationPageViewset(viewsets.ModelViewSet):
         else:
            corpora = self.request.user.searchable_corpora()
 
+        queried_corpus = self.request.query_params.get('corpus')
+        if queried_corpus:
+            corpora = corpora.filter(name=queried_corpus)
+
         return CorpusDocumentationPage.objects.filter(
             corpus_configuration__corpus__in=corpora
         )

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -4,7 +4,7 @@ from addcorpus.python_corpora.load_corpus import corpus_dir, load_corpus_definit
 import os
 from django.http.response import FileResponse
 from addcorpus.permissions import (
-    CorpusAccessPermission, filter_user_corpora, corpus_name_from_request, IsCurator,
+    CanSearchCorpus, filter_user_corpora, corpus_name_from_request, IsCurator,
     IsCuratorOrReadOnly)
 from rest_framework.exceptions import NotFound
 from rest_framework import viewsets
@@ -26,7 +26,7 @@ class CorpusView(viewsets.ReadOnlyModelViewSet):
 
 
 class CorpusDocumentationPageViewset(viewsets.ReadOnlyModelViewSet):
-    permission_classes = [CorpusAccessPermission, IsCuratorOrReadOnly]
+    permission_classes = [CanSearchCorpus, IsCuratorOrReadOnly]
     serializer_class = CorpusDocumentationPageSerializer
 
     @staticmethod
@@ -72,7 +72,7 @@ class CorpusDocumentView(APIView):
     Return a file for a corpus - e.g. extra metadata.
     '''
 
-    permission_classes = [CorpusAccessPermission]
+    permission_classes = [CanSearchCorpus]
 
     def get(self, request, *args, **kwargs):
         corpus = Corpus.objects.get(corpus_name_from_request(request))

--- a/backend/addcorpus/views.py
+++ b/backend/addcorpus/views.py
@@ -4,7 +4,7 @@ from addcorpus.python_corpora.load_corpus import corpus_dir, load_corpus_definit
 import os
 from django.http.response import FileResponse
 from addcorpus.permissions import (
-    CanSearchCorpus, filter_user_corpora, corpus_name_from_request, IsCurator,
+    CanSearchCorpus, corpus_name_from_request, IsCurator,
     IsCuratorOrReadOnly)
 from rest_framework.exceptions import NotFound
 from rest_framework import viewsets
@@ -20,9 +20,7 @@ class CorpusView(viewsets.ReadOnlyModelViewSet):
     serializer_class = CorpusSerializer
 
     def get_queryset(self):
-        corpora = Corpus.objects.filter(active=True)
-        filtered_corpora = filter_user_corpora(corpora, self.request.user)
-        return filtered_corpora
+        return self.request.user.searchable_corpora()
 
 
 class CorpusDocumentationPageViewset(viewsets.ModelViewSet):

--- a/backend/download/views.py
+++ b/backend/download/views.py
@@ -2,14 +2,13 @@ import logging
 import os
 
 from addcorpus.models import Corpus
-from addcorpus.permissions import (CorpusAccessPermission,
+from addcorpus.permissions import (CanSearchCorpus,
                                    corpus_name_from_request)
 from django.conf import settings
 from django.http.response import FileResponse
 from download import convert_csv, tasks
 from download.models import Download
 from download.serializers import DownloadSerializer
-from es import download as es_download
 from rest_framework.exceptions import (APIException, NotFound, ParseError,
                                        PermissionDenied)
 from rest_framework.permissions import IsAuthenticated
@@ -17,7 +16,6 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 from api.utils import check_json_keys
-from api.api_query import api_query_to_es_query
 
 logger = logging.getLogger()
 
@@ -36,7 +34,7 @@ class ResultsDownloadView(APIView):
     Download search results up to 1.000 documents
     '''
 
-    permission_classes = [CorpusAccessPermission]
+    permission_classes = [CanSearchCorpus]
 
     def post(self, request, *args, **kwargs):
         check_json_keys(request, ['es_query', 'corpus', 'fields', 'route', 'encoding'])
@@ -64,7 +62,7 @@ class ResultsDownloadTaskView(APIView):
     over 10.000 documents
     '''
 
-    permission_classes = [IsAuthenticated, CorpusAccessPermission]
+    permission_classes = [IsAuthenticated, CanSearchCorpus]
 
     def post(self, request, *args, **kwargs):
         check_json_keys(request, ['es_query', 'corpus', 'fields', 'route'])
@@ -88,7 +86,7 @@ class FullDataDownloadTaskView(APIView):
     for a visualisation.
     '''
 
-    permission_classes = [IsAuthenticated, CorpusAccessPermission]
+    permission_classes = [IsAuthenticated, CanSearchCorpus]
 
     def post(self, request, *args, **kwargs):
         check_json_keys(request, ['visualization', 'parameters', 'corpus_name'])

--- a/backend/es/views.py
+++ b/backend/es/views.py
@@ -5,12 +5,7 @@ from django.utils import timezone
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.exceptions import APIException
-from ianalyzer.elasticsearch import elasticsearch
-from es.search import get_index, total_hits, hits
-import logging
-from rest_framework.exceptions import APIException
 from addcorpus.permissions import CanSearchCorpus
-from tag.permissions import CanSearchTags
 from api.save_query import should_save_query
 from addcorpus.models import Corpus
 from api.models import Query

--- a/backend/es/views.py
+++ b/backend/es/views.py
@@ -5,8 +5,12 @@ from django.utils import timezone
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.exceptions import APIException
-
-from addcorpus.permissions import CorpusAccessPermission
+from ianalyzer.elasticsearch import elasticsearch
+from es.search import get_index, total_hits, hits
+import logging
+from rest_framework.exceptions import APIException
+from addcorpus.permissions import CanSearchCorpus
+from tag.permissions import CanSearchTags
 from api.save_query import should_save_query
 from addcorpus.models import Corpus
 from api.models import Query
@@ -46,7 +50,7 @@ class ForwardSearchView(APIView):
     the query parameter will be used.
     '''
 
-    permission_classes = [CorpusAccessPermission, CanSearchTags]
+    permission_classes = [CanSearchCorpus, CanSearchTags]
 
     def post(self, request, *args, **kwargs):
         corpus_name = kwargs.get('corpus')
@@ -113,7 +117,7 @@ class NamedEntitySearchView(APIView):
         'MISC': 'miscellaneous'
     }
 
-    permission_classes = [CorpusAccessPermission]
+    permission_classes = [CanSearchCorpus]
 
     def get(self, request, *args, **kwargs):
         corpus_name = kwargs.get('corpus')

--- a/backend/ianalyzer/urls.py
+++ b/backend/ianalyzer/urls.py
@@ -33,12 +33,13 @@ from api import urls as api_urls
 from media import urls as media_urls
 from tag import urls as tag_urls
 from tag.views import TagViewSet
-from addcorpus.views import CorpusDefinitionViewset
+from addcorpus.views import CorpusDefinitionViewset, CorpusDocumentationPageViewset
 
 api_router = routers.DefaultRouter()  # register viewsets with this router
 api_router.register('search_history', QueryViewset, basename='query')
 api_router.register('tag/tags', TagViewSet)
 api_router.register('corpus/definitions', CorpusDefinitionViewset, basename='corpus')
+api_router.register('corpus/documentation', CorpusDocumentationPageViewset, basename='corpus-documentation')
 
 if settings.PROXY_FRONTEND:
     spa_url = re_path(r'^(?P<path>.*)$', proxy_frontend)

--- a/backend/media/views.py
+++ b/backend/media/views.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 from addcorpus.python_corpora.load_corpus import load_corpus_definition
-from addcorpus.permissions import (CorpusAccessPermission,
+from addcorpus.permissions import (CanSearchCorpus,
                                    corpus_name_from_request)
 from api.utils import check_json_keys
 from django.http.response import FileResponse
@@ -19,7 +19,7 @@ class GetMediaView(APIView):
     Return the image/pdf of a document
     '''
 
-    permission_classes = (CorpusAccessPermission,)
+    permission_classes = [CanSearchCorpus]
 
     def get(self, request, *args, **kwargs):
         corpus_name = corpus_name_from_request(request)
@@ -60,7 +60,7 @@ class MediaMetadataView(APIView):
     Return metadata on the media for a document
     '''
 
-    permission_classes = (CorpusAccessPermission,)
+    permission_classes = [CanSearchCorpus]
 
     def post(self, request, *args, **kwargs):
         corpus_name = corpus_name_from_request(request)

--- a/backend/tag/views.py
+++ b/backend/tag/views.py
@@ -3,13 +3,13 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.views import APIView
 from django.http import HttpRequest
-from rest_framework.exceptions import NotFound, PermissionDenied, ParseError
+from rest_framework.exceptions import NotFound, PermissionDenied
 
 from .models import Tag, TaggedDocument
 from .permissions import IsTagOwner
 from .serializers import TagSerializer
 from addcorpus.models import Corpus
-from addcorpus.permissions import CorpusAccessPermission
+from addcorpus.permissions import CanSearchCorpus
 
 def check_corpus_name(request: HttpRequest):
     '''
@@ -58,7 +58,7 @@ class TagViewSet(ModelViewSet):
         return Response(serializer.data)
 
 class DocumentTagsView(APIView):
-    permission_classes = [IsAuthenticated, CorpusAccessPermission]
+    permission_classes = [IsAuthenticated, CanSearchCorpus]
 
     def get(self, request, *args, **kwargs):
         '''

--- a/backend/users/conftest.py
+++ b/backend/users/conftest.py
@@ -19,7 +19,7 @@ def group_without_access():
 
 @pytest.fixture
 def test_corpus(group_with_access):
-    corpus = Corpus.objects.create(name='test-corpus')
+    corpus = Corpus.objects.create(name='test-corpus', active=True)
     corpus.groups.add(group_with_access)
     corpus.save()
     yield corpus

--- a/backend/users/tests/test_corpus_access.py
+++ b/backend/users/tests/test_corpus_access.py
@@ -1,16 +1,14 @@
 from users.models import CustomUser
-from addcorpus.models import Corpus
-from django.contrib.auth.models import Group
 
 
 def test_corpus_access(db, group_with_access, group_without_access, test_corpus):
     user = CustomUser.objects.create(username='test-user')
-    assert not user.has_access('test-corpus')
+    assert not user.can_search(test_corpus)
 
     user.groups.add(group_without_access)
     user.save()
-    assert not user.has_access('test-corpus')
+    assert not user.can_search(test_corpus)
 
     user.groups.add(group_with_access)
     user.save()
-    assert user.has_access('test-corpus')
+    assert user.can_search(test_corpus)

--- a/backend/visualization/views.py
+++ b/backend/visualization/views.py
@@ -6,7 +6,7 @@ from visualization import tasks
 import logging
 from django.conf import settings
 from rest_framework.permissions import IsAuthenticated
-from addcorpus.permissions import CorpusAccessPermission
+from addcorpus.permissions import CanSearchCorpus
 from tag.permissions import CanSearchTags
 from visualization.field_stats import report_coverage
 from addcorpus.permissions import corpus_name_from_request
@@ -20,7 +20,7 @@ class WordcloudView(APIView):
     Most frequent terms for a small batch of results
     '''
 
-    permission_classes = [CorpusAccessPermission, CanSearchTags]
+    permission_classes = [CanSearchCorpus, CanSearchTags]
 
     def post(self, request, *args, **kwargs):
         check_json_keys(request, ['corpus', 'es_query', 'field', 'size'])
@@ -44,7 +44,7 @@ class MapView(APIView):
     '''
 
     permission_classes = [IsAuthenticated,
-                          CorpusAccessPermission, CanSearchTags]
+                          CanSearchCorpus, CanSearchTags]
 
     def post(self, request, *args, **kwargs):
         check_json_keys(request, ['corpus', 'es_query', 'field'])
@@ -62,7 +62,7 @@ class NgramView(APIView):
     Schedule a task to retrieve ngrams containing the search term
     '''
 
-    permission_classes = [CorpusAccessPermission, CanSearchTags]
+    permission_classes = [CanSearchCorpus, CanSearchTags]
 
     def post(self, request, *args, **kwargs):
         check_json_keys(request, [
@@ -86,7 +86,7 @@ class DateTermFrequencyView(APIView):
     compared by a date field
     '''
 
-    permission_classes = [CorpusAccessPermission, CanSearchTags]
+    permission_classes = [CanSearchCorpus, CanSearchTags]
 
     def post(self, request, *args, **kwargs):
         check_json_keys(
@@ -114,7 +114,7 @@ class AggregateTermFrequencyView(APIView):
     compared by a keyword field
     '''
 
-    permission_classes = [CorpusAccessPermission, CanSearchTags]
+    permission_classes = [CanSearchCorpus, CanSearchTags]
 
     def post(self, request, *args, **kwargs):
         check_json_keys(
@@ -141,7 +141,7 @@ class FieldCoverageView(APIView):
     Get the coverage of each field in a corpus
     '''
 
-    permission_classes = [CorpusAccessPermission]
+    permission_classes = [CanSearchCorpus]
 
     def get(self, request, *args, **kwargs):
         corpus = corpus_name_from_request(request)

--- a/backend/wordmodels/tests/test_wordmodels_views.py
+++ b/backend/wordmodels/tests/test_wordmodels_views.py
@@ -1,11 +1,8 @@
 import pytest
 
 def test_wm_documentation_view(admin_client, mock_corpus):
-    response = admin_client.get(f'/api/corpus/documentation/')
-    assert any(
-        page['type'] == 'Word models' and page['corpus'] == mock_corpus
-        for page in response.data
-    )
+    response = admin_client.get(f'/api/corpus/documentation/?corpus={mock_corpus}')
+    assert any(page['type'] == 'Word models'for page in response.data)
 
 def test_related_words_view(admin_client, mock_corpus):
 

--- a/backend/wordmodels/tests/test_wordmodels_views.py
+++ b/backend/wordmodels/tests/test_wordmodels_views.py
@@ -1,8 +1,11 @@
 import pytest
 
 def test_wm_documentation_view(admin_client, mock_corpus):
-    response = admin_client.get(f'/api/corpus/documentation/{mock_corpus}/')
-    assert any(page['type'] == 'Word models' for page in response.data)
+    response = admin_client.get(f'/api/corpus/documentation/')
+    assert any(
+        page['type'] == 'Word models' and page['corpus'] == mock_corpus
+        for page in response.data
+    )
 
 def test_related_words_view(admin_client, mock_corpus):
 

--- a/backend/wordmodels/views.py
+++ b/backend/wordmodels/views.py
@@ -1,6 +1,6 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from addcorpus.permissions import CorpusAccessPermission, corpus_name_from_request
+from addcorpus.permissions import CanSearchCorpus, corpus_name_from_request
 from wordmodels import utils, visualisations
 from rest_framework.exceptions import APIException
 
@@ -9,7 +9,7 @@ class RelatedWordsView(APIView):
     Get words with the highest similarity to the query term
     '''
 
-    permission_classes = [CorpusAccessPermission]
+    permission_classes = [CanSearchCorpus]
 
     def post(self, request, *args, **kwargs):
         corpus = corpus_name_from_request(request)
@@ -33,7 +33,7 @@ class SimilarityView(APIView):
     Get similarity between two query terms
     '''
 
-    permission_classes = [CorpusAccessPermission]
+    permission_classes = [CanSearchCorpus]
 
     def get(self, request, *args, **kwargs):
         corpus = corpus_name_from_request(request)
@@ -53,7 +53,7 @@ class WordInModelView(APIView):
     Check if a word has a vector in the model for a corpus
     '''
 
-    permission_classes = [CorpusAccessPermission]
+    permission_classes = [CanSearchCorpus]
 
     def get(self, request, *args, **kwargs):
         corpus = corpus_name_from_request(request)

--- a/frontend/src/app/corpus-info/corpus-info.component.ts
+++ b/frontend/src/app/corpus-info/corpus-info.component.ts
@@ -32,7 +32,7 @@ export class CorpusInfoComponent implements OnInit {
 
     setCorpus(corpus: Corpus) {
         this.corpus = corpus;
-        this.documentation$ = this.corpusService.getDocumentation(corpus).pipe(
+        this.documentation$ = this.apiService.corpusDocumentationPages(corpus).pipe(
             map(pages => pages.filter(page => this.includePage(corpus, page))),
             map(this.sortPages)
         );

--- a/frontend/src/app/corpus-info/corpus-info.component.ts
+++ b/frontend/src/app/corpus-info/corpus-info.component.ts
@@ -34,7 +34,7 @@ export class CorpusInfoComponent implements OnInit {
         this.corpus = corpus;
         this.documentation$ = this.apiService.corpusDocumentationPages(corpus).pipe(
             map(pages => pages.filter(page => this.includePage(corpus, page))),
-            map(this.sortPages)
+            map(pages => _.sortBy(pages, 'index'))
         );
         this.apiService.fieldCoverage(corpus.name).then(
             result => this.fieldCoverage = result
@@ -46,12 +46,8 @@ export class CorpusInfoComponent implements OnInit {
         return marked.parse(content);
     }
 
-    private sortPages(pages: CorpusDocumentationPage[]): CorpusDocumentationPage[] {
-        return _.sortBy(pages, 'index');
-    }
-
     private includePage(corpus: Corpus, page: CorpusDocumentationPage): boolean {
-        return page.type !== 'Word models' || corpus.wordModelsPresent;
+        return (page.type !== 'Word models') || corpus.wordModelsPresent;
     }
 
 }

--- a/frontend/src/app/models/corpus.ts
+++ b/frontend/src/app/models/corpus.ts
@@ -30,6 +30,7 @@ export class Corpus {
         public languages: string[],
         public category: string,
         public hasNamedEntities: boolean,
+        public documentationPageIDs: number[],
         public documentContext?: DocumentContext,
         public newHighlight?: boolean,
         public defaultSort?: SortState,
@@ -150,6 +151,9 @@ export class CorpusField {
 }
 
 export interface CorpusDocumentationPage {
+    id: number;
+    corpus: string;
     type: string;
     content: string;
+    index?: number;
 }

--- a/frontend/src/app/models/corpus.ts
+++ b/frontend/src/app/models/corpus.ts
@@ -30,7 +30,6 @@ export class Corpus {
         public languages: string[],
         public category: string,
         public hasNamedEntities: boolean,
-        public documentationPageIDs: number[],
         public documentContext?: DocumentContext,
         public newHighlight?: boolean,
         public defaultSort?: SortState,

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -223,12 +223,14 @@ export class ApiService {
     }
 
     // Corpus
-    public corpusDocumentation(corpusName: string): Observable<CorpusDocumentationPage[]> {
-        const url = this.apiRoute(
-            this.corpusApiUrl,
-            `documentation/${corpusName}/`
-        );
+    public corpusDocumentationPages(): Observable<CorpusDocumentationPage[]> {
+        const url = this.apiRoute(this.corpusApiUrl, 'documentation/');
         return this.http.get<CorpusDocumentationPage[]>(url);
+    }
+
+    public corpusDocumentationPage(pageID: number): Observable<CorpusDocumentationPage> {
+        const url = this.apiRoute(this.corpusApiUrl, `documentation/${pageID}/`);
+        return this.http.get<CorpusDocumentationPage>(url);
     }
 
     public corpus() {

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -223,8 +223,9 @@ export class ApiService {
     }
 
     // Corpus
-    public corpusDocumentationPages(): Observable<CorpusDocumentationPage[]> {
-        const url = this.apiRoute(this.corpusApiUrl, 'documentation/');
+    public corpusDocumentationPages(corpus?: Corpus): Observable<CorpusDocumentationPage[]> {
+        const queryParams = corpus ? `?corpus=${corpus.name}` : ''
+        const url = this.apiRoute(this.corpusApiUrl, `documentation/${queryParams}`);
         return this.http.get<CorpusDocumentationPage[]>(url);
     }
 

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -224,9 +224,9 @@ export class ApiService {
 
     // Corpus
     public corpusDocumentationPages(corpus?: Corpus): Observable<CorpusDocumentationPage[]> {
-        const queryParams = corpus ? `?corpus=${corpus.name}` : ''
-        const url = this.apiRoute(this.corpusApiUrl, `documentation/${queryParams}`);
-        return this.http.get<CorpusDocumentationPage[]>(url);
+        const params = new URLSearchParams({corpus: corpus.name}).toString();
+        const url = this.apiRoute(this.corpusApiUrl, `documentation/?${params}`);
+        return this.http.get<CorpusDocumentationPage[]>(url.toString());
     }
 
     public corpusDocumentationPage(pageID: number): Observable<CorpusDocumentationPage> {

--- a/frontend/src/app/services/corpus.service.ts
+++ b/frontend/src/app/services/corpus.service.ts
@@ -1,14 +1,12 @@
 /* eslint-disable @typescript-eslint/member-ordering */
 import { Injectable } from '@angular/core';
 
-import { BehaviorSubject, Observable, combineLatest } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
-import { Corpus, CorpusDocumentationPage, CorpusField, DocumentContext, SortDirection, SortState } from '../models/index';
+import { Corpus, CorpusField, DocumentContext, SortDirection, SortState } from '../models/index';
 import { ApiRetryService } from './api-retry.service';
-import { AuthService } from './auth.service';
 import { findByName } from '../utils/utils';
 import * as _ from 'lodash';
-import { ApiService } from './api.service';
 
 @Injectable({
     providedIn: 'root',
@@ -24,8 +22,6 @@ export class CorpusService {
 
     constructor(
         private apiRetryService: ApiRetryService,
-        private authService: AuthService,
-        private apiService: ApiService,
     ) {
         this.parseField = this.parseField.bind(this);
     }

--- a/frontend/src/app/services/corpus.service.ts
+++ b/frontend/src/app/services/corpus.service.ts
@@ -72,13 +72,6 @@ export class CorpusService {
         }
     }
 
-    getDocumentation(corpus: Corpus): Observable<CorpusDocumentationPage[]> {
-        const requests = corpus.documentationPageIDs.map(
-            id => this.apiService.corpusDocumentationPage(id)
-        );
-        return combineLatest(requests);
-    }
-
     private async parseCorpusList(data: any): Promise<Corpus[]> {
         return data.map(this.parseCorpusItem);
     }
@@ -99,7 +92,6 @@ export class CorpusService {
             data.languages,
             data.category,
             data.has_named_entities,
-            data.documentation_pages,
             this.parseDocumentContext(data.document_context, allFields),
             data.new_highlight,
             this.parseDefaultSort(data.default_sort, allFields),

--- a/frontend/src/mock-data/api.ts
+++ b/frontend/src/mock-data/api.ts
@@ -73,7 +73,7 @@ export class ApiServiceMock {
         return of({ username: 'Thomas', email: 'thomas@cromwell.com' });
     }
 
-    public corpusDocumentationPage(corpus: Corpus): Observable<CorpusDocumentationPage[]> {
+    public corpusDocumentationPages(corpus: Corpus): Observable<CorpusDocumentationPage[]> {
         return of([{
             id: 1,
             corpus: corpus.name,

--- a/frontend/src/mock-data/api.ts
+++ b/frontend/src/mock-data/api.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import { Observable, Subject, from, of } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { mockUserResponse } from './user';
-import { CorpusDocumentationPage, TaskResult, TasksOutcome } from '../app/models';
+import { Corpus, CorpusDocumentationPage, TaskResult, TasksOutcome } from '../app/models';
 import { LimitedResultsDownloadParameters } from '../app/models/search-results';
 import { mockCorpusDefinition } from './corpus-definition';
 import { APIEditableCorpus } from '../app/models/corpus-definition';
@@ -73,10 +73,13 @@ export class ApiServiceMock {
         return of({ username: 'Thomas', email: 'thomas@cromwell.com' });
     }
 
-    public corpusDocumentation(): Observable<CorpusDocumentationPage[]> {
+    public corpusDocumentationPage(corpus: Corpus): Observable<CorpusDocumentationPage[]> {
         return of([{
+            id: 1,
+            corpus: corpus.name,
             type: 'General',
-            content: 'Example of _documentation_.'
+            content: 'Example of _documentation_.',
+            index: 1,
         }]);
     }
 

--- a/frontend/src/mock-data/corpus.ts
+++ b/frontend/src/mock-data/corpus.ts
@@ -218,14 +218,4 @@ export class CorpusServiceMock {
             }
         });
     }
-
-    public getDocumentation(corpus: Corpus): Observable<CorpusDocumentationPage[]> {
-        return of([{
-            id: 1,
-            corpus: corpus.name,
-            type: 'General',
-            content: 'Example of _documentation_.',
-            index: 1,
-        }]);
-    }
 }

--- a/frontend/src/mock-data/corpus.ts
+++ b/frontend/src/mock-data/corpus.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { findByName } from '../app/utils/utils';
 import { BooleanFilterOptions } from '../app/models/field-filter-options';
-import { Corpus, CorpusField } from '../app/models';
+import { Corpus, CorpusDocumentationPage, CorpusField } from '../app/models';
 
 const mockFilterOptions: BooleanFilterOptions = {
     checked: false,
@@ -217,5 +217,15 @@ export class CorpusServiceMock {
                 return true;
             }
         });
+    }
+
+    public getDocumentation(corpus: Corpus): Observable<CorpusDocumentationPage[]> {
+        return of([{
+            id: 1,
+            corpus: corpus.name,
+            type: 'General',
+            content: 'Example of _documentation_.',
+            index: 1,
+        }]);
     }
 }

--- a/frontend/src/mock-data/corpus.ts
+++ b/frontend/src/mock-data/corpus.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { BehaviorSubject, Observable, of } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import { findByName } from '../app/utils/utils';
 import { BooleanFilterOptions } from '../app/models/field-filter-options';
-import { Corpus, CorpusDocumentationPage, CorpusField } from '../app/models';
+import { Corpus, CorpusField } from '../app/models';
 
 const mockFilterOptions: BooleanFilterOptions = {
     checked: false,


### PR DESCRIPTION
This update changes the backend API to allow uploading corpus documentation (part of https://github.com/UUDigitalHumanitieslab/I-analyzer/issues/1573). It also makes some quality improvements to permissions in corpus-related views.

The corpus documentation view now has create/update/delete endpoints (accessible to admin users). Some changes to the view to make that more convenient:
- The corpus name is now an optional query parameter, e.g. `/api/corpus/documentation/dbnl/` -> `/api/corpus/documentation/?corpus=dbnl`. It's also included in the JSON data, so you can create/update on `/api/corpus/documentation/`.
- The view includes both the original template for the documentation, and the rendered version (the latter is read-only).
- The order of pages is now included as a (read-only) `index` field in the JSON, rather than implicit in the array order.
- If the corpus has word models documentation but no models, they are filtered out in the frontend instead of the backend.
- Admin users can now view the documentation of inactive corpora

I added two new permissions for corpus-related views: `IsCurator` and `IsCuratorOrReadOnly`. Also, the name `CorpusAccessPermission` was getting confusing (access to do what?), so I renamed that to `CanSearchCorpus`.