### PR TITLE
Feature/unify settings formats

### DIFF
--- a/backend/addcorpus/python_corpora/corpus.py
+++ b/backend/addcorpus/python_corpora/corpus.py
@@ -547,10 +547,3 @@ def transform_to_date_range(earliest, latest):
         'gte': earliest,
         'lte': latest
     }
-
-
-def get_deprecated_setting(setting: str):
-    '''Utility function to get a corpus-specific Django setting'''
-    if hasattr(settings, setting):
-        logger.warning('Setting %s is deprecated; use CORPUS_SETTINGS', setting)
-        return getattr(settings, setting)

--- a/backend/addcorpus/python_corpora/tests/test_times_source.py
+++ b/backend/addcorpus/python_corpora/tests/test_times_source.py
@@ -11,9 +11,10 @@ def times_test_settings(settings):
     settings.CORPORA = {
         'times': 'corpora.times.times.Times',
     }
-    settings.TIMES_DATA = join(settings.BASE_DIR, 'addcorpus/python_corpora/tests')
-    settings.TIMES_ES_INDEX = 'test-times'
-
+    settings.CORPUS_SETTINGS["times"] = {
+        "data_directory": join(settings.BASE_DIR, "addcorpus/python_corpora/tests"),
+        "es_index": "test-times",
+    }
 
 
 def test_times_source(times_test_settings):

--- a/backend/corpora/dbnl/dbnl.py
+++ b/backend/corpora/dbnl/dbnl.py
@@ -4,7 +4,7 @@ import re
 from tqdm import tqdm
 from ianalyzer_readers.xml_tag import Tag, CurrentTag, TransformTag
 
-from addcorpus.python_corpora.corpus import XMLCorpusDefinition, FieldDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import XMLCorpusDefinition, FieldDefinition
 from ianalyzer_readers.extract import Metadata, XML, Pass, Order, Backup, Combined
 import corpora.dbnl.utils as utils
 from addcorpus.es_mappings import *
@@ -14,17 +14,10 @@ from corpora.dbnl.dbnl_metadata import DBNLMetadata
 class DBNL(XMLCorpusDefinition):
     title = 'DBNL'
     description = 'Dutch literature and publications on literary or linguistic studies, from the Middle Ages to the 19th century'
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('DBNL_DATA') or super().data_directory
+    es_index = 'dbnl'  # default setting for development
 
     min_date = datetime(year=1200, month=1, day=1)
     max_date = datetime(year=1890, month=12, day=31)
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('DBNL_ES_INDEX') or 'dbnl'
 
     image = 'dbnl.png'
     description_page = 'dbnl.md'

--- a/backend/corpora/dutchannualreports/dutchannualreports.py
+++ b/backend/corpora/dutchannualreports/dutchannualreports.py
@@ -25,7 +25,6 @@ class DutchAnnualReports(XMLCorpusDefinition):
     description = "Annual reports of Dutch financial and non-financial institutes"
     min_date = datetime(year=1957, month=1, day=1)
     max_date = datetime(year=2008, month=12, day=31)
-    data_directory = settings.DUTCHANNUALREPORTS_DATA
     es_index = 'dutchannualreports'
     image = 'dutchannualreports.jpg'
     scan_image_type = 'application/pdf'

--- a/backend/corpora/dutchannualreports/dutchannualreports.py
+++ b/backend/corpora/dutchannualreports/dutchannualreports.py
@@ -26,12 +26,11 @@ class DutchAnnualReports(XMLCorpusDefinition):
     min_date = datetime(year=1957, month=1, day=1)
     max_date = datetime(year=2008, month=12, day=31)
     data_directory = settings.DUTCHANNUALREPORTS_DATA
-    es_index = getattr(settings, 'DUTCHANNUALREPORTS_ES_INDEX', 'dutchannualreports')
+    es_index = 'dutchannualreports'
     image = 'dutchannualreports.jpg'
-    scan_image_type = getattr(settings, 'DUTCHANNUALREPORTS_SCAN_IMAGE_TYPE', 'application/pdf')
+    scan_image_type = 'application/pdf'
     description_page = 'dutchannualreports.md'
-    allow_image_download = getattr(settings, 'DUTCHANNUALREPORTS_ALLOW_IMAGE_DOWNLOAD', True)
-    word_model_path = getattr(settings, 'DUTCHANNUALREPORTS_WM', None)
+    allow_image_download = True
 
     languages = ['nl']
     category = 'finance'

--- a/backend/corpora/dutchnewspapers/dutchnewspapers_all.py
+++ b/backend/corpora/dutchnewspapers/dutchnewspapers_all.py
@@ -14,7 +14,6 @@ class DutchNewsPapersAll(DutchNewspapersPublic):
 
     title = "Dutch Newspapers (full)"
     description = "Full collection of Dutch newspapers digitised by the Koninklijke Bibliotheek."
-    data_directory = settings.DUTCHNEWSPAPERS_ALL_DATA
     es_index = 'dutchnewspapers-all'
     max_date = datetime(year=1995, month=12, day=31)
 

--- a/backend/corpora/dutchnewspapers/dutchnewspapers_all.py
+++ b/backend/corpora/dutchnewspapers/dutchnewspapers_all.py
@@ -15,9 +15,8 @@ class DutchNewsPapersAll(DutchNewspapersPublic):
     title = "Dutch Newspapers (full)"
     description = "Full collection of Dutch newspapers digitised by the Koninklijke Bibliotheek."
     data_directory = settings.DUTCHNEWSPAPERS_ALL_DATA
-    es_index = getattr(settings, 'DUTCHNEWSPAPERS_ALL_ES_INDEX', 'dutchnewspapers-all')
+    es_index = 'dutchnewspapers-all'
     max_date = datetime(year=1995, month=12, day=31)
-    word_model_path = getattr(settings, "DUTCHNEWSPAPERS_WM", None)
 
     def update_body(self, doc=None):
         if not doc:

--- a/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
+++ b/backend/corpora/dutchnewspapers/dutchnewspapers_public.py
@@ -32,14 +32,12 @@ class DutchNewspapersPublic(XMLCorpusDefinition):
     description = "Collection of Dutch newspapers in the public domain, digitised by the Koninklijke Bibliotheek."
     min_date = datetime(year=1600, month=1, day=1)
     max_date = datetime(year=1876, month=12, day=31)
-    data_directory = getattr(settings, 'DUTCHNEWSPAPERS_DATA', None)
-    es_index = getattr(settings, 'DUTCHNEWSPAPERS_ES_INDEX', 'dutchnewspapers-public')
+    es_index = 'dutchnewspapers-public'
     image = 'dutchnewspapers.jpg'
     languages = ['nl']
     category = 'periodical'
     description_page = 'description_public.md'
     citation_page = 'citation_public.md'
-    word_model_path = getattr(settings, "DUTCHNEWSPAPERS_WM", None)
 
     @property
     def es_settings(self):

--- a/backend/corpora/ecco/ecco.py
+++ b/backend/corpora/ecco/ecco.py
@@ -32,9 +32,9 @@ class Ecco(XMLCorpusDefinition):
     max_date = datetime(year=1800, month=12, day=31)
 
     data_directory = settings.ECCO_DATA
-    es_index = getattr(settings, 'ECCO_ES_INDEX', 'ecco')
+    es_index = 'ecco'
     image = 'ecco.jpg'
-    scan_image_type = getattr(settings, 'ECCO_SCAN_IMAGE_TYPE', 'application/pdf')
+    scan_image_type = 'application/pdf'
     es_settings = None
     languages = ['en', 'fr', 'la', 'grc', 'de',  'it', 'cy', 'ga', 'gd']
     category = 'book'

--- a/backend/corpora/ecco/ecco.py
+++ b/backend/corpora/ecco/ecco.py
@@ -31,7 +31,6 @@ class Ecco(XMLCorpusDefinition):
     min_date = datetime(year=1700, month=1, day=1)
     max_date = datetime(year=1800, month=12, day=31)
 
-    data_directory = settings.ECCO_DATA
     es_index = 'ecco'
     image = 'ecco.jpg'
     scan_image_type = 'application/pdf'

--- a/backend/corpora/economist/economist.py
+++ b/backend/corpora/economist/economist.py
@@ -54,8 +54,7 @@ class Economist(GaleCorpus):
     description = "Archive of The Economist, a weekly news magazine."
     min_date = datetime(1843, 8, 1)
     max_date = datetime(2021, 1, 1)
-    data_directory = settings.ECONOMIST_DATA
-    es_index = getattr(settings, 'ECONOMIST_ES_INDEX', 'economist')
+    es_index = 'economist'
     image = 'A_stack_of_Economist_papers.jpg'
     description_page = 'Economist.md'
     languages = ['en']

--- a/backend/corpora/gallica/caricature.py
+++ b/backend/corpora/gallica/caricature.py
@@ -12,7 +12,7 @@ class Caricature(Gallica):
     max_date = datetime(year=1843, month=12, day=31)
     corpus_id = "cb344523348"
     category = "periodical"
-    es_index = getattr(settings, 'CARICATURE_INDEX', 'caricature')
+    es_index = 'caricature'
     description_page = 'caricature.md'
     image = "caricature.jpg"
 

--- a/backend/corpora/gallica/figaro.py
+++ b/backend/corpora/gallica/figaro.py
@@ -12,7 +12,7 @@ class Figaro(Gallica):
     max_date = datetime(year=1954, month=12, day=31)
     corpus_id = "cb34355551z"
     category = "periodical"
-    es_index = getattr(settings, 'FIGARO_INDEX', 'figaro')
+    es_index = 'figaro'
     image = "figaro.jpg"
     description_page = 'figaro.md'
 

--- a/backend/corpora/gallica/resistance.py
+++ b/backend/corpora/gallica/resistance.py
@@ -81,7 +81,7 @@ class JournauxResistance(Gallica):
         "cb32853253x",
     ]
     category = "periodical"
-    es_index = getattr(settings, 'RESISTANCE_INDEX', 'resistance')
+    es_index = 'resistance'
     image = "resistance.png"
     description_page = "resistance.md"
 

--- a/backend/corpora/goodreads/goodreads.py
+++ b/backend/corpora/goodreads/goodreads.py
@@ -8,7 +8,7 @@ import openpyxl
 
 from ianalyzer_readers.extract import CSV, Metadata
 from addcorpus.python_corpora.filters import MultipleChoiceFilter, RangeFilter
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, FieldDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition, FieldDefinition
 
 from addcorpus.es_mappings import main_content_mapping
 
@@ -20,19 +20,12 @@ class GoodReads(CSVCorpusDefinition):
     # Data overrides from .common.Corpus (fields at bottom of class)
     title = "DIOPTRA-L"
     description = "Goodreads reviews of translated literary texts"
+    es_index = 'goodreads'  # default setting for development
 
     delimiter = ';'
 
     min_date=datetime(2007, 1, 1)
     max_date=datetime(2022, 12, 31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('GOODREADS_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('GOODREADS_ES_INDEX') or 'goodreads'
 
     image = 'DioptraL.png'
     description_page = 'goodreads.md'

--- a/backend/corpora/guardianobserver/guardianobserver.py
+++ b/backend/corpora/guardianobserver/guardianobserver.py
@@ -3,6 +3,7 @@ Collect information from the Guardian-Observer corpus: the articles are containe
 separate xml-files, zipped.
 '''
 
+from addcorpus.python_corpora.corpus import XMLCorpusDefinition, FieldDefinition
 import logging
 logger = logging.getLogger(__name__)
 import re
@@ -18,7 +19,6 @@ from ianalyzer_readers import extract
 from api.utils import find_media_file
 from indexing.run_update_task import update_document
 from addcorpus.python_corpora import filters
-from addcorpus.python_corpora.corpus import XMLCorpusDefinition, FieldDefinition, get_deprecated_setting
 from media.image_processing import sizeof_fmt
 from media.media_url import media_url
 
@@ -36,27 +36,13 @@ class GuardianObserver(XMLCorpusDefinition):
     description_page = 'guardianobserver.md'
     min_date = datetime(year=1791, month=1, day=1)
     max_date = datetime(year=2003, month=12, day=31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('GO_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('GO_ES_INDEX') or 'guardianobserver'
+    scan_image_type = 'application/pdf'
 
     image = 'guardianobserver.jpg'
 
-    @property
-    def scan_image_type(self):
-        return get_deprecated_setting('GO_SCAN_IMAGE_TYPE') or 'application/pdf'
 
     languages = ['en']
     category = 'periodical'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('GO_WM') or super().word_model_path
 
     @property
     def es_settings(self):

--- a/backend/corpora/guardianobserver/guardianobserver.py
+++ b/backend/corpora/guardianobserver/guardianobserver.py
@@ -37,6 +37,7 @@ class GuardianObserver(XMLCorpusDefinition):
     min_date = datetime(year=1791, month=1, day=1)
     max_date = datetime(year=2003, month=12, day=31)
     scan_image_type = 'application/pdf'
+    es_index = 'guardianobserver'
 
     image = 'guardianobserver.jpg'
 

--- a/backend/corpora/heraldtribune/heraldtribune.py
+++ b/backend/corpora/heraldtribune/heraldtribune.py
@@ -59,8 +59,7 @@ class HeraldTribune(GaleCorpus):
     description = "Archive of the International Herald Tribune, an American globally-focused newspaper."
     min_date = datetime(1887, 11, 11)
     max_date = datetime(2013, 10, 14)
-    data_directory = settings.HERALD_TRIBUNE_DATA
-    es_index = getattr(settings, 'HERALD_TRIBUNE_ES_INDEX', 'heraldtribune')
+    es_index = 'heraldtribune'
     image = 'Neuilly-sur-Seine_International_Herald_Tribune.jpg'
     description_page = 'HeraldTribune.md'
     languages = ['en']

--- a/backend/corpora/illustrated_london_news/illustrated_london_news.py
+++ b/backend/corpora/illustrated_london_news/illustrated_london_news.py
@@ -11,8 +11,7 @@ class IllustratedLondonNews(GaleCorpus):
     description = "Archive of Illustrated London News, a British weekly news magazine."
     min_date = datetime(1842, 5, 14)
     max_date = datetime(2003, 7, 7)
-    data_directory = settings.ILLUSTRATED_LONDON_NEWS_DATA
-    es_index = getattr(settings, 'ILLUSTRATED_LONDON_NEWS_ES_INDEX', 'illustrated_london_news')
+    es_index = 'illustrated_london_news'
     image = 'the_happy_land.png'
     description_page = 'IllustratedLondonNews.md'
     languages = ['en']

--- a/backend/corpora/jewishinscriptions/jewishinscriptions.py
+++ b/backend/corpora/jewishinscriptions/jewishinscriptions.py
@@ -20,8 +20,7 @@ class JewishInscriptions(XMLCorpusDefinition):
     description = "A collection of inscriptions on Jewish burial sites"
     min_date = datetime(year=769, month=1, day=1)
     max_date = datetime(year=849, month=12, day=31)
-    data_directory = settings.JEWISH_INSCRIPTIONS_DATA
-    es_index = getattr(settings, 'JEWISH_INSCRIPTIONS_ES_INDEX', 'jewishinscriptions')
+    es_index = 'jewishinscriptions'
     image = 'jewishinscriptions.jpg'
     visualize = []
     languages = ['heb', 'lat']

--- a/backend/corpora/jewishmigration/jewishmigration.py
+++ b/backend/corpora/jewishmigration/jewishmigration.py
@@ -42,13 +42,12 @@ class JewishMigration(PeacePortal, JSONCorpusDefinition):
     min_date = datetime(year=1, month=1, day=1)
     max_date = datetime(year=1800, month=12, day=31)
 
-    data_directory = settings.JMIG_DATA_DIR
-    data_filepath = getattr(settings, 'JMIG_DATA', None)
-    data_url = getattr(settings, 'JMIG_DATA_URL', None)
-    data_api_key = getattr(settings, 'JMIG_DATA_API_KEY', None)
+    data_filepath = None
+    data_url = None
+    data_api_key = None
 
-    es_alias = getattr(settings, 'JMIG_ALIAS', None)
-    es_index = getattr(settings, 'JMIG_INDEX', 'jewishmigration')
+    es_alias = None
+    es_index = 'jewishmigration'
     image = 'jewishmigration.jpg'
     languages = ['en']
 

--- a/backend/corpora/jewishmigration/test_jewishmigration.py
+++ b/backend/corpora/jewishmigration/test_jewishmigration.py
@@ -126,11 +126,11 @@ def jm_corpus_settings(settings):
     settings.CORPORA = {
         'jewishmigration': 'corpora.jewishmigration.jewishmigration.JewishMigration',
     }
-    settings.JMIG_DATA_DIR = None
-    settings.JMIG_DATA = None
-    settings.JMIG_DATA_URL = 'http://www.example.com'
-    settings.JMIG_DATA_API_KEY = None
-    settings.JMIG_INDEX = 'test-jewishmigration'
+    settings.CORPUS_SETTINGS['jewishmigration'] = {
+        'data_directory': None,
+        'data_url': 'http://www.example.com',
+        'es_index': 'test_jewishmigration'
+    }
 
 
 @pytest.fixture

--- a/backend/corpora/news_us_19/news_us_19.py
+++ b/backend/corpora/news_us_19/news_us_19.py
@@ -10,8 +10,7 @@ class NewsUS(GaleCorpus):
     description = "A collection of 19th century newspapers from the United States"
     min_date = datetime(1800,1,1)
     max_date = datetime(1900,1,1)
-    data_directory = settings.NEWS_US_19_DATA
-    es_index = getattr(settings, 'NEWS_US_19_ES_INDEX', 'news_us_19')
+    es_index = 'news_us_19'
     image = 'press_room.jpg'
     description_page = '19thCenturyUSNewspapers.md'
     languages = ['en']

--- a/backend/corpora/parliament/canada.py
+++ b/backend/corpora/parliament/canada.py
@@ -6,7 +6,7 @@ import re
 from corpora.parliament.parliament import Parliament
 from corpora.utils.constants import document_context
 from ianalyzer_readers.extract import Constant, CSV
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 import corpora.parliament.utils.field_defaults as field_defaults
 from corpora.parliament.uk import format_house
 
@@ -14,18 +14,7 @@ class ParliamentCanada(Parliament, CSVCorpusDefinition):
     title = 'People & Parliament (Canada)'
     description = "Speeches from House of Commons"
     min_date = datetime(year=1901, month=1, day=1)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_CANADA_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_CANADA_INDEX') or 'parliament-canada'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_CANADA_WM') or super().word_model_path
+    es_index = 'parliament-canada'
 
     image = 'canada.jpeg'
     languages = ['en']

--- a/backend/corpora/parliament/denmark-new.py
+++ b/backend/corpora/parliament/denmark-new.py
@@ -6,7 +6,7 @@ import re
 
 from corpora.parliament.parliament import Parliament
 from ianalyzer_readers.extract import Constant, CSV, Metadata, Combined
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 import corpora.parliament.utils.field_defaults as field_defaults
 import corpora.utils.formatting as formatting
 import corpora.utils.constants as constants
@@ -37,19 +37,7 @@ class ParliamentDenmarkNew(Parliament, CSVCorpusDefinition):
     description = "Speeches from the Folketing"
     min_date = datetime(year=2009, month=1, day=1)
     max_date = datetime(year=2016, month=12, day=31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_DENMARK_NEW_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_DENMARK_NEW_INDEX') or 'parliament-denmark-new'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_DENMARK_WM') or super().word_model_path
-
+    es_index = 'parliament-denmark-new'
 
     image = 'denmark.jpg'
     description_page = 'denmark-new.md'

--- a/backend/corpora/parliament/denmark.py
+++ b/backend/corpora/parliament/denmark.py
@@ -4,7 +4,7 @@ import logging
 
 from corpora.parliament.parliament import Parliament
 from ianalyzer_readers.extract import Constant, CSV
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 import corpora.parliament.utils.field_defaults as field_defaults
 import corpora.utils.formatting as formatting
 
@@ -27,14 +27,7 @@ class ParliamentDenmark(Parliament, CSVCorpusDefinition):
     description = "Speeches from the Folketing and Landsting"
     min_date = datetime(year=1848, month=1, day=1)
     max_date = datetime(year=2008, month=12, day=31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_DENMARK_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_DENMARK_INDEX') or 'parliament-denmark'
+    es_index = 'parliament-denmark'
 
     image = 'denmark.jpg'
     description_page = 'denmark.md'

--- a/backend/corpora/parliament/euparl.py
+++ b/backend/corpora/parliament/euparl.py
@@ -15,7 +15,7 @@ from ianalyzer_readers.readers.core import Field
 from ianalyzer_readers.readers.json import JSONReader
 
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
-from addcorpus.python_corpora.corpus import FieldDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import FieldDefinition
 from addcorpus.python_corpora.filters import MultipleChoiceFilter
 from corpora.parliament.parliament import Parliament
 import corpora.parliament.utils.field_defaults as field_defaults
@@ -40,30 +40,16 @@ class ParliamentEurope(Parliament):
     title = 'People & Parliament (European Parliament)'
     description = "Speeches from the European Parliament (EP)"
 
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_EUPARL_INDEX') or 'parliament-euparl'
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_EUPARL_DATA') or super().data_directory
-
     languages = ['en']
     category = "parliament"
     document_context = document_context()
     description_page = 'euparl.md'
     image = 'euparl.jpeg'
     min_date = datetime(year=1999, month=7, day=20)
-
-    @property
-    def max_date(self):
-        return get_deprecated_setting('PP_EUPARL_MAX_DATE') or datetime.now()
+    max_date = datetime.now()
+    es_index = 'parliament-euparl'
 
     language_field = 'original_language_code'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_EUPARL_WM') or super().word_model_path
 
     wordmodels_page = 'euparl.md'
 

--- a/backend/corpora/parliament/finland-old.py
+++ b/backend/corpora/parliament/finland-old.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from glob import glob
 
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 from ianalyzer_readers.extract import CSV, Combined, Constant
 from addcorpus.python_corpora.filters import MultipleChoiceFilter
 from corpora.parliament.parliament import Parliament
@@ -15,14 +15,7 @@ class ParliamentFinlandOld(Parliament, CSVCorpusDefinition):
     description = 'Speeches from the early Finnish estates'
     max_date = datetime(year=1906, month=12, day=31)
     min_date = datetime(year=1863, month=1, day=1)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_FINLAND_OLD_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_FINLAND_OLD_INDEX') or 'parliament-finland-old'
+    es_index = 'parliament-finland-old'
 
     def sources(self, start, end):
         for csv_file in glob('{}/**/*.csv'.format(self.data_directory), recursive=True):

--- a/backend/corpora/parliament/finland.py
+++ b/backend/corpora/parliament/finland.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from glob import glob
 from ianalyzer_readers.xml_tag import Tag, FindParentTag, PreviousSiblingTag, ParentTag
 
-from addcorpus.python_corpora.corpus import XMLCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import XMLCorpusDefinition
 from ianalyzer_readers.extract import XML, Combined, Constant, Metadata
 from corpora.parliament.parliament import Parliament
 import corpora.parliament.utils.field_defaults as field_defaults
@@ -22,18 +22,7 @@ class ParliamentFinland(Parliament, XMLCorpusDefinition):
     title = 'People and Parliament (Finland, 1907-)'
     description = 'Speeches from the eduskunta'
     min_date = datetime(year=1907, month=1, day=1)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_FINLAND_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_FINLAND_INDEX') or 'parliament-finland'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_FINLAND_WM') or super().word_model_path
+    es_index = 'parliament-finland'
 
     def sources(self, start, end):
         for xml_file in glob('{}/**/*.xml'.format(self.data_directory), recursive=True):

--- a/backend/corpora/parliament/france.py
+++ b/backend/corpora/parliament/france.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from corpora.parliament.parliament import Parliament
 from ianalyzer_readers.extract import Constant, Combined, CSV
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 import corpora.parliament.utils.field_defaults as field_defaults
 from corpora.utils.formatting import underscore_to_space
 from corpora.utils.constants import document_context
@@ -13,22 +13,11 @@ class ParliamentFrance(Parliament, CSVCorpusDefinition):
     title = "People & Parliament (France 1881-2022)"
     description = "Speeches from the 3rd, 4th and 5th republic of France"
     min_date = datetime(year=1881, month=1, day=1)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_FR_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_FR_INDEX') or 'parliament-france'
+    es_index = 'parliament-france'
 
     image = 'france.jpg'
     languages = ['fr']
     description_page = 'france.md'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_FR_WM') or super().word_model_path
 
     field_entry = 'speech_id'
 

--- a/backend/corpora/parliament/germany-new.py
+++ b/backend/corpora/parliament/germany-new.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from corpora.parliament.parliament import Parliament
 from ianalyzer_readers.extract import Constant, Combined, CSV
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 import corpora.utils.formatting as formatting
 import corpora.parliament.utils.field_defaults as field_defaults
 
@@ -15,21 +15,10 @@ class ParliamentGermanyNew(Parliament, CSVCorpusDefinition):
     description = "Speeches from the Bundestag"
     min_date = datetime(year=1949, month=1, day=1)
     max_date = datetime(year=2021, month=12, day=31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_GERMANY_NEW_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_GERMANY_NEW_INDEX') or 'parliament-germany-new'
+    es_index = 'parliament-germany-new'
 
     image = 'germany-new.jpeg'
     languages = ['de']
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_DE_WM') or super().word_model_path
 
     field_entry = 'id'
     required_field = 'speech_content'

--- a/backend/corpora/parliament/germany-old.py
+++ b/backend/corpora/parliament/germany-old.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from corpora.parliament.parliament import Parliament
 from ianalyzer_readers.extract import Constant, CSV
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 import corpora.parliament.utils.field_defaults as field_defaults
 
 
@@ -14,21 +14,10 @@ class ParliamentGermanyOld(Parliament, CSVCorpusDefinition):
     description = "Speeches from the Reichstag"
     min_date = datetime(year=1867, month=1, day=1)
     max_date = datetime(year=1942, month=12, day=31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_GERMANY_OLD_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_GERMANY_OLD_INDEX') or 'parliament-germany-old'
+    es_index = 'parliament-germany-old'
 
     image = 'germany-old.jpeg'
     languages = ['de']
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_DE_WM') or super().word_model_path
 
     description_page = 'germany-old.md'
 

--- a/backend/corpora/parliament/ireland.py
+++ b/backend/corpora/parliament/ireland.py
@@ -8,7 +8,7 @@ import csv
 from ianalyzer_readers.xml_tag import Tag, PreviousSiblingTag
 
 from addcorpus.python_corpora.corpus import (
-    CorpusDefinition, CSVCorpusDefinition, XMLCorpusDefinition, get_deprecated_setting
+    CorpusDefinition, CSVCorpusDefinition, XMLCorpusDefinition
 )
 from ianalyzer_readers.extract import Constant, CSV, XML, Metadata, Combined, Backup
 from corpora.parliament.parliament import Parliament
@@ -312,8 +312,6 @@ class ParliamentIrelandNew(XMLCorpusDefinition):
     Only used for data extraction, use the `ParliamentIreland` class in the application.
     '''
 
-    data_directory = None
-
     def __init__(self, data_directory: str):
         self.data_directory = data_directory
 
@@ -445,18 +443,7 @@ class ParliamentIreland(Parliament, CorpusDefinition):
     description = 'Speeches from the Dáil Éireann and Seanad Éireann'
     min_date = datetime(year=1919, month=1, day=1)
     max_date = datetime(year=2020, month=12, day=31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_IRELAND_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_IRELAND_INDEX') or 'parliament-ireland'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_IRELAND_WM') or super().word_model_path
+    es_index = 'parliament-ireland'
 
     image = 'ireland.jpg'
     description_page = 'ireland.md'

--- a/backend/corpora/parliament/netherlands.py
+++ b/backend/corpora/parliament/netherlands.py
@@ -5,7 +5,7 @@ import logging
 import bs4
 from ianalyzer_readers.xml_tag import Tag, FindParentTag, PreviousTag, TransformTag
 
-from addcorpus.python_corpora.corpus import XMLCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import XMLCorpusDefinition
 from ianalyzer_readers.extract import XML, Constant, Combined, Order
 from corpora.parliament.utils.parlamint_v4 import (
     current_party_id_extractor,
@@ -428,26 +428,11 @@ class ParliamentNetherlands(Parliament, XMLCorpusDefinition):
     description = "Debates in the Dutch national parliament, from its founding to the present. A collection of the speeches in the Eerste Kamer and Tweede Kamer."
     min_date = datetime(year=1815, month=1, day=1)
     max_date = datetime(year=2022, month=12, day=31)
+    es_index = 'parliament-netherlands'
 
     languages = ["nl"]
     category = "parliament"
     document_context = document_context()
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_NL_RECENT_DATA') or super().data_directory
-
-    @property
-    def data_directory_old(self):
-        return get_deprecated_setting('PP_NL_DATA')
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_NL_WM') or super().word_model_path
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_NL_INDEX') or 'parliament-netherlands'
 
     image = "netherlands.jpg"
     description_page = "netherlands.md"

--- a/backend/corpora/parliament/netherlands.py
+++ b/backend/corpora/parliament/netherlands.py
@@ -439,6 +439,11 @@ class ParliamentNetherlands(Parliament, XMLCorpusDefinition):
     citation_page = "netherlands.md"
 
     @property
+    def data_directory_old(self):
+        raise NotImplementedError(
+            'Required configuration data_directory_old is missing')
+
+    @property
     def subcorpora(self):
         return [
             ParliamentNetherlandsOld(self.data_directory_old),

--- a/backend/corpora/parliament/norway-new.py
+++ b/backend/corpora/parliament/norway-new.py
@@ -2,7 +2,7 @@ from glob import glob
 from datetime import datetime
 
 from ianalyzer_readers.extract import Combined, Constant, CSV
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 from corpora.parliament.parliament import Parliament
 import corpora.parliament.utils.field_defaults as field_defaults
 import corpora.utils.formatting as formatting
@@ -49,18 +49,7 @@ class ParliamentNorwayNew(Parliament, CSVCorpusDefinition):
     description = "Speeches from the Storting"
     min_date = datetime(year=1998, month=1, day=1)
     max_date = datetime(year=2016, month=12, day=31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_NORWAY_NEW_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_NORWAY_NEW_INDEX') or 'parliament-norway-new'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_NORWAY_WM') or super().word_model_path
+    es_index = 'parliament-norway-new'
 
     image = 'norway.JPG'
     languages = ['no']

--- a/backend/corpora/parliament/norway.py
+++ b/backend/corpora/parliament/norway.py
@@ -4,7 +4,7 @@ import re
 import os
 
 from ianalyzer_readers.extract import Combined, Constant, CSV
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 from corpora.utils.constants import document_context
 from corpora.parliament.parliament import Parliament
 import corpora.parliament.utils.field_defaults as field_defaults
@@ -23,14 +23,7 @@ class ParliamentNorway(Parliament, CSVCorpusDefinition):
     description = "Speeches from the Storting"
     min_date = datetime(year=1814, month=1, day=1)
     max_date = datetime(year=2004, month=12, day=31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_NORWAY_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_NORWAY_INDEX') or 'parliament-norway'
+    es_index = 'parliament-norway'
 
     image = 'norway.JPG'
     languages = ['no']

--- a/backend/corpora/parliament/parliament.py
+++ b/backend/corpora/parliament/parliament.py
@@ -1,9 +1,8 @@
 import logging
 import os
 import os.path as op
-from typing import Optional
 
-from addcorpus.python_corpora.corpus import CorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CorpusDefinition
 from addcorpus.python_corpora.filters import MultipleChoiceFilter
 import corpora.parliament.utils.field_defaults as field_defaults
 from addcorpus.es_settings import es_settings
@@ -26,9 +25,7 @@ class Parliament(CorpusDefinition):
     # store min_year as int, since datetime does not support BCE dates
     visualize = []
 
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_ALIAS') or 'parliament'
+    es_index = 'parliament'
 
     # fields below are required by code but not actually used
     min_date = field_defaults.MIN_DATE

--- a/backend/corpora/parliament/sweden-old.py
+++ b/backend/corpora/parliament/sweden-old.py
@@ -1,7 +1,7 @@
 from glob import glob
 from datetime import datetime
 
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 from ianalyzer_readers.extract import CSV, Constant
 from corpora.parliament.parliament import Parliament
 import corpora.parliament.utils.field_defaults as field_defaults
@@ -34,18 +34,8 @@ class ParliamentSwedenOld(Parliament, CSVCorpusDefinition):
     description = 'Speeches from the Riksdag'
     min_date = datetime(year=1809, month=1, day=1)
     max_date = datetime(year=1919, month=12, day=31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_SWEDEN_OLD_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_SWEDEN_OLD_INDEX') or 'parliament-sweden-old'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_SWEDEN_WM') or super().word_model_path
+    es_index = 'parliament-sweden-old'
+    image = 'sweden-old.jpg'
 
     document_context = constants.document_context(
         context_fields=['chamber', 'date_earliest', 'date_latest']

--- a/backend/corpora/parliament/sweden-swerik.py
+++ b/backend/corpora/parliament/sweden-swerik.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 from corpora.parliament.parliament import Parliament
 from corpora.parliament.utils import field_defaults
 from addcorpus.es_mappings import date_estimate_mapping
-from addcorpus.python_corpora.corpus import FieldDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import FieldDefinition
 from api.utils import document_link
 from corpora.parliament.sweden import ParliamentSweden
 
@@ -259,14 +259,9 @@ class ParliamentSwedenSwerik(Parliament, XMLReader):
     languages = ['sv']
     image = 'sweden.jpg'
     description_page = 'sweden-swerik.md'
+    es_index = 'parliament-sweden-swerik'
 
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_SWEDEN_SWERIK_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_SWEDEN_SWERIK_INDEX') or 'parliament-sweden-swerik'
+    hide_cross_corpus_link = False
 
     tag_toplevel = Tag('TEI')
     tag_entry = Tag('u', attrs={'prev': None})
@@ -439,9 +434,6 @@ class ParliamentSwedenSwerik(Parliament, XMLReader):
         PreviousSiblingTag('note', type='title'),
         transform=lambda value: str.strip(value) if value else None,
     )
-
-    hide_cross_corpus_link = \
-        get_deprecated_setting('PP_SWEDEN_SWERIK_HIDE_CROSSCORPUS_LINK') or False
 
     url_sweden_corpus = FieldDefinition(
         name='url_sweden_corpus',

--- a/backend/corpora/parliament/sweden.py
+++ b/backend/corpora/parliament/sweden.py
@@ -1,7 +1,7 @@
 from datetime import date
 from glob import glob
 
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 from ianalyzer_readers.extract import CSV, Constant
 from corpora.parliament.parliament import Parliament
 import corpora.utils.formatting as formatting
@@ -44,18 +44,7 @@ class ParliamentSweden(Parliament, CSVCorpusDefinition):
     description = 'Speeches from the Riksdag'
     min_date = date(year=1920, month=1, day=1)
     max_date = date(2022, 1, 11)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_SWEDEN_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_SWEDEN_INDEX') or 'parliament-sweden'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_SWEDEN_WM') or super().word_model_path
+    es_index = 'parliament-sweden'
 
     def sources(self, start, end):
         for csv_file in glob('{}/**/*.csv'.format(self.data_directory), recursive=True):

--- a/backend/corpora/parliament/uk-new.py
+++ b/backend/corpora/parliament/uk-new.py
@@ -35,7 +35,7 @@ def extract_chamber(path: str):
         return 'House of Commons'
     else:
         return None
-    
+
 def generate_title(chamber: str, date: str):
     return "{} Debate on {}".format(chamber, date)
 
@@ -56,12 +56,12 @@ def abbreviate_speech_id(full_id):
 def extract_topics_and_subtopics(path):
     with open(path, 'r', encoding='utf-8') as file:
         soup = BeautifulSoup(file, "lxml")
-    
+
     topics = {}
     subtopics = {}
     for tag in soup.find_all('major-heading'):
         topics[abbreviate_speech_id(tag['id'])] = tag.text.replace('\n', '')
-    
+
     for tag in soup.find_all('minor-heading'):
         subtopics[abbreviate_speech_id(tag['id'])] = tag.text.replace('\n', '')
 
@@ -70,7 +70,7 @@ def extract_topics_and_subtopics(path):
 def extract_speaker_ids(path):
     with open(path, 'r', encoding='utf-8') as file:
         soup = BeautifulSoup(file, "lxml")
-    
+
     speaker_ids = []
     for tag in soup.find_all('speech'):
         if tag.has_attr('person_id'):
@@ -92,7 +92,7 @@ def select_topic(input):
 def lookup_person_attribute(lookup_tuple):
     metadata_dict, id, name, label = lookup_tuple #name is only included for debugging purposes
 
-    id = id.split('/')[-1] if id else None # twfy ID is at the end of uri 
+    id = id.split('/')[-1] if id else None  # twfy ID is at the end of uri
     if id in metadata_dict and label in metadata_dict[id]:
         return metadata_dict[id][label]
     else:
@@ -104,7 +104,7 @@ def lookup_person_atttribute_date(lookup_tuple):
         return date_string[:10]
     else:
         return None
-    
+
 def find_current_positions(metadata_dict, date):
     current_positions = {}
     for person in metadata_dict:
@@ -112,7 +112,7 @@ def find_current_positions(metadata_dict, date):
         for position in metadata_dict[person]['positions']:
             if 'startTime' in position and 'endTime' in position:
                 try:
-                    date_range = (datetime.strptime(position['startTime'][:10], "%Y-%m-%d"), 
+                    date_range = (datetime.strptime(position['startTime'][:10], "%Y-%m-%d"),
                                 datetime.strptime(position['endTime'][:10], "%Y-%m-%d"))
                 except ValueError:
                     continue #disregard missing dates
@@ -169,9 +169,8 @@ class ParliamentUKNew(Parliament, XMLCorpusDefinition):
     data_directory = settings.TE_UK_NEW_DATA
     min_date = datetime(year=2022, month=1, day=1)
     max_date = datetime(year=2025, month=12, day=31)
-    es_index = getattr(settings, 'TE_UK_NEW_ES_INDEX', 'parliament-uk-new')
+    es_index = 'parliament-uk-new'
     image = 'uk.jpeg'
-    # word_model_path = getattr(settings, 'TE_UK_NEW_WM', None) ## TODO: add word model?
     languages = ['en']
     description_page = 'uk-new.md'
     field_entry = 'speech_id'
@@ -201,9 +200,9 @@ class ParliamentUKNew(Parliament, XMLCorpusDefinition):
                 metadata['current_positions'] = find_current_positions(metadata['speaker_metadata'], metadata['date'])
 
                 yield str(full_path), metadata
-        
+
     _speech_id_extractor = Cache(XML(attribute='id'))
-    
+
     chamber = field_defaults.chamber()
     chamber.extractor = Metadata('chamber')
 
@@ -366,7 +365,7 @@ class ParliamentUKNew(Parliament, XMLCorpusDefinition):
             self.debate_title, self.debate_id,
             self.topic, self.subtopic,
             self.chamber,
-            self.speech, self.speech_id, 
+            self.speech, self.speech_id,
             self.speech_type,
             self.speaker, self.speaker_id,
             self.speaker_gender, self.speaker_birthdate,

--- a/backend/corpora/parliament/uk-new.py
+++ b/backend/corpora/parliament/uk-new.py
@@ -166,7 +166,6 @@ def lookup_current_party(lookup_tuple):
 class ParliamentUKNew(Parliament, XMLCorpusDefinition):
     title = 'Talking Empire (UK 2022-2025)'
     description = "Speeches from the House of Lords and House of Commons (2022-2025)"
-    data_directory = settings.TE_UK_NEW_DATA
     min_date = datetime(year=2022, month=1, day=1)
     max_date = datetime(year=2025, month=12, day=31)
     es_index = 'parliament-uk-new'

--- a/backend/corpora/parliament/uk.py
+++ b/backend/corpora/parliament/uk.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 
 from ianalyzer_readers.extract import Constant, CSV
-from addcorpus.python_corpora.corpus import CSVCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import CSVCorpusDefinition
 from corpora.parliament.parliament import Parliament
 import corpora.parliament.utils.field_defaults as field_defaults
 from corpora.utils.constants import document_context
@@ -33,24 +33,11 @@ def format_speaker(speaker):
 class ParliamentUK(Parliament, CSVCorpusDefinition):
     title = 'People & Parliament (UK)'
     description = "Speeches from the House of Lords and House of Commons"
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('PP_UK_DATA') or super().data_directory
-
     min_date = datetime(year=1803, month=1, day=1)
     max_date = datetime(year=2021, month=12, day=31)
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('PP_UK_INDEX') or 'parliament-uk'
+    es_index = 'parliament-uk'
 
     image = 'uk.jpeg'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('PP_UK_WM') or super().word_model_path
-
     languages = ['en']
     description_page = 'uk.md'
     field_entry = 'speech_id'

--- a/backend/corpora/periodicals/periodicals.py
+++ b/backend/corpora/periodicals/periodicals.py
@@ -30,9 +30,9 @@ class Periodicals(XMLCorpusDefinition):
     min_date = datetime(1800,1,1)
     max_date = datetime(1900,1,1)
     data_directory = settings.PERIODICALS_DATA
-    es_index = getattr(settings, 'PERIODICALS_ES_INDEX', 'periodicals')
+    es_index = 'periodicals'
     image = 'Fleet_Street.jpg'
-    scan_image_type = getattr(settings, 'PERIODICALS_SCAN_IMAGE_TYPE', 'image/jpeg')
+    scan_image_type = 'image/jpeg'
     description_page = '19thCenturyUKPeriodicals.md'
     languages = ['en']
     category = 'periodical'

--- a/backend/corpora/periodicals/periodicals.py
+++ b/backend/corpora/periodicals/periodicals.py
@@ -28,8 +28,7 @@ class Periodicals(XMLCorpusDefinition):
     title = "Periodicals"
     description = "A collection of 19th century periodicals"
     min_date = datetime(1800,1,1)
-    max_date = datetime(1900,1,1)
-    data_directory = settings.PERIODICALS_DATA
+    max_date = datetime(1900, 1, 1)
     es_index = 'periodicals'
     image = 'Fleet_Street.jpg'
     scan_image_type = 'image/jpeg'

--- a/backend/corpora/punch/punch.py
+++ b/backend/corpora/punch/punch.py
@@ -13,8 +13,7 @@ class Punch(GaleCorpus):
     description = "Archive of Punch, a British satirical magazine."
     min_date = datetime(1841, 7, 1)
     max_date = datetime(1992, 4, 8)
-    data_directory = settings.PUNCH_DATA
-    es_index = getattr(settings, 'PUNCH_ES_INDEX', 'punch')
+    es_index = 'punch'
     image = 'Collected_volumes_of_Punch.jpg'
     description_page = 'Punch.md'
     languages = ['en']

--- a/backend/corpora/rechtspraak/rechtspraak.py
+++ b/backend/corpora/rechtspraak/rechtspraak.py
@@ -8,7 +8,7 @@ from zipfile import ZipFile, BadZipFile
 from ianalyzer_readers.xml_tag import Tag, ParentTag
 
 from ianalyzer_readers import extract
-from addcorpus.python_corpora.corpus import FieldDefinition, XMLCorpusDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import FieldDefinition, XMLCorpusDefinition
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 from addcorpus.es_settings import es_settings
 from addcorpus.python_corpora import filters
@@ -39,14 +39,7 @@ class Rechtspraak(XMLCorpusDefinition):
     description = "Open data of (anonymised) court rulings of the Dutch judicial system"
     min_date = datetime(year=1900, month=1, day=1)
     max_date = datetime(year=2022, month=12, day=6)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('RECHTSPRAAK_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('RECHTSPRAAK_ES_INDEX') or 'rechtspraak'
+    es_index = 'rechtspraak'
 
     image = 'rechtspraak.jpg' #CC-0, from https://commons.wikimedia.org/wiki/File:Courtroom_One_Gavel_-_Flickr_-_Joe_Gratz.jpg
     description_page = 'rechtspraak.md'

--- a/backend/corpora/times/times.py
+++ b/backend/corpora/times/times.py
@@ -32,15 +32,13 @@ class Times(XMLCorpusDefinition):
     description = "Archives from The Times, a British daily newspaper."
     min_date = datetime(year=1785, month=1, day=1)
     max_date = datetime(year=2010, month=12, day=31)
-    data_directory = settings.TIMES_DATA
-    es_index = getattr(settings, 'TIMES_ES_INDEX', 'times')
+    es_index = 'times'
     image = 'times.jpg'
-    scan_image_type = getattr(settings, 'TIMES_SCAN_IMAGE_TYPE', 'image/png')
+    scan_image_type = 'image/png'
     description_page = 'times.md'
     citation_page = 'citation.md'
     languages = ['en']
     category = 'periodical'
-    word_model_path = getattr(settings, "TIMES_WM", None)
 
     @property
     def es_settings(self):

--- a/backend/corpora/traces_of_sound/conftest.py
+++ b/backend/corpora/traces_of_sound/conftest.py
@@ -8,4 +8,6 @@ def traces_corpora_settings(settings):
     settings.CORPORA = {
         'traces-of-sound': 'corpora.traces_of_sound.traces_of_sound.TracesOfSound',
     }
-    settings.TRACES_OF_SOUND_DATA = join(here, 'tests', 'data')
+    settings.CORPUS_SETTINGS['traces-of-sound'] = {
+        'data_directory': join(here, 'tests', 'data')
+    }

--- a/backend/corpora/traces_of_sound/traces_of_sound.py
+++ b/backend/corpora/traces_of_sound/traces_of_sound.py
@@ -38,13 +38,11 @@ class TracesOfSound(CSVCorpusDefinition):
         "corpus."
     min_date = DutchNewspapersPublic.min_date
     max_date = DutchNewspapersPublic.max_date
-    data_directory = settings.TRACES_OF_SOUND_DATA
-    es_index = getattr(settings, 'TRACES_OF_SOUND_ES_INDEX', 'traces-of-sound')
+    es_index = 'traces-of-sound'
     languages = DutchNewspapersPublic.languages
     category = DutchNewspapersPublic.category
     description_page = 'traces_of_sound.md'
     image = 'Oren.webp'
-    word_model_path = getattr(settings, "DUTCHNEWSPAPERS_WM", None)
     delimiter = ';'
 
     @property

--- a/backend/corpora/troonredes/troonredes.py
+++ b/backend/corpora/troonredes/troonredes.py
@@ -3,6 +3,7 @@ Collect corpus-specific information, that is, data structures and file
 locations.
 '''
 
+from addcorpus.python_corpora.corpus import XMLCorpusDefinition, FieldDefinition
 import logging
 logger = logging.getLogger(__name__)
 import os
@@ -12,7 +13,6 @@ from ianalyzer_readers.xml_tag import Tag
 
 from ianalyzer_readers import extract
 from addcorpus.python_corpora import filters
-from addcorpus.python_corpora.corpus import XMLCorpusDefinition, FieldDefinition, get_deprecated_setting
 
 from addcorpus.es_mappings import keyword_mapping, main_content_mapping
 from addcorpus.es_settings import es_settings
@@ -30,18 +30,7 @@ class Troonredes(XMLCorpusDefinition):
     description = "Speeches by Dutch monarchs"
     min_date = datetime(year=1814, month=1, day=1)
     max_date = datetime(year=2025, month=12, day=31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('TROONREDES_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('TROONREDES_ES_INDEX') or 'troonredes'
-
-    @property
-    def word_model_path(self):
-        return get_deprecated_setting('TROONREDES_WM') or super().word_model_path
+    es_index = 'troonredes'
 
     image = 'troonrede.jpg'
     languages = ['nl']

--- a/backend/corpora/ublad/ublad.py
+++ b/backend/corpora/ublad/ublad.py
@@ -4,7 +4,7 @@ import bs4
 from os.path import join
 import logging
 
-from addcorpus.python_corpora.corpus import HTMLCorpusDefinition, FieldDefinition, get_deprecated_setting
+from addcorpus.python_corpora.corpus import HTMLCorpusDefinition, FieldDefinition
 from ianalyzer_readers.extract import XML
 from ianalyzer_readers.xml_tag import Tag
 from addcorpus.es_mappings import *
@@ -57,14 +57,7 @@ class UBlad(HTMLCorpusDefinition):
     description_page = 'ublad.md'
     min_date = datetime(year=1969, month=1, day=1)
     max_date = datetime(year=2010, month=12, day=31)
-
-    @property
-    def data_directory(self):
-        return get_deprecated_setting('UBLAD_DATA') or super().data_directory
-
-    @property
-    def es_index(self):
-        return get_deprecated_setting('UBLAD_ES_INDEX') or 'ublad'
+    es_index = 'ublad'
 
     image = 'ublad.jpg'
     scan_image_type = 'image/jpeg'

--- a/backend/corpora/uu_course_descriptions/tests/test_hum_course_descriptions.py
+++ b/backend/corpora/uu_course_descriptions/tests/test_hum_course_descriptions.py
@@ -10,9 +10,11 @@ here = os.path.abspath(os.path.dirname(__file__))
 @pytest.fixture()
 def hum_course_descriptions_settings(settings, db):
     settings.CORPORA = {
-        'hum_course_descriptions': 'corpora.uu_course_descriptions.uu_course_descriptions_gw_2023.HumCourseDescriptions',
+        "hum_course_descriptions": "corpora.uu_course_descriptions.uu_course_descriptions_gw_2023.HumCourseDescriptions",
     }
-    settings.HUM_COURSE_DESCRIPTIONS_DATA = os.path.join(here, 'data')
+    settings.CORPUS_SETTINGS["hum_course_descriptions"] = {
+        "data_directory": os.path.join(here, "data")
+    }
 
 def test_hum_course_descriptions_model(hum_course_descriptions_settings, db, admin_client):
     corpus = corpus_from_api(admin_client, 'hum_course_descriptions')

--- a/backend/corpora/uu_course_descriptions/uu_course_descriptions_gw_2023.py
+++ b/backend/corpora/uu_course_descriptions/uu_course_descriptions_gw_2023.py
@@ -76,7 +76,9 @@ def teacher_extractor(role):
     )
 
 class CourseStaffMetadata(XLSXCorpusDefinition):
-    data_directory = settings.HUM_COURSE_DESCRIPTIONS_DATA
+
+    def __init__(self, data_directory: str):
+        self.data_directory = data_directory
 
     def sources(self, **kwargs):
         path = os.path.join(self.data_directory, 'docenten_cursussen2023GW.xlsx')
@@ -123,7 +125,7 @@ class HumCourseDescriptions(XLSXCorpusDefinition):
         yield path, { 'teacher_roles': teacher_roles }
 
     def _extract_teacher_data(self):
-        reader = CourseStaffMetadata()
+        reader = CourseStaffMetadata(data_directory=self.data_directory)
         roles = reader.documents()
         return list(roles)
 

--- a/backend/corpora/uu_course_descriptions/uu_course_descriptions_gw_2023.py
+++ b/backend/corpora/uu_course_descriptions/uu_course_descriptions_gw_2023.py
@@ -115,9 +115,7 @@ class HumCourseDescriptions(XLSXCorpusDefinition):
     max_date = datetime(2023, 8, 31)
     image = 'uu_gw.jpg'
     languages = ['nl', 'en', 'de', 'fr', 'es', 'it']
-    es_index =  getattr(settings, 'HUM_COURSE_DESCRIPTIONS_INDEX', 'hum_course_descriptions')
-
-    data_directory = settings.HUM_COURSE_DESCRIPTIONS_DATA
+    es_index = 'hum_course_descriptions'
 
     def sources(self, *args, **kwargs):
         teacher_roles = self._extract_teacher_data()

--- a/backend/ianalyzer/settings_test.py
+++ b/backend/ianalyzer/settings_test.py
@@ -21,9 +21,6 @@ CORPUS_SETTINGS = {
         "data_directory": os.path.join(BASE_DIR, 'addcorpus', 'python_corpora', 'tests'),
         "es_index": "test-times",
     },
-    "ublad": {
-        "data_directory": ""
-    }
 }
 
 SERVERS['default']['index_prefix'] = 'test'

--- a/backend/ianalyzer/settings_test.py
+++ b/backend/ianalyzer/settings_test.py
@@ -16,10 +16,15 @@ CORPORA = {
     'cjk-mock-corpus': 'corpora_test.cjk.corpus.CJKMockCorpus'
 }
 
-TIMES_DATA = os.path.join(BASE_DIR, 'addcorpus', 'python_corpora', 'tests')
-TIMES_ES_INDEX = 'test-times'
-
-UBLAD_DATA = '' # necessary to make ublad test not fail
+CORPUS_SETTINGS = {
+    "times": {
+        "data_directory": os.path.join(BASE_DIR, 'addcorpus', 'python_corpora', 'tests'),
+        "es_index": "test-times",
+    },
+    "ublad": {
+        "data_directory": ""
+    }
+}
 
 SERVERS['default']['index_prefix'] = 'test'
 


### PR DESCRIPTION
Reverts the `get_deprecated_setting` helper, and adjusts all corpora using it to the new settings format.


Also removes (almost) all old-style settings (`getatttr(settings.SOME_SETTING, <default>`). Exceptions:
- Course Explorer related corpora
- Peace Portal related corpora 

This was a combination of manual moving of settings, and using an LLM-based helper. So a quick sanity check would be much appreciated.


### Deployment
Branches updated for:
- [textcavator](https://github.com/CentreForDigitalHumanities/deployment-rsl/commit/94b1f053be574139a7d3b248b1b512ac970e7b81)
- [people&parliament](https://github.com/CentreForDigitalHumanities/deployment-rsl/commit/71ae0b7b0ef0acae4ec25375ce5eca59d2ad9057) 

Sanity checks also appreciated