### PR TITLE
Add try/except clause around streaming_bulk operation

### DIFF
--- a/backend/es/es_index.py
+++ b/backend/es/es_index.py
@@ -132,14 +132,17 @@ def populate(client: Elasticsearch, corpus: Corpus, start=None, end=None):
         settings.CORPUS_SERVER_NAMES.get(corpus_name, 'default')]
 
     # Do bulk operation
-    for success, info in es_helpers.streaming_bulk(
-        client,
-        actions,
-        chunk_size=corpus_server['chunk_size'],
-        max_chunk_bytes=corpus_server['max_chunk_bytes'],
-    ):
-        if not success:
-            logger.error(f"FAILED INDEX: {info}")
+    try:
+        for success, info in es_helpers.streaming_bulk(
+            client,
+            actions,
+            chunk_size=corpus_server["chunk_size"],
+            max_chunk_bytes=corpus_server["max_chunk_bytes"],
+        ):
+            if not success:
+                logger.error(f"FAILED INDEX: {info}")
+    except Exception as e:
+        logger.warning(e)
 
 
 def perform_indexing(

--- a/backend/es/es_index.py
+++ b/backend/es/es_index.py
@@ -138,6 +138,7 @@ def populate(client: Elasticsearch, corpus: Corpus, start=None, end=None):
         chunk_size=corpus_server["chunk_size"],
         max_chunk_bytes=corpus_server["max_chunk_bytes"],
         raise_on_exception=False,
+        raise_on_error=False,
     ):
         if not success:
             logger.error(f"FAILED INDEX: {info}")

--- a/backend/es/es_index.py
+++ b/backend/es/es_index.py
@@ -132,17 +132,15 @@ def populate(client: Elasticsearch, corpus: Corpus, start=None, end=None):
         settings.CORPUS_SERVER_NAMES.get(corpus_name, 'default')]
 
     # Do bulk operation
-    try:
-        for success, info in es_helpers.streaming_bulk(
-            client,
-            actions,
-            chunk_size=corpus_server["chunk_size"],
-            max_chunk_bytes=corpus_server["max_chunk_bytes"],
-        ):
-            if not success:
-                logger.error(f"FAILED INDEX: {info}")
-    except Exception as e:
-        logger.warning(e)
+    for success, info in es_helpers.streaming_bulk(
+        client,
+        actions,
+        chunk_size=corpus_server["chunk_size"],
+        max_chunk_bytes=corpus_server["max_chunk_bytes"],
+        raise_on_exception=False,
+    ):
+        if not success:
+            logger.error(f"FAILED INDEX: {info}")
 
 
 def perform_indexing(


### PR DESCRIPTION
When indexing the JewishMigration corpus, the process stopped after ca. 300 documents, with the following message: `elasticsearch.helpers.BulkIndexError: 1 document(s) failed to index.` To me it seemed an overkill to let the whole process fail on this, so I wrapped the `streaming_bulk` operation in a try / except clause. Unfortunately, the error message is not more specific about which document failed and why. Curiously, locally the indexing operation finishes with 1960 documents having been indexed, i.e., all documents currently in this corpus.