### PR TITLE
Fix registration issues

### DIFF
--- a/backend/ianalyzer/common_settings.py
+++ b/backend/ianalyzer/common_settings.py
@@ -98,6 +98,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+ACCOUNT_USER_DISPLAY = lambda user: user.username.replace(".", "\u2024")
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.0/topics/i18n/

--- a/backend/ianalyzer/settings.py
+++ b/backend/ianalyzer/settings.py
@@ -48,8 +48,6 @@ PROXY_FRONTEND = None
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 CSRF_TRUSTED_ORIGINS = ['http://localhost:8000']
 
-ACCOUNT_USER_DISPLAY = lambda user: user.username.replace(".", "\u2024")
-
 SITE_NAME = 'IANALYZER'
 HOST = 'localhost:8000'
 

--- a/backend/ianalyzer/settings.py
+++ b/backend/ianalyzer/settings.py
@@ -48,8 +48,7 @@ PROXY_FRONTEND = None
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 CSRF_TRUSTED_ORIGINS = ['http://localhost:8000']
 
-
-# ACCOUNT_ADAPTER = 'users.adapters.CustomAccountAdapter'
+ACCOUNT_USER_DISPLAY = lambda user: user.username.replace(".", "\u2024")
 
 SITE_NAME = 'IANALYZER'
 HOST = 'localhost:8000'

--- a/frontend/src/app/login/registration/registration.component.html
+++ b/frontend/src/app/login/registration/registration.component.html
@@ -24,7 +24,7 @@
                     <div class="field">
                         <label class="label" for="email">Email</label>
                         <p class="control has-icons-left">
-                            <input class="input" type="email" name="email" ngModel #email="ngModel" required pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,3}$" />
+                            <input class="input" type="email" name="email" ngModel #email="ngModel" required pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$" />
                             <span class="icon is-left">
                                 <fa-icon [icon]="userIcons.email" aria-hidden="true"></fa-icon>
                             </span>

--- a/frontend/src/app/login/registration/registration.component.html
+++ b/frontend/src/app/login/registration/registration.component.html
@@ -24,7 +24,7 @@
                     <div class="field">
                         <label class="label" for="email">Email</label>
                         <p class="control has-icons-left">
-                            <input class="input" type="email" name="email" ngModel #email="ngModel" required pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$" />
+                            <input class="input" type="email" name="email" ngModel #email="ngModel" required email/>
                             <span class="icon is-left">
                                 <fa-icon [icon]="userIcons.email" aria-hidden="true"></fa-icon>
                             </span>
@@ -32,7 +32,7 @@
                         <div class="notification is-warning" *ngIf="email.errors?.required && (email.dirty || email.touched)">
                             Email is required.
                         </div>
-                        <div class="notification is-warning" class="notification is-warning" *ngIf="email.errors?.pattern && email.touched">
+                        <div class="notification is-warning" class="notification is-warning" *ngIf="email.errors && email.touched">
                             Please enter a valid email address.
                         </div>
                         <div class="notification is-danger" *ngIf="errors?.email">

--- a/frontend/src/app/login/reset-password/request-reset.component.html
+++ b/frontend/src/app/login/reset-password/request-reset.component.html
@@ -17,7 +17,7 @@
                             <div class="notification is-warning" *ngIf="email.errors?.required && (email.dirty || email.touched)">
                                 Email is required.
                             </div>
-                            <div class="notification is-warning" class="notification is-warning" *ngIf="email.errors?.pattern && email.touched">
+                            <div class="notification is-warning" class="notification is-warning" *ngIf="email.errors && email.touched">
                                 Please enter a valid email address.
                             </div>
                             <div *ngIf="showMessage && message" class="notification" [ngClass]="{'is-danger': !success, 'is-success': success}">{{message}}</div>


### PR DESCRIPTION
Following a SO post, I decided to keep the username in the emails, but replace dots in the username by a square dot. Bad luck for a "dotty" user who wants to copy / paste their username, but I think it is still more user friendly that way. Also thought to include a fix for the registration form to allow longer domains.

![Screenshot 2024-09-27 at 09 53 52](https://github.com/user-attachments/assets/ae34e5ec-e4f9-4e1a-98c5-4f235d34f01a)
