### PR TITLE
Add basic registration ratelimit

### DIFF
--- a/backend/ianalyzer/common_settings.py
+++ b/backend/ianalyzer/common_settings.py
@@ -77,7 +77,10 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication'
-    ]
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'registration': '5/minute',
+    }
 }
 
 # Password validation

--- a/backend/ianalyzer/common_settings.py
+++ b/backend/ianalyzer/common_settings.py
@@ -79,6 +79,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.SessionAuthentication'
     ],
     'DEFAULT_THROTTLE_RATES': {
+        'password': '3/minute',
         'registration': '5/minute',
     }
 }

--- a/backend/users/throttles.py
+++ b/backend/users/throttles.py
@@ -1,5 +1,17 @@
+from rest_framework.exceptions import Throttled
 from rest_framework.throttling import ScopedRateThrottle
 
-class UserRateThrottle(ScopedRateThrottle):
+
+class PasswordResetRateThrottle(ScopedRateThrottle):
+    def get_ident(self, request):
+        return 'globaluserident'
+
+    def throttle_failure(self):
+        raise Throttled(detail={
+            "error": "Too many attempts. Please try again later."
+        })
+
+
+class RegistrationRateThrottle(ScopedRateThrottle):
     def get_ident(self, request):
         return 'globaluserident'

--- a/backend/users/throttles.py
+++ b/backend/users/throttles.py
@@ -1,0 +1,5 @@
+from rest_framework.throttling import ScopedRateThrottle
+
+class RegistrationRateThrottle(ScopedRateThrottle):
+    def get_ident(self, request):
+        return 'globaluserident'

--- a/backend/users/throttles.py
+++ b/backend/users/throttles.py
@@ -1,5 +1,5 @@
 from rest_framework.throttling import ScopedRateThrottle
 
-class RegistrationRateThrottle(ScopedRateThrottle):
+class UserRateThrottle(ScopedRateThrottle):
     def get_ident(self, request):
         return 'globaluserident'

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,7 +1,14 @@
 from django.urls import include, path, re_path
 from dj_rest_auth.registration.views import VerifyEmailView
 
-from .views import KeyInfoView, redirect_confirm, redirect_reset, SamlLogoutView, ThrottledRegisterView
+from .views import (
+    KeyInfoView,
+    redirect_confirm,
+    redirect_reset,
+    SamlLogoutView,
+    ThrottledPasswordResetView,
+    ThrottledRegisterView
+)
 
 urlpatterns = [
     # registration
@@ -12,6 +19,7 @@ urlpatterns = [
     path('account-confirm-email/', VerifyEmailView.as_view(),
          name='account_email_verification_sent'),
     # password reset
+    path('password/reset/', ThrottledPasswordResetView.as_view(), name='rest_password_reset'),
     path('password-reset/<uidb64>/<token>/',
          redirect_reset, name='password_reset_confirm'),
     # generic routes

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -12,7 +12,7 @@ from .views import (
 
 urlpatterns = [
     # registration
-    path('registration/', ThrottledRegisterView.as_view(), name='rest_registration'),
+    path('registration/', ThrottledRegisterView.as_view(), name='rest_register'),
     re_path(r'registration/account-confirm-email/(?P<key>.+)/',
             redirect_confirm, name='account_confirm_email'),
     path('registration/key-info/', KeyInfoView.as_view(), name='key-info'),

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,11 +1,11 @@
 from django.urls import include, path, re_path
-from .views import redirect_confirm, KeyInfoView, SamlLogoutView
 from dj_rest_auth.registration.views import VerifyEmailView
 
-from .views import KeyInfoView, redirect_confirm, redirect_reset
+from .views import KeyInfoView, redirect_confirm, redirect_reset, SamlLogoutView, ThrottledRegisterView
 
 urlpatterns = [
     # registration
+    path('registration/', ThrottledRegisterView.as_view(), name='rest_registration'),
     re_path(r'registration/account-confirm-email/(?P<key>.+)/',
             redirect_confirm, name='account_confirm_email'),
     path('registration/key-info/', KeyInfoView.as_view(), name='key-info'),
@@ -15,8 +15,8 @@ urlpatterns = [
     path('password-reset/<uidb64>/<token>/',
          redirect_reset, name='password_reset_confirm'),
     # generic routes
-    path('', include('dj_rest_auth.urls')),
     path('registration/', include('dj_rest_auth.registration.urls')),
+    path('', include('dj_rest_auth.urls')),
     path('saml2/ls/post', SamlLogoutView.as_view()),
     path('saml2/', include('djangosaml2.urls')),
 ]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -2,6 +2,7 @@ from allauth.account.models import EmailConfirmationHMAC
 from django.http import HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
 from dj_rest_auth.registration.views import RegisterView
+from dj_rest_auth.views import PasswordResetView
 from rest_framework.exceptions import APIException
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -11,7 +12,7 @@ from rest_framework.viewsets import ModelViewSet
 from rest_framework.permissions import IsAuthenticated
 from djangosaml2.views import LogoutView
 from .serializers import CustomUserDetailsSerializer
-from .throttles import RegistrationRateThrottle
+from .throttles import UserRateThrottle
 
 
 def redirect_confirm(request, key):
@@ -53,6 +54,11 @@ class UserViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated]
     serializer_class = CustomUserDetailsSerializer
 
+
+class ThrottledPasswordResetView(PasswordResetView):
+    throttle_scope = 'password'
+    throttle_classes = [UserRateThrottle]
+
 class ThrottledRegisterView(RegisterView):
     throttle_scope = 'registration'
-    throttle_classes = [RegistrationRateThrottle]
+    throttle_classes = [UserRateThrottle]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -1,6 +1,7 @@
 from allauth.account.models import EmailConfirmationHMAC
 from django.http import HttpResponseRedirect
 from django.views.decorators.csrf import csrf_exempt
+from dj_rest_auth.registration.views import RegisterView
 from rest_framework.exceptions import APIException
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -10,6 +11,7 @@ from rest_framework.viewsets import ModelViewSet
 from rest_framework.permissions import IsAuthenticated
 from djangosaml2.views import LogoutView
 from .serializers import CustomUserDetailsSerializer
+from .throttles import RegistrationRateThrottle
 
 
 def redirect_confirm(request, key):
@@ -51,3 +53,6 @@ class UserViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated]
     serializer_class = CustomUserDetailsSerializer
 
+class ThrottledRegisterView(RegisterView):
+    throttle_scope = 'registration'
+    throttle_classes = [RegistrationRateThrottle]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -12,7 +12,7 @@ from rest_framework.viewsets import ModelViewSet
 from rest_framework.permissions import IsAuthenticated
 from djangosaml2.views import LogoutView
 from .serializers import CustomUserDetailsSerializer
-from .throttles import UserRateThrottle
+from .throttles import PasswordResetRateThrottle, RegistrationRateThrottle
 
 
 def redirect_confirm(request, key):
@@ -57,8 +57,8 @@ class UserViewSet(ModelViewSet):
 
 class ThrottledPasswordResetView(PasswordResetView):
     throttle_scope = 'password'
-    throttle_classes = [UserRateThrottle]
+    throttle_classes = [PasswordResetRateThrottle]
 
 class ThrottledRegisterView(RegisterView):
     throttle_scope = 'registration'
-    throttle_classes = [UserRateThrottle]
+    throttle_classes = [RegistrationRateThrottle]

--- a/frontend/src/app/login/registration/registration.component.html
+++ b/frontend/src/app/login/registration/registration.component.html
@@ -1,7 +1,7 @@
 <section class="section">
     <div class="columns is-centered">
 
-        <div *ngIf="!registrationSucceeded && !serverError">
+        <div *ngIf="!registrationSucceeded && !serverErrorCode">
             <form (ngSubmit)="register(signupForm)" class="container is-readable" #signupForm="ngForm">
                 <div class="container is-login">
                     <h1 class="title">I-Analyzer sign-up</h1>
@@ -113,7 +113,10 @@
             <p>Please follow the instructions in this email to complete your registration. </p>
         </div>
 
-        <div class="notification is-danger container" *ngIf=serverError>
+        <div class="notification is-danger container" *ngIf="serverErrorCode === 429">
+            <p>Too many requests. Try again later.</p>
+        </div>
+        <div class="notification is-danger container" *ngIf="![0, 429].includes(serverErrorCode)">
             <p>A problem occurred on our side. Please contact the Digital Humanities Lab (<b>digitalhumanities [at] uu [dot] nl</b>), so that we can fix it for you.</p>
         </div>
     </div>

--- a/frontend/src/app/login/registration/registration.component.ts
+++ b/frontend/src/app/login/registration/registration.component.ts
@@ -33,7 +33,7 @@ export class RegistrationComponent implements OnInit, OnDestroy {
     public isLoading: boolean;
 
     public registrationSucceeded: boolean;
-    public serverError = false;
+    public serverErrorCode: number = 0;
 
     public isModalActive = false;
 
@@ -88,8 +88,7 @@ export class RegistrationComponent implements OnInit, OnDestroy {
         if (errorResponse.status === 400) {
             this.errors = errorResponse.error;
         } else {
-            this.serverError = true;
+            this.serverErrorCode = errorResponse.status;
         }
     }
 }
-


### PR DESCRIPTION
@tymees does this throttle implementation look reasonable?

Team, do we want `DEFAULT_THROTTLE_RATES` in common or local settings? And what's a rate that's high enough for potential peak registration periods (like a course/lecture)?