### PR TITLE
Jewishmigration: request data with API key

### DIFF
--- a/backend/corpora/jewishmigration/jewishmigration.py
+++ b/backend/corpora/jewishmigration/jewishmigration.py
@@ -54,6 +54,7 @@ class JewishMigration(PeacePortal, JSONCorpusDefinition):
     data_url = getattr(settings, 'JMIG_DATA_URL', None)
     data_api_key = getattr(settings, 'JMIG_DATA_API_KEY', None)
 
+    es_alias = getattr(settings, 'JMIG_ALIAS', None)
     es_index = getattr(settings, 'JMIG_INDEX', 'jewishmigration')
     image = 'jewish_inscriptions.jpg'
     languages = ['en']

--- a/backend/corpora/jewishmigration/jewishmigration.py
+++ b/backend/corpora/jewishmigration/jewishmigration.py
@@ -5,6 +5,7 @@ import logging
 from django.conf import settings
 import langcodes
 import requests
+from requests.auth import HTTPBasicAuth
 
 from addcorpus.python_corpora.corpus import JSONCorpusDefinition, FieldDefinition
 from addcorpus.es_mappings import int_mapping, keyword_mapping
@@ -51,6 +52,7 @@ class JewishMigration(PeacePortal, JSONCorpusDefinition):
     data_directory = settings.JMIG_DATA_DIR
     data_filepath = getattr(settings, 'JMIG_DATA', None)
     data_url = getattr(settings, 'JMIG_DATA_URL', None)
+    data_api_key = getattr(settings, 'JMIG_DATA_API_KEY', None)
 
     es_index = getattr(settings, 'JMIG_INDEX', 'jewishmigration')
     image = 'jewish_inscriptions.jpg'
@@ -60,7 +62,11 @@ class JewishMigration(PeacePortal, JSONCorpusDefinition):
 
     def sources(self, start, end):
         if self.data_url:
-            response = requests.get(self.data_url)
+            if self.data_api_key:
+                auth = HTTPBasicAuth('apikey', self.data_api_key)
+                response = requests.get(self.data_url, auth=auth)
+            else:
+                response = requests.get(self.data_url)
             list_of_sources = response.json()
         elif self.data_filepath:
             with open(self.data_filepath, 'r') as f:

--- a/backend/corpora/jewishmigration/jewishmigration.py
+++ b/backend/corpora/jewishmigration/jewishmigration.py
@@ -5,7 +5,6 @@ import logging
 from django.conf import settings
 import langcodes
 import requests
-from requests.auth import HTTPBasicAuth
 
 from addcorpus.python_corpora.corpus import JSONCorpusDefinition, FieldDefinition
 from addcorpus.es_mappings import int_mapping, keyword_mapping

--- a/backend/corpora/jewishmigration/jewishmigration.py
+++ b/backend/corpora/jewishmigration/jewishmigration.py
@@ -64,7 +64,7 @@ class JewishMigration(PeacePortal, JSONCorpusDefinition):
     def sources(self, start, end):
         if self.data_url:
             if self.data_api_key:
-                auth = HTTPBasicAuth('apikey', self.data_api_key)
+                auth = HTTPBasicAuth('Token', self.data_api_key)
                 response = requests.get(self.data_url, auth=auth)
             else:
                 response = requests.get(self.data_url)

--- a/backend/corpora/jewishmigration/jewishmigration.py
+++ b/backend/corpora/jewishmigration/jewishmigration.py
@@ -63,7 +63,7 @@ class JewishMigration(PeacePortal, JSONCorpusDefinition):
     def sources(self, start, end):
         if self.data_url:
             if self.data_api_key:
-                headers = {'Authorization': f'Token {self.api_key}'}
+                headers = {"Authorization": f"Token {self.data_api_key}"}
                 response = requests.get(self.data_url, headers=headers)
             else:
                 response = requests.get(self.data_url)
@@ -76,7 +76,6 @@ class JewishMigration(PeacePortal, JSONCorpusDefinition):
                 'No data filepath or URL provided.')
         for source in list_of_sources:
             yield source
-
 
     def __init__(self):
         super().__init__()

--- a/backend/corpora/jewishmigration/jewishmigration.py
+++ b/backend/corpora/jewishmigration/jewishmigration.py
@@ -64,8 +64,8 @@ class JewishMigration(PeacePortal, JSONCorpusDefinition):
     def sources(self, start, end):
         if self.data_url:
             if self.data_api_key:
-                auth = HTTPBasicAuth('Token', self.data_api_key)
-                response = requests.get(self.data_url, auth=auth)
+                headers = {'Authorization': f'Token {self.api_key}'}
+                response = requests.get(self.data_url, headers=headers)
             else:
                 response = requests.get(self.data_url)
             list_of_sources = response.json()


### PR DESCRIPTION
This PR adds a couple of lines to send a get request with an authorization header in case an api key is defined in the settings. It also fixes a problem with `JewishMigration`'s `es_alias` being set to "peaceportal" (inherited from `PeacePortal` parent class).