### PR TITLE
Hotfix/date term frequency validation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -35,5 +35,5 @@ keywords:
   - elasticsearch
   - natural language processing
 license: MIT
-version: 5.30.0
-date-released: '2026-04-09'
+version: 5.30.1
+date-released: '2026-05-19'

--- a/backend/visualization/tests/test_visualization_views.py
+++ b/backend/visualization/tests/test_visualization_views.py
@@ -1,5 +1,7 @@
 from visualization.query import MATCH_ALL
+from visualization.views import TERM_FREQUENCY_SIZE_LIMIT
 import pytest
+import math
 from rest_framework import status
 
 @pytest.fixture()
@@ -86,13 +88,24 @@ def test_date_term_frequency(transactional_db, admin_client, date_term_frequency
     post_response = admin_client.post('/api/visualization/date_term_frequency', date_term_frequency_body, content_type='application/json')
     assert post_response.status_code == 400
 
-def test_term_frequency_limit(transactional_db, admin_client, date_term_frequency_body, aggregate_term_frequency_body, index_small_mock_corpus, celery_worker):
+def test_date_term_frequency_limit(transactional_db, admin_client, date_term_frequency_body, index_small_mock_corpus, celery_worker):
     for bin in date_term_frequency_body['bins']:
         bin['size'] = 1000000
     post_response = admin_client.post('/api/visualization/date_term_frequency', date_term_frequency_body, content_type='application/json')
     assert post_response.status_code == 400
 
+    for bin in date_term_frequency_body['bins']:
+        bin['size'] = math.ceil(TERM_FREQUENCY_SIZE_LIMIT / len(date_term_frequency_body['bins']))
+    post_response = admin_client.post('/api/visualization/date_term_frequency', date_term_frequency_body, content_type='application/json')
+    assert post_response.status_code == 200
+
+def test_aggregate_term_frequency_limit(transactional_db, admin_client, aggregate_term_frequency_body, index_small_mock_corpus, celery_worker):
     for bin in aggregate_term_frequency_body['bins']:
         bin['size'] = 1000000
     post_response = admin_client.post('/api/visualization/aggregate_term_frequency', aggregate_term_frequency_body, content_type='application/json')
     assert post_response.status_code == 400
+
+    for bin in aggregate_term_frequency_body['bins']:
+        bin['size'] = math.ceil(TERM_FREQUENCY_SIZE_LIMIT / len(aggregate_term_frequency_body['bins']))
+    post_response = admin_client.post('/api/visualization/aggregate_term_frequency', aggregate_term_frequency_body, content_type='application/json')
+    assert post_response.status_code == 200

--- a/backend/visualization/views.py
+++ b/backend/visualization/views.py
@@ -20,6 +20,12 @@ The frontend rounds up in every bin so the total size of the request may be
 `10.000 + N(bins)`.
 '''
 
+def validate_term_frequency_size(bins):
+    max_size = TERM_FREQUENCY_SIZE_LIMIT + len(bins)
+    if sum(bin['size'] for bin in bins) > max_size:
+        raise ValidationError(detail='Maximum size exceeded')
+
+
 
 class WordcloudView(APIView):
     '''
@@ -121,8 +127,7 @@ class DateTermFrequencyView(APIView):
                     raise ParseError(
                         detail=f'key {key} is not present for all bins in request data')
 
-        if sum(bin['size'] for bin in bins) > TERM_FREQUENCY_SIZE_LIMIT:
-            raise ValidationError(detail='Maximum size exceeded')
+        validate_term_frequency_size(bins)
 
         try:
             group = tasks.timeline_term_frequency_tasks(
@@ -153,9 +158,7 @@ class AggregateTermFrequencyView(APIView):
                     raise ParseError(
                         detail=f'key {key} is not present for all bins in request data')
 
-        max_size = TERM_FREQUENCY_SIZE_LIMIT + len(bins)
-        if sum(bin['size'] for bin in bins) > max_size:
-            raise ValidationError(detail='Maximum size exceeded')
+        validate_term_frequency_size(bins)
 
         try:
             group = tasks.histogram_term_frequency_tasks(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textcavator",
-  "version": "5.30.0",
+  "version": "5.30.1",
   "license": "MIT",
   "scripts": {
     "postinstall": "yarn install-back && yarn install-front",


### PR DESCRIPTION
Fixes a bug where the validation for the date / term frequency graph would fail when the total documents exceed 10.000.

