### PR TITLE
Fix Peace Portal visualizations & add visualization for Jewishmigration

### DIFF
--- a/backend/corpora/jewishmigration/jewishmigration.py
+++ b/backend/corpora/jewishmigration/jewishmigration.py
@@ -98,61 +98,63 @@ class JewishMigration(PeacePortal, JSONCorpusDefinition):
             key='transcription')
         extra_fields = [
             FieldDefinition(
-                name='script',
-                display_name='Script',
-                description='Which alphabet the source was written in',
+                name="script",
+                display_name="Script",
+                description="Which alphabet the source was written in",
                 es_mapping=keyword_mapping(),
-                extractor=extract.JSON(key='scripts'),
+                extractor=extract.JSON(key="scripts"),
+                visualizations=["resultscount"],
             ),
             FieldDefinition(
-                name='site_type',
-                display_name='Site Type',
-                description='Type of site where evidence for settlement was found',
+                name="site_type",
+                display_name="Site Type",
+                description="Type of site where evidence for settlement was found",
                 es_mapping=keyword_mapping(),
-                extractor=extract.JSON(key='site_type')
+                extractor=extract.JSON(key="site_type"),
             ),
             FieldDefinition(
-                name='inscription_type',
-                display_name='Inscription type',
-                description='Type of inscription',
+                name="inscription_type",
+                display_name="Inscription type",
+                description="Type of inscription",
                 es_mapping=keyword_mapping(),
-                extractor=extract.JSON(key='inscription_type')
+                extractor=extract.JSON(key="inscription_type"),
             ),
             FieldDefinition(
-                name='period',
-                display_name='Period',
-                description='Period in which the inscription was made',
+                name="period",
+                display_name="Period",
+                description="Period in which the inscription was made",
                 es_mapping=keyword_mapping(),
-                extractor=extract.JSON(key='period')
+                extractor=extract.JSON(key="period"),
             ),
             FieldDefinition(
-                name='estimated_centuries',
-                display_name='Estimated Centuries',
-                description='Estimate of centuries in which the inscription was made',
+                name="estimated_centuries",
+                display_name="Estimated Centuries",
+                description="Estimate of centuries in which the inscription was made",
                 es_mapping=int_mapping(),
                 extractor=extract.JSON(
-                    key='estimated_centuries', transform=transform_centuries)
+                    key="estimated_centuries", transform=transform_centuries
+                ),
             ),
             FieldDefinition(
-                name='inscription_count',
-                display_name='Inscription count',
-                description='Number of inscriptions',
+                name="inscription_count",
+                display_name="Inscription count",
+                description="Number of inscriptions",
                 es_mapping=int_mapping(),
-                extractor=extract.JSON(key='inscriptions_count')
+                extractor=extract.JSON(key="inscriptions_count"),
             ),
             FieldDefinition(
-                name='religious_profession',
-                display_name='Religious profession',
-                description='Religious profession of deceased',
+                name="religious_profession",
+                display_name="Religious profession",
+                description="Religious profession of deceased",
                 es_mapping=keyword_mapping(),
-                extractor=extract.JSON(key='religious_profession')
+                extractor=extract.JSON(key="religious_profession"),
             ),
             FieldDefinition(
-                name='sex_dedicator',
-                display_name='Gender dedicator',
-                description='Gender of the dedicator',
+                name="sex_dedicator",
+                display_name="Gender dedicator",
+                description="Gender of the dedicator",
                 es_mapping=keyword_mapping(),
-                extractor=extract.JSON(key='sex_dedicator')
-            )
+                extractor=extract.JSON(key="sex_dedicator"),
+            ),
         ]
         self.fields = [*exclude_fields_without_extractor(self.fields), *extra_fields]

--- a/backend/corpora/peaceportal/utils/field_defaults.py
+++ b/backend/corpora/peaceportal/utils/field_defaults.py
@@ -39,20 +39,20 @@ def url():
 
 def year(min_year, max_year):
     return FieldDefinition(
-        name='year',
-        display_name='Year',
-        description='Year of origin of the inscription.',
+        name="year",
+        display_name="Year",
+        description="Year of origin of the inscription.",
         es_mapping=int_mapping(),
         search_filter=RangeFilter(
-            description='Restrict the years from which search results will be returned.',
+            description="Restrict the years from which search results will be returned.",
             lower=min_year,
             upper=max_year,
         ),
         csv_core=True,
         sortable=True,
-        visualization_type='term_frequency',
-        visualization_sort='key',
-        results_overview=True
+        visualizations=["resultscount"],
+        visualization_sort="key",
+        results_overview=True,
     )
 
 
@@ -68,7 +68,6 @@ def date(min_date, max_date):
             upper=max_date,
         )
     )
-
 
 
 def not_before():
@@ -204,44 +203,41 @@ def sex():
 
 def country():
     return FieldDefinition(
-        name='country',
-        display_name='Country',
-        description='Country where the inscription was found.',
+        name="country",
+        display_name="Country",
+        description="Country where the inscription was found.",
         es_mapping=keyword_mapping(True),
         search_filter=MultipleChoiceFilter(
-            description='Search only within these countries.',
-            option_count=5
+            description="Search only within these countries.", option_count=5
         ),
-        visualization_type='term_frequency',
-        results_overview=True
+        visualizations=["resultscount"],
+        results_overview=True,
     )
 
 
 def settlement():
     return FieldDefinition(
-        name='settlement',
-        display_name='Settlement',
-        description='The settlement where the inscription was found.',
+        name="settlement",
+        display_name="Settlement",
+        description="The settlement where the inscription was found.",
         es_mapping=keyword_mapping(True),
         search_filter=MultipleChoiceFilter(
-            description='Search only within these settlements.',
-            option_count=29
+            description="Search only within these settlements.", option_count=29
         ),
-        visualization_type='term_frequency'
+        visualizations=["resultscount"],
     )
 
 
 def region():
     return FieldDefinition(
-        name='region',
-        display_name='Region',
-        description='The region where the inscription was found.',
+        name="region",
+        display_name="Region",
+        description="The region where the inscription was found.",
         es_mapping=keyword_mapping(True),
         search_filter=MultipleChoiceFilter(
-            description='Search only within these regions.',
-            option_count=29
+            description="Search only within these regions.", option_count=29
         ),
-        visualization_type='term_frequency'
+        visualizations=["resultscount"],
     )
 
 
@@ -256,15 +252,14 @@ def location_details():
 
 def material():
     return FieldDefinition(
-        name='material',
-        display_name='Material',
-        description='Type of material the inscription is written on.',
+        name="material",
+        display_name="Material",
+        description="Type of material the inscription is written on.",
         es_mapping=keyword_mapping(),
         search_filter=MultipleChoiceFilter(
-            description='Search only within these material types.',
-            option_count=39
+            description="Search only within these material types.", option_count=39
         ),
-        visualization_type='term_frequency'
+        visualization_type="resultscount",
     )
 
 
@@ -280,16 +275,15 @@ def material_details():
 
 def language():
     return FieldDefinition(
-        name='language',
-        display_name='Language',
-        description='Language of the inscription.',
+        name="language",
+        display_name="Language",
+        description="Language of the inscription.",
         es_mapping=keyword_mapping(),
         search_filter=MultipleChoiceFilter(
-            description='Search only within these languages.',
-            option_count=10
+            description="Search only within these languages.", option_count=10
         ),
         csv_core=True,
-        visualization_type='term_frequency'
+        visualizations=["resultscount"],
     )
 
 


### PR DESCRIPTION
I wanted to add visualizations for Jewishmigration and noticed in the process that the Peace Portal `field_defaults` used the old format for specifying visualizations. This branch should fix that.