### PR TITLE
Add word_model_path to times and guardian corpus

### DIFF
--- a/backend/corpora/guardianobserver/guardianobserver.py
+++ b/backend/corpora/guardianobserver/guardianobserver.py
@@ -42,6 +42,7 @@ class GuardianObserver(XMLCorpusDefinition):
     scan_image_type = getattr(settings, 'GO_SCAN_IMAGE_TYPE', 'application/pdf')
     languages = ['en']
     category = 'periodical'
+    word_model_path = getattr(settings, "GO_WM", None)
 
     @property
     def es_settings(self):
@@ -243,7 +244,6 @@ class GuardianObserver(XMLCorpusDefinition):
             "fileSize": sizeof_fmt(getsize(join(self.data_directory, image_path)))
         }
         return {'media': image_urls, 'info': pdf_info}
-
 
     def get_media(self, request_args):
         '''

--- a/backend/corpora/times/times.py
+++ b/backend/corpora/times/times.py
@@ -40,6 +40,7 @@ class Times(XMLCorpusDefinition):
     citation_page = 'citation.md'
     languages = ['en']
     category = 'periodical'
+    word_model_path = getattr(settings, "TIMES_WM", None)
 
     @property
     def es_settings(self):


### PR DESCRIPTION
This PR makes it possible to easily test / deploy word models for Times and Guardian by modifying a server's `settings.py`